### PR TITLE
Fix macOS bundled bin path in runtime hook

### DIFF
--- a/hook-gtk_runtime.py
+++ b/hook-gtk_runtime.py
@@ -58,7 +58,7 @@ if sys.platform == "darwin":
     os.environ["PATH"] = ":".join(system_paths + [current_path])
     
     # Add bundled sshpass to PATH
-    bundled_bin = str(frameworks / "Resources" / "bin")
+    bundled_bin = str(resources / "bin")
     if Path(bundled_bin).exists():
         os.environ["PATH"] = f"{bundled_bin}:{os.environ['PATH']}"
         print(f"DEBUG: Added bundled bin to PATH: {bundled_bin}")


### PR DESCRIPTION
## Summary
- ensure runtime hook prepends Contents/Resources/bin to PATH

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc40123a5883288a8dba5b21517a81