### PR TITLE
Handle background quit requests with terminal confirmation

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -3217,6 +3217,12 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
     def show_quit_confirmation_dialog(self):
         """Show confirmation dialog when quitting with active connections"""
+        # Bring the main window to the foreground first
+        try:
+            self.present()
+        except Exception as e:
+            logger.debug(f"Failed to bring window to foreground: {e}")
+        
         # Only count terminals that are actually connected across all tabs
         connected_items = []
         for conn, terms in self.connection_to_terminals.items():


### PR DESCRIPTION
Bring main window to foreground before showing quit confirmation dialog to ensure visibility.

Previously, if the app was not in the foreground (e.g., minimized or behind other windows) and a quit was initiated (e.g., via launcher icon or Ctrl+C) while terminals were open, the quit confirmation dialog would appear but remain hidden behind other windows, preventing user interaction. This change ensures the main window is raised, making the dialog visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-fede48c7-f0ff-44b6-a737-4905d3374058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fede48c7-f0ff-44b6-a737-4905d3374058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

