### PR TITLE
Improve ssh-copy-id key handling

### DIFF
--- a/sshpilot/ssh_utils.py
+++ b/sshpilot/ssh_utils.py
@@ -4,6 +4,7 @@ SSH utilities for building consistent SSH options across the application
 
 import os
 import logging
+import shlex
 import subprocess
 import tempfile
 from typing import List, Optional, Tuple
@@ -120,16 +121,20 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
         if hasattr(connection, 'keyfile') and connection.keyfile and \
            os.path.isfile(connection.keyfile) and \
            not connection.keyfile.startswith('Select key file'):
-            
-            if not for_ssh_copy_id:
-                options.extend(['-i', connection.keyfile])
-            # Enforce using only the specified key when key_select_mode == 1
-            # But for ssh-copy-id, we want to try all keys first
+
             try:
-                if int(getattr(connection, 'key_select_mode', 0) or 0) == 1 and not for_ssh_copy_id:
-                    options.extend(['-o', 'IdentitiesOnly=yes'])
+                key_mode = int(getattr(connection, 'key_select_mode', 0) or 0)
             except Exception:
-                pass
+                key_mode = 0
+
+            if not for_ssh_copy_id or key_mode == 1:
+                options.extend(['-i', connection.keyfile])
+
+            if key_mode == 1 and not for_ssh_copy_id:
+                try:
+                    options.extend(['-o', 'IdentitiesOnly=yes'])
+                except Exception:
+                    pass
     else:
         # For ssh-copy-id, don't restrict authentication methods - let it try all keys first
         if not for_ssh_copy_id:
@@ -143,204 +148,187 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
     
     return options
 
+
 def custom_ssh_copy_id(connection, public_key_path, config=None, connection_manager=None, terminal_widget=None):
     """
-    Custom ssh-copy-id implementation that tries all keys and then password, like default SSH behavior.
-    
+    Custom ssh-copy-id implementation that first tries key-based auth and falls
+    back to password authentication when necessary.
+
     Args:
         connection: The connection object
         public_key_path: Path to the public key to copy
         config: Optional config object
         connection_manager: Optional connection manager for password retrieval
         terminal_widget: Optional terminal widget for interactive password prompts
-        
+
     Returns:
         Tuple of (success: bool, message: str)
     """
-    logger.info(f"Custom ssh-copy-id: Copying {public_key_path} to {connection.username}@{connection.host}")
-    
+    logger.info(
+        f"Custom ssh-copy-id: Copying {public_key_path} to {connection.username}@{connection.host}"
+    )
+
     try:
         # Verify public key file exists
         if not os.path.exists(public_key_path):
             return False, f"Public key file not found: {public_key_path}"
-        
+
         # Read the public key content
         with open(public_key_path, 'r') as f:
             public_key_content = f.read().strip()
-        
+
         if not public_key_content:
             return False, f"Public key file is empty: {public_key_path}"
-        
-        # Build SSH options for the connection
+
+        # Build base SSH options
         ssh_options = build_connection_ssh_options(connection, config, for_ssh_copy_id=True)
-        
+
         # Add port if specified
         if hasattr(connection, 'port') and connection.port != 22:
             ssh_options.extend(['-p', str(connection.port)])
-        
-        # Build the target string
+
         target = f"{connection.username}@{connection.host}"
-        
-        # Step 1: Try to connect and check if the key is already installed
-        logger.debug("Custom ssh-copy-id: Checking if key is already installed")
-        
-        # Check if we have a saved password for this connection (do this early)
+
+        # Retrieve saved password if available
         saved_password = None
         if connection_manager and hasattr(connection_manager, 'get_password'):
             try:
-                saved_password = connection_manager.get_password(connection.host, connection.username)
+                saved_password = connection_manager.get_password(
+                    connection.host, connection.username
+                )
                 if saved_password:
-                    logger.info(f"Custom ssh-copy-id: Found saved password for {connection.username}@{connection.host}")
+                    logger.info(
+                        f"Custom ssh-copy-id: Found saved password for {connection.username}@{connection.host}"
+                    )
                 else:
-                    logger.debug(f"Custom ssh-copy-id: No saved password found for {connection.username}@{connection.host}")
+                    logger.debug(
+                        f"Custom ssh-copy-id: No saved password found for {connection.username}@{connection.host}"
+                    )
             except Exception as e:
-                logger.debug(f"Custom ssh-copy-id: Could not retrieve saved password: {e}")
+                logger.debug(
+                    f"Custom ssh-copy-id: Could not retrieve saved password: {e}"
+                )
         else:
