### PR TITLE
Support certificate files in SSH config

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -560,6 +560,7 @@ class Connection:
         self.username = data.get('username', '')
         self.port = data.get('port', 22)
         self.keyfile = data.get('keyfile') or data.get('private_key', '') or ''
+        self.certificate = data.get('certificate', '')
         self.password = data.get('password', '')
         self.key_passphrase = data.get('key_passphrase', '')
         self.local_command = data.get('local_command', '')
@@ -814,6 +815,7 @@ class ConnectionManager(GObject.Object):
                 'username': _unwrap(config.get('user', getpass.getuser())),
                 # previously: 'private_key': config.get('identityfile'),
                 'keyfile': os.path.expanduser(_unwrap(config.get('identityfile'))) if config.get('identityfile') else None,
+                'certificate': os.path.expanduser(_unwrap(config.get('certificatefile'))) if config.get('certificatefile') else None,
                 'forwarding_rules': []
             }
             

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -814,8 +814,8 @@ class ConnectionManager(GObject.Object):
                 'port': int(_unwrap(config.get('port', 22))),
                 'username': _unwrap(config.get('user', getpass.getuser())),
                 # previously: 'private_key': config.get('identityfile'),
-                'keyfile': os.path.expanduser(_unwrap(config.get('identityfile'))) if config.get('identityfile') else None,
-                'certificate': os.path.expanduser(_unwrap(config.get('certificatefile'))) if config.get('certificatefile') else None,
+                'keyfile': os.path.expanduser(_unwrap(config.get('identityfile'))) if config.get('identityfile') else '',
+                'certificate': os.path.expanduser(_unwrap(config.get('certificatefile'))) if config.get('certificatefile') else '',
                 'forwarding_rules': []
             }
             

--- a/tests/test_certificate_persistence.py
+++ b/tests/test_certificate_persistence.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+
+# Stub external dependencies required by connection_manager
+sys.modules['secretstorage'] = types.ModuleType('secretstorage')
+
+gi_repo = types.ModuleType('gi.repository')
+gi_repo.GObject = types.SimpleNamespace(
+    SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
+    Object=type('GObject', (object,), {})
+)
+gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
+gi_repo.Gtk = types.SimpleNamespace()
+
+gi_mod = types.ModuleType('gi')
+gi_mod.repository = gi_repo
+gi_mod.require_version = lambda *args, **kwargs: None
+sys.modules['gi'] = gi_mod
+sys.modules['gi.repository'] = gi_repo
+
+# Ensure the project package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sshpilot.connection_manager import ConnectionManager, Connection
+
+
+def test_certificatefile_persistence():
+    manager = ConnectionManager.__new__(ConnectionManager)
+    config = {
+        'host': 'example',
+        'hostname': 'example.com',
+        'certificatefile': '~/cert.pub',
+    }
+
+    parsed = manager.parse_host_config(config)
+    expected = os.path.expanduser('~/cert.pub')
+    assert parsed['certificate'] == expected
+
+    conn = Connection(parsed)
+    assert conn.certificate == expected
+
+    # simulate reloading the SSH config
+    parsed_reload = manager.parse_host_config(config)
+    conn.update_data(parsed_reload)
+    assert conn.certificate == expected


### PR DESCRIPTION
## Summary
- Parse `CertificateFile` from SSH config and expose as `certificate`
- Keep connection `certificate` attribute in sync on updates
- Add regression test ensuring certificate path persists after reload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b191353e488328bc6d0eb138ae413a