### PR TITLE
Handle missing hostname in SSH config entries

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -743,18 +743,24 @@ class ConnectionManager(GObject.Object):
                         return val[1:-1]
                 return val
 
-            host = _unwrap(config.get('host', ''))
-            if not host:
+            host_token = _unwrap(config.get('host', ''))
+            if not host_token:
                 return None
 
             # ⬇️ Ignore global defaults (Host *)
-            if str(host).strip() == '*':
+            if str(host_token).strip() == '*':
                 return None
-                
+
+            # When HostName is missing, treat the Host token as both nickname and hostname
+            nickname = host_token.split()[0]
+            hostname = _unwrap(config.get('hostname', '')).strip()
+            if not hostname:
+                hostname = nickname
+
             # Extract relevant configuration
             parsed = {
-                'nickname': host,
-                'host': _unwrap(config.get('hostname', host)),
+                'nickname': nickname,
+                'host': hostname,
                 'port': int(_unwrap(config.get('port', 22))),
                 'username': _unwrap(config.get('user', getpass.getuser())),
                 # previously: 'private_key': config.get('identityfile'),

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+import asyncio
+
+# Stub external dependencies required by connection_manager
+sys.modules['secretstorage'] = types.ModuleType('secretstorage')
+
+gi_repo = types.ModuleType('gi.repository')
+gi_repo.GObject = types.SimpleNamespace(
+    SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
+    Object=type('GObject', (object,), {})
+)
+gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
+gi_repo.Gtk = types.SimpleNamespace()
+
+gi_mod = types.ModuleType('gi')
+gi_mod.repository = gi_repo
+gi_mod.require_version = lambda *args, **kwargs: None
+sys.modules['gi'] = gi_mod
+sys.modules['gi.repository'] = gi_repo
+
+# Ensure the project package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sshpilot.connection_manager import ConnectionManager
+
+
+def test_host_token_used_when_hostname_missing(tmp_path):
+    """Entries without HostName should use Host token for both nickname and hostname."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+    manager = ConnectionManager.__new__(ConnectionManager)
+    manager.connections = []
+
+    config_path = tmp_path / 'config'
+    config_path.write_text('Host example.com\n    User testuser\n')
+    manager.ssh_config_path = str(config_path)
+
+    manager.load_ssh_config()
+
+    assert len(manager.connections) == 1
+    conn = manager.connections[0]
+    assert conn.nickname == 'example.com'
+    assert conn.host == 'example.com'
+


### PR DESCRIPTION
## Summary
- Treat `Host` token as hostname when `Hostname` is absent
- Add regression test ensuring such entries become connections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca53a7384832883d57b93bd53d382