-            logger.debug("Custom ssh-copy-id: No connection manager or get_password method available")
-        
-        # Build SSH command for checking with proper auth options
-        check_ssh_options = ssh_options + [
-            '-o', 'PreferredAuthentications=publickey,password,keyboard-interactive',
-            '-o', 'PubkeyAuthentication=yes',
-            '-o', 'PasswordAuthentication=yes',
-            '-o', 'KbdInteractiveAuthentication=yes',
-            '-o', 'NumberOfPasswordPrompts=1',
-            '-o', 'IdentitiesOnly=no',
-        ]
-        check_cmd = ['ssh'] + check_ssh_options + [target, 'cat ~/.ssh/authorized_keys']
-        
-        # Try to check with saved password first if available
-        if saved_password:
-            try:
-                import shutil
-                sshpass_path = None
-                if shutil.which('sshpass'):
-                    sshpass_path = 'sshpass'
-                elif os.path.exists('/app/bin/sshpass'):
-                    sshpass_path = '/app/bin/sshpass'
-                
-                if sshpass_path:
-                    # Create temporary password file for checking
-                    with tempfile.NamedTemporaryFile(mode='w', delete=False) as pw_file:
-                        pw_file.write(saved_password)
-                        pw_file_path = pw_file.name
-                    
-                    try:
-                        os.chmod(pw_file_path, 0o600)
-                        check_cmd_with_pass = [sshpass_path, '-f', pw_file_path] + check_cmd
-                        
-                        logger.debug("Custom ssh-copy-id: Checking with saved password")
-                        result = subprocess.run(
-                            check_cmd_with_pass,
-                            capture_output=True,
-                            text=True,
-                            timeout=30
-                        )
-                        
-                        if result.returncode == 0:
-                            # Successfully read authorized_keys, check if our key is already there
-                            authorized_keys = result.stdout
-                            if public_key_content in authorized_keys:
-                                logger.info("Custom ssh-copy-id: Key already installed")
-                                return True, "Public key is already installed on the server"
-                            else:
-                                logger.debug("Custom ssh-copy-id: Key not found, will install")
-                        else:
-                            logger.debug(f"Custom ssh-copy-id: Check failed with saved password: {result.stderr}")
-                    finally:
-                        try:
-                            os.unlink(pw_file_path)
-                        except Exception:
-                            pass
-            except Exception as e:
-                logger.debug(f"Custom ssh-copy-id: Failed to check with saved password: {e}")
-        
-        # Fallback: try without saved password (interactive)
-        try:
-            logger.debug("Custom ssh-copy-id: Checking without saved password (interactive)")
-            result = subprocess.run(
-                check_cmd,
-                capture_output=True,
-                text=True,
-                timeout=30
+            logger.debug(
+                "Custom ssh-copy-id: No connection manager or get_password method available"
             )
-            
-            if result.returncode == 0:
-                # Successfully read authorized_keys, check if our key is already there
-                authorized_keys = result.stdout
-                if public_key_content in authorized_keys:
-                    logger.info("Custom ssh-copy-id: Key already installed")
-                    return True, "Public key is already installed on the server"
-                else:
-                    logger.debug("Custom ssh-copy-id: Key not found, will install")
-            else:
-                logger.debug(f"Custom ssh-copy-id: Check failed: {result.stderr}")
-        except subprocess.TimeoutExpired:
-            logger.debug("Custom ssh-copy-id: Timeout checking existing keys, continuing with installation")
+
+        # --------------------------------------------------------------
+        # Step 1: Gather candidate key files
+        candidate_keys = []
+        try:
+            # Include selected key file when in single-key mode
+            if int(getattr(connection, 'key_select_mode', 0) or 0) == 1:
+                keyfile = getattr(connection, 'keyfile', None)
+                if keyfile and os.path.exists(os.path.expanduser(keyfile)):
+                    candidate_keys.append(os.path.expanduser(keyfile))
+
+            # Include any identity files from config
+            try:
+                cfg = (
+                    config
+                    if config is not None
+                    else __import__('sshpilot.config', fromlist=['Config']).Config()
+                )
+                ssh_cfg = cfg.get_ssh_config() if hasattr(cfg, 'get_ssh_config') else {}
+                id_files = ssh_cfg.get('identity_files') or ssh_cfg.get('identityfile') or []
+                if isinstance(id_files, str):
+                    id_files = [id_files]
+                for path in id_files:
+                    expanded = os.path.expanduser(path)
+                    if os.path.exists(expanded) and expanded not in candidate_keys:
+                        candidate_keys.append(expanded)
+            except Exception as e:
+                logger.debug(
+                    f"Custom ssh-copy-id: Could not load identity files from config: {e}"
+                )
+
+            # Include standard default key locations
+            default_keys = [
+                '~/.ssh/id_ed25519',
+                '~/.ssh/id_rsa',
+                '~/.ssh/id_ecdsa',
+                '~/.ssh/id_ecdsa_sk',
+                '~/.ssh/id_ed25519_sk',
+                '~/.ssh/id_dsa',
+                '~/.ssh/id_xmss',
+            ]
+            for path in default_keys:
+                expanded = os.path.expanduser(path)
+                if os.path.exists(expanded) and expanded not in candidate_keys:
+                    candidate_keys.append(expanded)
         except Exception as e:
-            logger.debug(f"Custom ssh-copy-id: Could not check existing keys: {e}")
-        
-        # Step 2: Try to copy the key using SSH with multiple authentication methods
-        logger.debug("Custom ssh-copy-id: Attempting to copy key with multiple auth methods")
-        
-        # Create a temporary script to copy the key
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as temp_script:
-            script_content = f"""#!/bin/bash
-set -e
+            logger.debug(f"Custom ssh-copy-id: Error gathering key files: {e}")
 
-# Create .ssh directory if it doesn't exist
-mkdir -p ~/.ssh
+        logger.debug(f"Custom ssh-copy-id: Candidate keys: {candidate_keys}")
 
-# Set proper permissions
-chmod 700 ~/.ssh
+        # Build remote command that installs the key
+        remote_cmd = (
+            "mkdir -p ~/.ssh && "
+            "chmod 700 ~/.ssh && "
+            f"echo {shlex.quote(public_key_content)} >> ~/.ssh/authorized_keys && "
+            "chmod 600 ~/.ssh/authorized_keys && "
+            "echo 'Public key successfully installed'"
+        )
 
-# Append the public key to authorized_keys
-echo '{public_key_content}' >> ~/.ssh/authorized_keys
+        # --------------------------------------------------------------
+        # Step 2: Attempt key-based copy first
+        if candidate_keys:
+            for key in candidate_keys:
+                key_cmd = ['ssh'] + ssh_options + [
+                    '-o', 'IdentitiesOnly=yes',
+                    '-o', 'PreferredAuthentications=publickey',
+                    '-o', 'PasswordAuthentication=no',
+                    '-o', 'NumberOfPasswordPrompts=0',
+                    '-i', key,
+                    target,
+                    remote_cmd,
+                ]
+                logger.debug(
+                    f"Custom ssh-copy-id: Trying key-only copy with {key}: {' '.join(key_cmd)}"
+                )
+                success, message = _run_ssh_copy_id_with_subprocess(key_cmd)
+                if success:
+                    return success, message
 
-# Set proper permissions on authorized_keys
-chmod 600 ~/.ssh/authorized_keys
+        # --------------------------------------------------------------
+        # Step 3: Fallback to password/interactive authentication
+        logger.debug(
+            "Custom ssh-copy-id: Key-only attempt failed, falling back to password methods"
+        )
 
-echo "Public key successfully installed"
-"""
-            temp_script.write(script_content)
-            temp_script_path = temp_script.name
-        
-        # Make the script executable
-        os.chmod(temp_script_path, 0o755)
-        
-        # Build SSH command to execute the script
-        # For ssh-copy-id, always try public key first, then password (auth mode 0)
-        # Override any connection-specific auth settings
         ssh_cmd = ['ssh'] + ssh_options + [
-            '-o', 'PreferredAuthentications=publickey,password,keyboard-interactive',
-            '-o', 'PubkeyAuthentication=yes',
+            '-o', 'PreferredAuthentications=password,keyboard-interactive',
+            '-o', 'PubkeyAuthentication=no',
             '-o', 'PasswordAuthentication=yes',
             '-o', 'KbdInteractiveAuthentication=yes',
             '-o', 'NumberOfPasswordPrompts=1',
-            # Ensure we try all available keys, not just the connection's specific key
-            '-o', 'IdentitiesOnly=no',
+            '-o', 'IdentitiesOnly=yes',
             target,
-            f'bash < {temp_script_path}'
+            remote_cmd,
         ]
-        
-        logger.debug(f"Custom ssh-copy-id: Executing command: {' '.join(ssh_cmd)}")
-        
+
+        logger.debug(
+            f"Custom ssh-copy-id: Executing fallback command: {' '.join(ssh_cmd)}"
+        )
+
         if saved_password and terminal_widget:
-            # Use saved password with sshpass
-            return _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_password, terminal_widget)
+            return _run_ssh_copy_id_with_saved_password(
+                ssh_cmd, saved_password, terminal_widget
+            )
         elif terminal_widget:
