### PR TITLE
Preserve all SSH auth methods when optional password present

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -1038,7 +1038,9 @@ class ConnectionDialog(Adw.Window):
                         config_lines.append(f"    CertificateFile {certificate_val}")
                 # Add combined authentication if a password is provided
                 if password_val:
-                    config_lines.append("    PreferredAuthentications publickey,password")
+                    config_lines.append(
+                        "    PreferredAuthentications gssapi-with-mic,hostbased,publickey,keyboard-interactive,password"
+                    )
                 # For automatic key selection, don't add IdentityFile
             else:  # Password auth only
                 config_lines.append("    PreferredAuthentications password")

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1218,7 +1218,9 @@ class ConnectionManager(GObject.Object):
                     lines.append(f"    CertificateFile {certificate}")
             # Include password-based fallback if a password is provided
             if data.get('password'):
-                lines.append("    PreferredAuthentications publickey,password")
+                lines.append(
+                    "    PreferredAuthentications gssapi-with-mic,hostbased,publickey,keyboard-interactive,password"
+                )
         else:
             # Password-based authentication only
             lines.append("    PreferredAuthentications password")

--- a/sshpilot/ssh_password_exec.py
+++ b/sshpilot/ssh_password_exec.py
@@ -34,7 +34,10 @@ def run_ssh_with_password(host: str, user: str, password: str, *,
 
     ssh_opts = []
     if use_publickey:
-        ssh_opts += ["-o", "PreferredAuthentications=publickey,password"]
+        ssh_opts += [
+            "-o",
+            "PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password",
+        ]
     else:
         ssh_opts += ["-o", "PreferredAuthentications=password",
                      "-o", "PubkeyAuthentication=no"]
@@ -118,7 +121,10 @@ def run_scp_with_password(host: str, user: str, password: str,
 
     ssh_opts = []
     if use_publickey:
-        ssh_opts += ["-o", "PreferredAuthentications=publickey,password"]
+        ssh_opts += [
+            "-o",
+            "PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password",
+        ]
     else:
         ssh_opts += ["-o", "PreferredAuthentications=password",
                      "-o", "PubkeyAuthentication=no"]

--- a/sshpilot/ssh_utils.py
+++ b/sshpilot/ssh_utils.py
@@ -126,13 +126,19 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
                os.path.isfile(connection.certificate):
                 options.extend(['-o', f'CertificateFile={connection.certificate}'])
 
-            # If a password is available, allow publickey+password authentication
+            # If a password is available, allow all standard authentication methods
             if has_saved_password:
-                options.extend(['-o', 'PreferredAuthentications=publickey,password'])
+                options.extend([
+                    '-o',
+                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+                ])
         else:
             # If no specific key or certificate, still append combined auth if password exists
             if has_saved_password:
-                options.extend(['-o', 'PreferredAuthentications=publickey,password'])
+                options.extend([
+                    '-o',
+                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+                ])
     else:
         # Force password authentication when user chose password auth (same as terminal.py)
         # But don't disable pubkey auth for ssh-copy-id since we're installing a key

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -590,9 +590,12 @@ class TerminalWidget(Gtk.Box):
                 else:
                     logger.debug("Using default SSH key selection (key_select_mode=0 or no valid key specified)")
 
-                # If a password exists, allow publickey+password authentication
+                # If a password exists, allow all standard authentication methods
                 if has_saved_password:
-                    ssh_cmd.extend(['-o', 'PreferredAuthentications=publickey,password'])
+                    ssh_cmd.extend([
+                        '-o',
+                        'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+                    ])
             else:
                 # Force password authentication when user chose password auth
                 ssh_cmd.extend(['-o', 'PreferredAuthentications=password'])

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -2503,8 +2503,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 argv += ['-o', 'PubkeyAuthentication=no', '-o', 'PreferredAuthentications=password']
                 logger.debug("Main window: Added password authentication options - PubkeyAuthentication=no, PreferredAuthentications=password")
             elif combined_auth:
-                argv += ['-o', 'PreferredAuthentications=publickey,password']
-                logger.debug("Main window: Added combined authentication options - PreferredAuthentications=publickey,password")
+                argv += [
+                    '-o',
+                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+                ]
+                logger.debug(
+                    "Main window: Added combined authentication options - "
+                    "PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password"
+                )
         
         # Target
         target = f"{connection.username}@{connection.host}" if getattr(connection, 'username', '') else str(connection.host)
@@ -2857,7 +2863,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             if prefer_password:
                 argv += ['-o', 'PubkeyAuthentication=no', '-o', 'PreferredAuthentications=password']
             else:
-                argv += ['-o', 'PreferredAuthentications=publickey,password']
+                argv += [
+                    '-o',
+                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+                ]
             
             # Try to get saved password
             try:

--- a/tests/test_optional_password.py
+++ b/tests/test_optional_password.py
@@ -5,11 +5,17 @@ from sshpilot import ssh_utils
 def test_key_auth_with_optional_password_adds_combined_options():
     conn = types.SimpleNamespace(auth_method=0, password='secret', key_select_mode=0)
     opts = ssh_utils.build_connection_ssh_options(conn)
-    assert 'PreferredAuthentications=publickey,password' in opts
+    assert (
+        'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+        in opts
+    )
     assert 'PubkeyAuthentication=no' not in opts
 
 
 def test_key_auth_without_password_omits_combined_options():
     conn = types.SimpleNamespace(auth_method=0, key_select_mode=0)
     opts = ssh_utils.build_connection_ssh_options(conn)
-    assert 'PreferredAuthentications=publickey,password' not in opts
+    assert (
+        'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
+        not in opts
+    )


### PR DESCRIPTION
## Summary
- allow combined SSH authentication to use all standard methods (gssapi-with-mic, hostbased, publickey, keyboard-interactive, password)
- update tests for new combined authentication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e1152c148328930f29b3f4c36ec4