### PR TITLE
Allow optional password in key-based authentication

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1216,8 +1216,11 @@ class ConnectionManager(GObject.Object):
                     if ' ' in certificate and not (certificate.startswith('"') and certificate.endswith('"')):
                         certificate = f'"{certificate}"'
                     lines.append(f"    CertificateFile {certificate}")
+            # Include password-based fallback if a password is provided
+            if data.get('password'):
+                lines.append("    PreferredAuthentications publickey,password")
         else:
-            # Password-based authentication
+            # Password-based authentication only
             lines.append("    PreferredAuthentications password")
             lines.append("    PubkeyAuthentication no")
         

--- a/tests/test_optional_password.py
+++ b/tests/test_optional_password.py
@@ -1,0 +1,15 @@
+import types
+from sshpilot import ssh_utils
+
+
+def test_key_auth_with_optional_password_adds_combined_options():
+    conn = types.SimpleNamespace(auth_method=0, password='secret', key_select_mode=0)
+    opts = ssh_utils.build_connection_ssh_options(conn)
+    assert 'PreferredAuthentications=publickey,password' in opts
+    assert 'PubkeyAuthentication=no' not in opts
+
+
+def test_key_auth_without_password_omits_combined_options():
+    conn = types.SimpleNamespace(auth_method=0, key_select_mode=0)
+    opts = ssh_utils.build_connection_ssh_options(conn)
+    assert 'PreferredAuthentications=publickey,password' not in opts


### PR DESCRIPTION
## Summary
- Always show password field and store it for key-based connections
- Send both key and password by setting `PreferredAuthentications=publickey,password`
- Support combined authentication across ssh, scp, and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c3cff4108328b0854d2c8a9f2d63