### PR TITLE
Reduce default logging noise with optional verbosity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ You can also run the app from source. Install the modules listed in requirements
 python3 run.py
 `
 
+To enable verbose debugging output, run the app with the `--verbose` flag:
+
+`
+python3 run.py --verbose
+`
+
 
 
 
@@ -95,6 +101,12 @@ Run from source
 
 ```
 python3 run.py
+```
+
+Enable verbose debugging with:
+
+```
+python3 run.py --verbose
 ```
 
 


### PR DESCRIPTION
## Summary
- Default logging is now set to INFO to avoid noisy output
- Added `--verbose` flag and config override for debugging
- Documented how to enable verbose logs via CLI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b474f713e8832896af53aaeed2404f