### PR TITLE
Handle SSH config Include directives

### DIFF
--- a/sshpilot/ssh_config_utils.py
+++ b/sshpilot/ssh_config_utils.py
@@ -1,0 +1,43 @@
+import os
+import glob
+import shlex
+from typing import List, Set
+
+
+def resolve_ssh_config_files(main_path: str) -> List[str]:
+    """Return a list of SSH config files including those referenced by Include.
+
+    Paths are expanded and resolved relative to their parent file. Duplicate files
+    are ignored. The main file is always first in the returned list.
+    """
+    resolved: List[str] = []
+    visited: Set[str] = set()
+
+    def _resolve(path: str):
+        abs_path = os.path.abspath(os.path.expanduser(path))
+        if abs_path in visited:
+            return
+        visited.add(abs_path)
+        try:
+            with open(abs_path, 'r') as f:
+                lines = f.readlines()
+        except OSError:
+            return
+        resolved.append(abs_path)
+        base_dir = os.path.dirname(abs_path)
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line or line.startswith('#'):
+                continue
+            lowered = line.lower()
+            if lowered.startswith('include '):
+                patterns = shlex.split(line[len('include '):])
+                for pattern in patterns:
+                    pattern = os.path.expanduser(pattern)
+                    if not os.path.isabs(pattern):
+                        pattern = os.path.join(base_dir, pattern)
+                    for matched in sorted(glob.glob(pattern)):
+                        _resolve(matched)
+
+    _resolve(main_path)
+    return resolved

--- a/tests/test_include_resolution.py
+++ b/tests/test_include_resolution.py
@@ -1,0 +1,44 @@
+import asyncio
+from sshpilot.connection_manager import ConnectionManager
+
+# Ensure an event loop for Connection objects
+asyncio.set_event_loop(asyncio.new_event_loop())
+
+def test_include_directives_parsed(tmp_path):
+    main_cfg = tmp_path / "config"
+    inc_dir = tmp_path / "conf.d"
+    inc_dir.mkdir()
+    a_cfg = inc_dir / "a.conf"
+    b_cfg = inc_dir / "b.conf"
+    a_cfg.write_text("\n".join([
+        "Host hosta",
+        "    HostName hosta.example.com",
+    ]))
+    b_cfg.write_text("\n".join([
+        "Host hostb",
+        "    HostName hostb.example.com",
+    ]))
+    main_cfg.write_text("\n".join([
+        "Host main",
+        "    HostName main.example.com",
+        "Include conf.d/*.conf",
+    ]))
+
+    cm = ConnectionManager.__new__(ConnectionManager)
+    cm.connections = []
+    cm.ssh_config_path = str(main_cfg)
+    cm.load_ssh_config()
+
+    names = {c.nickname for c in cm.connections}
+    assert names == {"main", "hosta", "hostb"}
+    sources = {c.nickname: c.source for c in cm.connections}
+    assert sources["main"] == str(main_cfg)
+    assert sources["hosta"] == str(a_cfg)
+    assert sources["hostb"] == str(b_cfg)
+
+    hosta = next(c for c in cm.connections if c.nickname == "hosta")
+    new_data = dict(hosta.data)
+    new_data["port"] = 2222
+    cm.update_ssh_config_file(hosta, new_data)
+    assert "Port 2222" in a_cfg.read_text()
+    assert "Port 2222" not in main_cfg.read_text()


### PR DESCRIPTION
## Summary
- Resolve `Include` glob patterns in SSH configs and parse included files
- Track each connection's source file and update/remove entries in the correct config
- Add regression test covering `Include` handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca9d9c05c8328afeaf97a8f01e7bd