-            # Use terminal widget for interactive password prompts
-            return _run_ssh_copy_id_with_terminal(ssh_cmd, temp_script_path, terminal_widget)
+            return _run_ssh_copy_id_with_terminal(
+                ssh_cmd, terminal_widget
+            )
         else:
-            # Fallback to subprocess for non-interactive mode
-            return _run_ssh_copy_id_with_subprocess(ssh_cmd, temp_script_path)
-                
+            return _run_ssh_copy_id_with_subprocess(ssh_cmd)
+
     except Exception as e:
         logger.error(f"Custom ssh-copy-id: Unexpected error: {e}")
         return False, f"Unexpected error: {str(e)}"
 
 
-def _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_password, terminal_widget):
+def _run_ssh_copy_id_with_saved_password(ssh_cmd, saved_password, terminal_widget):
     """Run ssh-copy-id using saved password with sshpass"""
     try:
         logger.info(f"Running ssh-copy-id with saved password using sshpass")
@@ -355,7 +343,7 @@ def _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_passwo
         
         if not sshpass_path:
             logger.warning("sshpass not found, falling back to interactive terminal")
-            return _run_ssh_copy_id_with_terminal(ssh_cmd, temp_script_path, terminal_widget)
+            return _run_ssh_copy_id_with_terminal(ssh_cmd, terminal_widget)
         
         logger.info(f"Using sshpass at: {sshpass_path}")
         
