### PR TITLE
Automate macOS bundler setup

### DIFF
--- a/packaging/macos/gtk-osx-setup.sh
+++ b/packaging/macos/gtk-osx-setup.sh
@@ -7,51 +7,48 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 GTK_MAC_BUNDLER_DIR="${HOME}/gtk-mac-bundler"
-# Directory where the gtk-mac-bundler executable will be installed
+GTK_MAC_BUNDLER_PREFIX=""
 GTK_MAC_BUNDLER_INSTALL_DIR=""
 
 echo "Setting up gtk-mac-bundler for sshPilot packaging"
 
-# Check if Homebrew is available
-if ! command -v brew >/dev/null 2>&1; then
+if command -v brew >/dev/null 2>&1; then
+  GTK_MAC_BUNDLER_PREFIX="$(brew --prefix)"
+  # Ensure we have the GTK stack
+  if ! brew list gtk4 >/dev/null 2>&1; then
+    echo "Installing GTK4 stack..."
+    brew install gtk4 libadwaita pygobject3 py3cairo vte3 gobject-introspection
+  fi
+elif command -v jhbuild >/dev/null 2>&1; then
+  GTK_MAC_BUNDLER_PREFIX="$(jhbuild --prefix)"
+else
   echo "Homebrew is required. Install it first:" >&2
   echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" >&2
   exit 1
-fi
-
-# Ensure we have the GTK stack
-if ! brew list gtk4 >/dev/null 2>&1; then
-  echo "Installing GTK4 stack..."
-  brew install gtk4 libadwaita pygobject3 py3cairo vte3 gobject-introspection
 fi
 
 # Install gtk-mac-bundler from source
 if [ ! -d "${GTK_MAC_BUNDLER_DIR}" ]; then
   echo "Installing gtk-mac-bundler..."
   git clone https://gitlab.gnome.org/GNOME/gtk-mac-bundler.git "${GTK_MAC_BUNDLER_DIR}"
-  cd "${GTK_MAC_BUNDLER_DIR}"
-  make install
-  cd "${ROOT_DIR}"
-else
-  # Ensure gtk-mac-bundler is installed even if repo exists
-  cd "${GTK_MAC_BUNDLER_DIR}"
-  make install
-  cd "${ROOT_DIR}"
 fi
+cd "${GTK_MAC_BUNDLER_DIR}"
+make install PREFIX="${GTK_MAC_BUNDLER_PREFIX}"
+cd "${ROOT_DIR}"
 
-# Determine where gtk-mac-bundler was installed
-if command -v brew >/dev/null 2>&1; then
-  GTK_MAC_BUNDLER_INSTALL_DIR="$(brew --prefix)/bin"
-elif command -v jhbuild >/dev/null 2>&1; then
-  GTK_MAC_BUNDLER_INSTALL_DIR="$(jhbuild --prefix)/bin"
-else
-  GTK_MAC_BUNDLER_INSTALL_DIR="${HOME}/.local/bin"
-fi
+# Directory where the executable was installed
+GTK_MAC_BUNDLER_INSTALL_DIR="${GTK_MAC_BUNDLER_PREFIX}/bin"
 
-# Add gtk-mac-bundler to PATH
+# Add gtk-mac-bundler to PATH and verify
 export PATH="${GTK_MAC_BUNDLER_INSTALL_DIR}:${PATH}"
+if ! command -v gtk-mac-bundler >/dev/null 2>&1; then
+  echo "gtk-mac-bundler installation failed" >&2
+  exit 1
+fi
 
 echo "Setup complete! gtk-mac-bundler installed at ${GTK_MAC_BUNDLER_INSTALL_DIR}"
-echo "Now run: bash packaging/macos/make-bundle.sh"
 
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Now run: bash packaging/macos/make-bundle.sh"
+fi
 

--- a/packaging/macos/make-bundle.sh
+++ b/packaging/macos/make-bundle.sh
@@ -14,9 +14,16 @@ mkdir -p "${DIST_DIR}"
 rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 
-# Check if gtk-mac-bundler is available
+# Ensure gtk-mac-bundler is available
 if ! command -v gtk-mac-bundler >/dev/null 2>&1; then
-  echo "gtk-mac-bundler not found. Run gtk-osx-setup.sh first." >&2
+  echo "gtk-mac-bundler not found. Running gtk-osx-setup.sh..."
+  # shellcheck source=packaging/macos/gtk-osx-setup.sh
+  source "${SCRIPT_DIR}/gtk-osx-setup.sh"
+fi
+
+# Verify installation succeeded
+if ! command -v gtk-mac-bundler >/dev/null 2>&1; then
+  echo "gtk-mac-bundler installation failed." >&2
   exit 1
 fi
 
@@ -45,8 +52,8 @@ echo "Building Python application..."
 if [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
   # Only install dependencies locally, not in CI
   echo "Installing Python dependencies locally..."
-  python3 -m pip install --user --upgrade pip
-  python3 -m pip install --user -r "${ROOT_DIR}/requirements.txt"
+  python3 -m pip install --user --break-system-packages --upgrade pip
+  python3 -m pip install --user --break-system-packages -r "${ROOT_DIR}/requirements.txt"
 else
   echo "Running in CI environment, skipping pip install (dependencies should be pre-installed)"
 fi


### PR DESCRIPTION
## Summary
- Ensure make-bundle.sh installs gtk-mac-bundler on demand and fails gracefully if setup fails
- Allow pip installs in macOS bundling by passing --break-system-packages
- Suppress setup reminder in gtk-osx-setup.sh when sourced by another script
- Install gtk-mac-bundler into the Homebrew or jhbuild prefix and export its bin directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b80ad789248328895bc8fe2b090fc2