### PR TITLE
Add architecture-specific macOS build scripts

### DIFF
--- a/packaging/macos/build_app_intel.sh
+++ b/packaging/macos/build_app_intel.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build sshPilot macOS app bundle and DMG for Intel (x86_64) Macs.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+arch -x86_64 bash "${SCRIPT_DIR}/build_app.sh" "$@"

--- a/packaging/macos/build_app_m4.sh
+++ b/packaging/macos/build_app_m4.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build sshPilot macOS app bundle and DMG for Apple Silicon (arm64/M-series) Macs.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+arch -arm64 bash "${SCRIPT_DIR}/build_app.sh" "$@"


### PR DESCRIPTION
## Summary
- Add wrapper scripts for building macOS app bundles/DMGs for Intel and Apple Silicon machines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4f5cacf608328b8fcd78594e9be29