### PR TITLE
Fix inconsistent error callback execution

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -265,7 +265,7 @@ def _open_sftp_flatpak_compatible(uri: str, user: str, host: str, port: Optional
     progress_dialog.show_error(error_msg)
     GLib.timeout_add(1500, lambda: GLib.idle_add(progress_dialog.close))
     if error_callback:
-        GLib.idle_add(error_callback, error_msg)
+        error_callback(error_msg)
     return False, error_msg
 
 def _try_portal_file_access(uri: str, user: str, host: str) -> bool:


### PR DESCRIPTION
Standardize `error_callback` invocation by removing `GLib.idle_add()` wrapper to prevent inconsistent timing and race conditions.

---
<a href="https://cursor.com/background-agent?bcId=bc-42e10f38-602c-4901-a307-8433da0d3396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42e10f38-602c-4901-a307-8433da0d3396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