@@ -378,7 +366,7 @@ def _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_passwo
                 os.unlink(pw_file_path)
             except Exception:
                 pass
-            return _run_ssh_copy_id_with_subprocess(sshpass_cmd, temp_script_path)
+            return _run_ssh_copy_id_with_subprocess(sshpass_cmd)
         
         # Get SSH environment with askpass for passphrase handling
         from .askpass_utils import get_ssh_env_with_askpass
@@ -414,8 +402,8 @@ def _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_passwo
         
         logger.info("sshpass process started in terminal for ssh-copy-id with saved password")
         
-        # Note: We don't clean up the temp_script_path or pw_file_path here because the SSH process is still running
-        # The files will be cleaned up by the system when the process exits
+        # Note: We don't clean up the pw_file_path here because the SSH process is still running
+        # The file will be cleaned up by the system when the process exits
         
         return True, "sshpass process started in terminal - operation should complete automatically"
         
@@ -424,12 +412,12 @@ def _run_ssh_copy_id_with_saved_password(ssh_cmd, temp_script_path, saved_passwo
         return False, f"Saved password execution failed: {str(e)}"
 
 
-def _run_ssh_copy_id_with_terminal(ssh_cmd, temp_script_path, terminal_widget):
+def _run_ssh_copy_id_with_terminal(ssh_cmd, terminal_widget):
     """Run ssh-copy-id using terminal widget for interactive password prompts"""
     try:
         if Vte is None or GLib is None:
             logger.error("Vte or GLib not available, falling back to subprocess")
-            return _run_ssh_copy_id_with_subprocess(ssh_cmd, temp_script_path)
+            return _run_ssh_copy_id_with_subprocess(ssh_cmd)
         
         # Get SSH environment with askpass for passphrase handling
         from .askpass_utils import get_ssh_env_with_askpass
@@ -464,15 +452,12 @@ def _run_ssh_copy_id_with_terminal(ssh_cmd, temp_script_path, terminal_widget):
         logger.info("SSH process started in terminal for interactive ssh-copy-id")
         return True, "SSH process started in terminal - complete the operation in the terminal"
         
-        # Note: We don't clean up the temp_script_path here because the SSH process is still running
-        # The script will be cleaned up by the system when the process exits
-        
     except Exception as e:
         logger.error(f"Failed to run ssh-copy-id with terminal: {e}")
         return False, f"Terminal execution failed: {str(e)}"
 
 
-def _run_ssh_copy_id_with_subprocess(ssh_cmd, temp_script_path):
+def _run_ssh_copy_id_with_subprocess(ssh_cmd):
     """Run ssh-copy-id using subprocess (fallback method)"""
     try:
         # Execute the command
@@ -497,9 +482,3 @@ def _run_ssh_copy_id_with_subprocess(ssh_cmd, temp_script_path):
     except Exception as e:
         logger.error(f"Custom ssh-copy-id: Subprocess execution failed: {e}")
         return False, f"Subprocess execution failed: {str(e)}"
-    finally:
-        # Clean up temporary script file after subprocess completes
-        try:
-            os.unlink(temp_script_path)
-        except Exception:
-            pass


### PR DESCRIPTION
## Summary
- attempt key-based ssh-copy-id sequentially across available keys
- fall back to password-based ssh-copy-id without retrying public keys
- include selected key in ssh options when using single-key mode

## Testing
- `python -m py_compile sshpilot/ssh_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa8e0acfcc83288e544b797d86b2f6