### PR TITLE
Handle wildcard host blocks

### DIFF
--- a/tests/test_wildcard_rules.py
+++ b/tests/test_wildcard_rules.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+import asyncio
+
+# Stub external dependencies required by connection_manager
+sys.modules['secretstorage'] = types.ModuleType('secretstorage')
+
+gi_repo = types.ModuleType('gi.repository')
+gi_repo.GObject = types.SimpleNamespace(
+    SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
+    Object=type('GObject', (object,), {})
+)
+gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
+gi_repo.Gtk = types.SimpleNamespace()
+
+gi_mod = types.ModuleType('gi')
+gi_mod.repository = gi_repo
+gi_mod.require_version = lambda *args, **kwargs: None
+sys.modules['gi'] = gi_mod
+sys.modules['gi.repository'] = gi_repo
+
+# Ensure the project package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sshpilot.connection_manager import ConnectionManager
+
+
+def test_wildcard_and_negated_hosts_are_stored_as_rules(tmp_path):
+    """Host blocks with wildcard or negated tokens should be stored in rules and not connections."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+    cfg_path = tmp_path / 'config'
+    cfg_path.write_text(
+        '\n'.join([
+            'Host *.example.com alias?',
+            '    User user1',
+            '',
+            'Host normal',
+            '    HostName normal.example.com',
+            '    User user2',
+            '',
+            'Host !blocked',
+            '    User user3',
+        ])
+    )
+
+    cm = ConnectionManager.__new__(ConnectionManager)
+    cm.connections = []
+    cm.ssh_config_path = str(cfg_path)
+
+    cm.load_ssh_config()
+
+    # Only the normal host should appear in connections
+    assert len(cm.connections) == 1
+    assert cm.connections[0].nickname == 'normal'
+
+    # Wildcard and negated hosts are stored as rules
+    assert len(cm.rules) == 2
+    first, second = cm.rules
+    assert first['host'] == '*.example.com'
+    assert first.get('aliases') == ['alias?']
+    assert second['host'] == '!blocked'
+


### PR DESCRIPTION
## Summary
- Track wildcard and negated SSH config blocks separately from normal connections
- Exclude these rule-based blocks from the UI by storing them in `rules`
- Add regression test ensuring wildcard and negated hosts are handled correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca72c164c8328ba8e1870c90972c8