### PR TITLE
Add architecture-specific macOS build scripts

### DIFF
--- a/packaging/macos/build_app.sh
+++ b/packaging/macos/build_app.sh
@@ -91,9 +91,14 @@ copy_lib libfreetype
 copy_lib libfontconfig
 copy_lib libz
 
+# Rename PyInstaller-generated binary so we can wrap it with env setup
+ORIG_BIN="${MACOS_DIR}/${APP_NAME}"
+if [ -f "$ORIG_BIN" ]; then
+  mv "$ORIG_BIN" "${ORIG_BIN}-bin"
+fi
+
 # Create launcher that sets env for bundled GI/GTK
-LAUNCHER="${MACOS_DIR}/${APP_NAME}"
-cat > "$LAUNCHER" <<'EOF'
+cat > "$ORIG_BIN" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -107,12 +112,12 @@ export XDG_DATA_DIRS="${RES}/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
 export GTK_DATA_PREFIX="${RES}"
 export GTK_EXE_PREFIX="${RES}"
 
-exec "${HERE}/sshPilot" "$@"
+exec "${HERE}/sshPilot-bin" "$@"
 EOF
-chmod +x "$LAUNCHER"
+chmod +x "$ORIG_BIN"
 
 # Ensure main binary exists (PyInstaller output name)
-if [ ! -f "${MACOS_DIR}/sshPilot" ]; then
+if [ ! -f "${ORIG_BIN}-bin" ]; then
   echo "PyInstaller main binary not found; build may have failed" >&2
   exit 1
 fi

--- a/packaging/macos/build_app_intel.sh
+++ b/packaging/macos/build_app_intel.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build sshPilot macOS app bundle and DMG for Intel (x86_64) Macs.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+arch -x86_64 bash "${SCRIPT_DIR}/build_app.sh" "$@"

--- a/packaging/macos/build_app_m4.sh
+++ b/packaging/macos/build_app_m4.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Build sshPilot macOS app bundle and DMG for Apple Silicon (arm64/M-series) Macs.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+arch -arm64 bash "${SCRIPT_DIR}/build_app.sh" "$@"


### PR DESCRIPTION
## Summary
- Add wrapper scripts for macOS builds on Intel and Apple Silicon machines
- Fix build script to wrap PyInstaller binary without recursion so the app launches correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5cacf608328b8fcd78594e9be29