### PR TITLE
Handle proxy directives in SSH connections

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -73,6 +73,9 @@ class Connection:
         self.certificate = data.get('certificate') or ''
         self.password = data.get('password', '')
         self.key_passphrase = data.get('key_passphrase', '')
+        # Proxy settings
+        self.proxy_command = data.get('proxy_command', '')
+        self.proxy_jump = data.get('proxy_jump', '')
         # Commands
         self.local_command = data.get('local_command', '')
         self.remote_command = data.get('remote_command', '')
@@ -174,7 +177,13 @@ class Connection:
                         ssh_cmd.extend(['-o', f'CertificateFile={self.certificate}'])
             except Exception:
                 pass
-            
+
+            # Add proxy directives if present
+            if self.proxy_jump:
+                ssh_cmd.extend(['-o', f'ProxyJump={self.proxy_jump}'])
+            if self.proxy_command:
+                ssh_cmd.extend(['-o', f'ProxyCommand={self.proxy_command}'])
+
             # Add host and port
             if self.port != 22:
                 ssh_cmd.extend(['-p', str(self.port)])
@@ -549,6 +558,8 @@ class Connection:
         self.key_passphrase = data.get('key_passphrase', '')
         self.local_command = data.get('local_command', '')
         self.remote_command = data.get('remote_command', '')
+        self.proxy_command = data.get('proxy_command', '')
+        self.proxy_jump = data.get('proxy_jump', '')
         # Extra SSH config parameters
         self.extra_ssh_config = data.get('extra_ssh_config', '')
         self.pubkey_auth_no = bool(data.get('pubkey_auth_no', False))
@@ -844,6 +855,8 @@ class ConnectionManager(GObject.Object):
             # Handle proxy settings if any
             if 'proxycommand' in config:
                 parsed['proxy_command'] = config['proxycommand']
+            if 'proxyjump' in config:
+                parsed['proxy_jump'] = config['proxyjump']
             
             # Commands: LocalCommand requires PermitLocalCommand
             try:
@@ -896,7 +909,7 @@ class ConnectionManager(GObject.Object):
             standard_options = {
                 'host', 'hostname', 'port', 'user', 'identityfile', 'certificatefile',
                 'forwardx11', 'localforward', 'remoteforward', 'dynamicforward',
-                'proxycommand', 'localcommand', 'remotecommand', 'requesttty',
+                'proxycommand', 'proxyjump', 'localcommand', 'remotecommand', 'requesttty',
                 'identitiesonly', 'permitlocalcommand',
                 'preferredauthentications', 'pubkeyauthentication'
             }

--- a/tests/test_proxy_directives.py
+++ b/tests/test_proxy_directives.py
@@ -1,0 +1,45 @@
+import asyncio
+from sshpilot.connection_manager import Connection, ConnectionManager
+
+# Ensure an event loop for Connection objects
+asyncio.set_event_loop(asyncio.new_event_loop())
+
+def test_parse_and_load_proxy_directives(tmp_path):
+    cfg_path = tmp_path / "config"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "Host proxycmd",
+                "    HostName example.com",
+                "    ProxyCommand ssh -W %h:%p bastion",
+                "",
+                "Host proxyjump",
+                "    HostName example.com",
+                "    ProxyJump bastion",
+            ]
+        )
+    )
+
+    cm = ConnectionManager.__new__(ConnectionManager)
+    cm.connections = []
+    cm.ssh_config_path = str(cfg_path)
+    cm.load_ssh_config()
+
+    assert len(cm.connections) == 2
+    proxy_cmd_conn = next(c for c in cm.connections if c.nickname == "proxycmd")
+    proxy_jump_conn = next(c for c in cm.connections if c.nickname == "proxyjump")
+
+    assert proxy_cmd_conn.proxy_command == "ssh -W %h:%p bastion"
+    assert proxy_jump_conn.proxy_jump == "bastion"
+
+async def _connect(conn: Connection):
+    await conn.connect()
+
+def test_connection_passes_proxy_options():
+    loop = asyncio.get_event_loop()
+    conn1 = Connection({"host": "example.com", "proxy_command": "ssh -W %h:%p bastion"})
+    conn2 = Connection({"host": "example.com", "proxy_jump": "bastion"})
+    loop.run_until_complete(_connect(conn1))
+    loop.run_until_complete(_connect(conn2))
+    assert "ProxyCommand=ssh -W %h:%p bastion" in conn1.ssh_cmd
+    assert "ProxyJump=bastion" in conn2.ssh_cmd


### PR DESCRIPTION
## Summary
- parse ProxyCommand and ProxyJump entries into connections
- include ProxyJump/ProxyCommand when building ssh command
- add regression tests for proxy directives

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca53dcb9883288e8c70e9e0726d81