### PR TITLE
Add sidebar search for connections

### DIFF
--- a/sshpilot/search_utils.py
+++ b/sshpilot/search_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def connection_matches(connection: Any, query: str) -> bool:
+    """Return True if connection matches the search query.
+
+    The search checks the connection's nickname, host alias (``hname``), and
+    host/IP address in a case-insensitive manner.
+    """
+    if not query:
+        return True
+    text = query.lower()
+    fields = [
+        getattr(connection, "nickname", ""),
+        getattr(connection, "host", ""),
+        getattr(connection, "hname", ""),
+    ]
+    return any(text in (field or "").lower() for field in fields)
+
+
+__all__ = ["connection_matches"]

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -1,0 +1,27 @@
+from sshpilot.connection_manager import Connection
+from sshpilot.search_utils import connection_matches
+
+
+def make_connection(nickname, host, hname=None):
+    data = {"nickname": nickname, "host": host, "username": "user"}
+    conn = Connection(data)
+    if hname:
+        setattr(conn, "hname", hname)
+    return conn
+
+
+def test_matches_nickname():
+    conn = make_connection("server1", "192.168.0.1")
+    assert connection_matches(conn, "server")
+    assert not connection_matches(conn, "other")
+
+
+def test_matches_host():
+    conn = make_connection("server2", "10.0.0.5")
+    assert connection_matches(conn, "10.0.0.5")
+    assert connection_matches(conn, "10.0")
+
+
+def test_matches_alias():
+    conn = make_connection("alias", "host", hname="myalias")
+    assert connection_matches(conn, "myalias")


### PR DESCRIPTION
## Summary
- add Gtk.SearchEntry to sidebar to filter connections
- filter results by nickname, host alias or host/IP
- allow keyboard navigation from search field
- cover search utility with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3323512fc832880dcb2dfa8f9524f