### PR TITLE
Allow TTY fallback when askpass fails

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -177,7 +177,7 @@ def force_regenerate_askpass_script() -> str:
         _ASKPASS_DIR = None
     return ensure_passphrase_askpass()
 
-def get_ssh_env_with_askpass(require: str = "force") -> dict:
+def get_ssh_env_with_askpass(require: str = "prefer") -> dict:
     """Get SSH environment with askpass for passphrase handling"""
     env = os.environ.copy()
     env["SSH_ASKPASS"] = ensure_passphrase_askpass()

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -750,7 +750,7 @@ class TerminalWidget(Gtk.Box):
             else:
                 # Use askpass for passphrase prompts (key-based auth)
                 from .askpass_utils import get_ssh_env_with_askpass
-                askpass_env = get_ssh_env_with_askpass("force")
+                askpass_env = get_ssh_env_with_askpass()
                 env.update(askpass_env)
             env['TERM'] = env.get('TERM', 'xterm-256color')
             env['SHELL'] = env.get('SHELL', '/bin/bash')

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -34,7 +34,7 @@ from .config import Config
 from .key_manager import KeyManager, SSHKey
 from .port_forwarding_ui import PortForwardingRules
 from .connection_dialog import ConnectionDialog
-from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
+from .askpass_utils import ensure_askpass_script
 
 logger = logging.getLogger(__name__)
 
@@ -4043,7 +4043,7 @@ class MainWindow(Adw.ApplicationWindow):
                     # sshpass not available, fallback to askpass
                     logger.debug("Main window: sshpass not available, falling back to askpass")
                     from .askpass_utils import get_ssh_env_with_askpass
-                    askpass_env = get_ssh_env_with_askpass("force")
+                    askpass_env = get_ssh_env_with_askpass()
                     logger.debug(f"Main window: Askpass environment variables: {list(askpass_env.keys())}")
                     env.update(askpass_env)
             elif prefer_password and not has_saved_password:
@@ -4054,7 +4054,7 @@ class MainWindow(Adw.ApplicationWindow):
                 # Use askpass for passphrase prompts (key-based auth)
                 logger.debug("Main window: Using askpass for key-based authentication")
                 from .askpass_utils import get_ssh_env_with_askpass
-                askpass_env = get_ssh_env_with_askpass("force")
+                askpass_env = get_ssh_env_with_askpass()
                 logger.debug(f"Main window: Askpass environment variables: {list(askpass_env.keys())}")
                 env.update(askpass_env)
 


### PR DESCRIPTION
## Summary
- default SSH askpass to allow TTY fallback
- stop forcing askpass in interactive SSH flows

## Testing
- `python -m py_compile sshpilot/askpass_utils.py sshpilot/terminal.py sshpilot/window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af56e511348328ac947ed9bdecdc37