### PR TITLE
Reduce default logging noise with optional verbosity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ You can also run the app from source. Install the modules listed in requirements
 python3 run.py
 `
 
+By default, only warnings and errors are printed. To enable verbose debugging output, run the app with the `--verbose` flag:
+
+`
+python3 run.py --verbose
+`
+
 
 
 
@@ -95,6 +101,12 @@ Run from source
 
 ```
 python3 run.py
+```
+
+By default, logs only show warnings and errors. Enable verbose debugging with:
+
+```
+python3 run.py --verbose
 ```
 
 


### PR DESCRIPTION
## Summary
- Default logging now emits only warnings and errors unless `--verbose` or config enables debugging
- Resource bundle loading hooked into logging so startup is quiet
- README documents quiet logging and how to enable verbose output

## Testing
- `pytest`
- `python3 run.py --help` *(fails: No module named 'gi')*


------
https://chatgpt.com/codex/tasks/task_e_68b474f713e8832896af53aaeed2404f