### PR TITLE
Handle Match blocks in SSH config parsing and saving

### DIFF
--- a/tests/test_match_block_preservation.py
+++ b/tests/test_match_block_preservation.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+import asyncio
+
+# Stub external dependencies required by connection_manager
+sys.modules['secretstorage'] = types.ModuleType('secretstorage')
+
+# Minimal gi stub
+gi_repo = types.ModuleType('gi.repository')
+gi_repo.GObject = types.SimpleNamespace(
+    SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
+    Object=type('GObject', (object,), {})
+)
+gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
+gi_repo.Gtk = types.SimpleNamespace()
+
+gi_mod = types.ModuleType('gi')
+gi_mod.repository = gi_repo
+gi_mod.require_version = lambda *args, **kwargs: None
+sys.modules['gi'] = gi_mod
+sys.modules['gi.repository'] = gi_repo
+
+# Ensure the project package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sshpilot.connection_manager import ConnectionManager
+
+
+def test_match_block_preserved_on_update(tmp_path):
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+    cfg_path = tmp_path / 'config'
+    cfg_path.write_text(
+        '\n'.join([
+            'Match host example.com user root',
+            '    IdentityFile /match/id_rsa',
+            '',
+            'Host existing',
+            '    HostName old.example.com',
+            '    User user1',
+        ])
+    )
+
+    cm = ConnectionManager.__new__(ConnectionManager)
+    cm.connections = []
+    cm.ssh_config_path = str(cfg_path)
+
+    cm.load_ssh_config()
+
+    # Match block captured as rule
+    assert len(cm.rules) == 1
+    expected_block = 'Match host example.com user root\n    IdentityFile /match/id_rsa'
+    assert cm.rules[0]['raw'] == expected_block
+
+    # Update existing host (rewrite same data)
+    conn = cm.connections[0]
+    cm.update_ssh_config_file(conn, conn.data)
+
+    # Config should still contain the Match block exactly
+    assert expected_block in cfg_path.read_text()


### PR DESCRIPTION
## Summary
- Treat `Match` directives as block starters and capture their lines verbatim when loading SSH config.
- Ensure updates and removals stop at next `Host` or `Match` directive to preserve rule blocks.
- Add regression test confirming `Match` blocks remain unchanged after updating a host.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bca8d169088328be068e2692aa6fb2