### PR TITLE
feat: add grouped connections

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -671,6 +671,8 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             # Load basic connection data
             if hasattr(self.connection, 'nickname'):
                 self.nickname_row.set_text(self.connection.nickname or "")
+            if hasattr(self.connection, 'group'):
+                self.group_row.set_text(self.connection.group or "")
             if hasattr(self.connection, 'host'):
                 self.host_row.set_text(self.connection.host or "")
             if hasattr(self.connection, 'username'):
@@ -1516,7 +1518,26 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # Nickname
         self.nickname_row = Adw.EntryRow(title=_("Nickname (Only letters, digits, dot, underscore, dash)"))
         basic_group.add(self.nickname_row)
-        
+
+        # Group
+        self.group_row = Adw.EntryRow(title=_("Group"))
+        try:
+            if self.connection_manager:
+                groups = sorted({getattr(c, 'group', '') for c in self.connection_manager.get_connections() if getattr(c, 'group', '')})
+                if groups:
+                    entry = self.group_row.get_child()
+                    completion = Gtk.EntryCompletion()
+                    store = Gtk.ListStore(str)
+                    for g in groups:
+                        store.append([g])
+                    completion.set_model(store)
+                    completion.set_text_column(0)
+                    if hasattr(entry, 'set_completion'):
+                        entry.set_completion(completion)
+        except Exception:
+            pass
+        basic_group.add(self.group_row)
+
         # Host
         self.host_row = Adw.EntryRow(title=_("Host"))
         basic_group.add(self.host_row)
@@ -2716,6 +2737,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # Gather connection data
         connection_data = {
             'nickname': self.nickname_row.get_text().strip(),
+            'group': self.group_row.get_text().strip(),
             'host': self.host_row.get_text().strip(),
             'username': self.username_row.get_text().strip(),
             'port': int(self.port_row.get_text().strip() or '22'),
@@ -3322,7 +3344,8 @@ Host {host_nickname}
                                                 main_window.config.set_connection_meta(self.connection.nickname, {
                                                     'auth_method': getattr(self.connection, 'auth_method', 0),
                                                     'use_raw_sshconfig': True,
-                                                    'raw_ssh_config_block': content
+                                                    'raw_ssh_config_block': content,
+                                                    'group': getattr(self.connection, 'group', '')
                                                 })
                                                 logger.debug(f"Saved connection metadata for '{self.connection.nickname}' with use_raw_sshconfig=True")
                                         except Exception as e:

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -63,6 +63,7 @@ class Connection:
         self.raw_ssh_config_block = data.get('raw_ssh_config_block', '')
         self.password = data.get('password', '')
         self.key_passphrase = data.get('key_passphrase', '')
+        self.group = data.get('group', '')
         # Commands
         self.local_command = data.get('local_command', '')
         self.remote_command = data.get('remote_command', '')
@@ -562,6 +563,7 @@ class Connection:
         self.keyfile = data.get('keyfile') or data.get('private_key', '') or ''
         self.password = data.get('password', '')
         self.key_passphrase = data.get('key_passphrase', '')
+        self.group = data.get('group', '')
         self.local_command = data.get('local_command', '')
         self.remote_command = data.get('remote_command', '')
         
@@ -706,6 +708,8 @@ class ConnectionManager(GObject.Object):
                                                     existing.use_raw_sshconfig = meta['use_raw_sshconfig']
                                                 if 'raw_ssh_config_block' in meta:
                                                     existing.raw_ssh_config_block = meta['raw_ssh_config_block']
+                                                if 'group' in meta:
+                                                    existing.group = meta['group']
                                         except Exception:
                                             pass
                                         self.connections.append(existing)
@@ -724,6 +728,8 @@ class ConnectionManager(GObject.Object):
                                                     conn.use_raw_sshconfig = meta['use_raw_sshconfig']
                                                 if 'raw_ssh_config_block' in meta:
                                                     conn.raw_ssh_config_block = meta['raw_ssh_config_block']
+                                                if 'group' in meta:
+                                                    conn.group = meta['group']
                                         except Exception:
                                             pass
                                         self.connections.append(conn)
@@ -762,6 +768,8 @@ class ConnectionManager(GObject.Object):
                                     existing.use_raw_sshconfig = meta['use_raw_sshconfig']
                                 if 'raw_ssh_config_block' in meta:
                                     existing.raw_ssh_config_block = meta['raw_ssh_config_block']
+                                if 'group' in meta:
+                                    existing.group = meta['group']
                         except Exception:
                             pass
                         self.connections.append(existing)
@@ -780,6 +788,8 @@ class ConnectionManager(GObject.Object):
                                     conn.use_raw_sshconfig = meta['use_raw_sshconfig']
                                 if 'raw_ssh_config_block' in meta:
                                     conn.raw_ssh_config_block = meta['raw_ssh_config_block']
+                                if 'group' in meta:
+                                    conn.group = meta['group']
                         except Exception:
                             pass
                         self.connections.append(conn)


### PR DESCRIPTION
## Summary
- support grouping connections via new `group` field
- persist group metadata in config
- show connections organized by group with list headers and dialog field

## Testing
- `python -m py_compile sshpilot/connection_manager.py sshpilot/config.py sshpilot/window.py sshpilot/connection_dialog.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0abb5fc748328abacfbb37d9ff2e6