### PR TITLE
Maintain selection when toggling groups with Enter

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -3068,7 +3068,8 @@ class MainWindow(Adw.ApplicationWindow):
             if selected_row and hasattr(selected_row, 'connection'):
                 connection = selected_row.connection
                 self._focus_most_recent_tab_or_open_new(connection)
-            return True  # Consume the event to prevent row-activated
+                return True  # Consume the event to prevent row-activated
+            return False  # Allow group rows to be handled by row-activated
         return False
 
     def _stop_pulse_on_interaction(self, controller, *args):
@@ -4000,6 +4001,12 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_group_toggled(self, group_row, group_id, expanded):
         """Handle group expand/collapse"""
         self.rebuild_connection_list()
+
+        # Reselect the toggled group so focus doesn't jump to another row
+        for row in self.connection_list:
+            if hasattr(row, "group_id") and row.group_id == group_id:
+                self.connection_list.select_row(row)
+                break
     
     def add_connection_row(self, connection: Connection, indent_level: int = 0):
         """Add a connection row to the list with optional indentation"""


### PR DESCRIPTION
## Summary
- keep toggled group selected after expand/collapse so focus doesn't jump

## Testing
- `python -m py_compile sshpilot/window.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0cec05f9883289d67071680480a85