### PR TITLE
Automate macOS bundler setup

### DIFF
--- a/packaging/macos/gtk-osx-setup.sh
+++ b/packaging/macos/gtk-osx-setup.sh
@@ -52,6 +52,8 @@ fi
 export PATH="${GTK_MAC_BUNDLER_INSTALL_DIR}:${PATH}"
 
 echo "Setup complete! gtk-mac-bundler installed at ${GTK_MAC_BUNDLER_INSTALL_DIR}"
-echo "Now run: bash packaging/macos/make-bundle.sh"
 
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Now run: bash packaging/macos/make-bundle.sh"
+fi
 

--- a/packaging/macos/make-bundle.sh
+++ b/packaging/macos/make-bundle.sh
@@ -14,9 +14,16 @@ mkdir -p "${DIST_DIR}"
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 
-# Check if gtk-mac-bundler is available
+# Ensure gtk-mac-bundler is available
 if ! command -v gtk-mac-bundler >/dev/null 2>&1; then
-  echo "gtk-mac-bundler not found. Run gtk-osx-setup.sh first." >&2
+  echo "gtk-mac-bundler not found. Running gtk-osx-setup.sh..."
+  # shellcheck source=packaging/macos/gtk-osx-setup.sh
+  source "${SCRIPT_DIR}/gtk-osx-setup.sh"
+fi
+
+# Verify installation succeeded
+if ! command -v gtk-mac-bundler >/dev/null 2>&1; then
+  echo "gtk-mac-bundler installation failed." >&2
   exit 1
 fi
 
@@ -45,8 +52,8 @@ echo "Building Python application..."
 if [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
   # Only install dependencies locally, not in CI
   echo "Installing Python dependencies locally..."
-  python3 -m pip install --user --upgrade pip
-  python3 -m pip install --user -r "${ROOT_DIR}/requirements.txt"
+  python3 -m pip install --user --break-system-packages --upgrade pip
+  python3 -m pip install --user --break-system-packages -r "${ROOT_DIR}/requirements.txt"
 else
   echo "Running in CI environment, skipping pip install (dependencies should be pre-installed)"
 fi


### PR DESCRIPTION
## Summary
- Ensure `make-bundle.sh` installs gtk-mac-bundler on demand and fails gracefully if setup fails
- Allow pip installs in macOS bundling by passing `--break-system-packages`
- Suppress setup reminder in `gtk-osx-setup.sh` when sourced by another script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b80ad789248328895bc8fe2b090fc2