### PR TITLE
Scan .ssh subdirectories for keys

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -1662,7 +1662,11 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             paths = []
             for k in keys:
                 try:
-                    names.append(os.path.basename(k.private_path))
+                    rel = os.path.relpath(
+                        k.private_path,
+                        str(parent.key_manager.ssh_dir) if parent else None,
+                    )
+                    names.append(rel)
                     paths.append(k.private_path)
                 except Exception:
                     pass

--- a/sshpilot/key_manager.py
+++ b/sshpilot/key_manager.py
@@ -51,7 +51,8 @@ class KeyManager(GObject.Object):
         try:
             if not self.ssh_dir.exists():
                 return keys
-            for file_path in self.ssh_dir.iterdir():
+            # Recursively walk ~/.ssh for private keys that have a matching .pub
+            for file_path in self.ssh_dir.rglob("*"):
                 if not file_path.is_file():
                     continue
                 name = file_path.name

--- a/tests/test_key_discovery.py
+++ b/tests/test_key_discovery.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _write_dummy_key(path):
+    path.write_text("dummy")
+    path.with_suffix(path.suffix + ".pub").write_text("dummy")
+
+
+def test_discover_keys_recurses(tmp_path):
+    # Skip if gi (PyGObject) is unavailable in system python
+    gi_check = subprocess.run([
+        "/usr/bin/python3", "-c", "import gi"
+    ])
+    if gi_check.returncode != 0:
+        pytest.skip("gi not available")
+
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+
+    root_key = ssh_dir / "id_root"
+    _write_dummy_key(root_key)
+
+    nested_dir = ssh_dir / "nested"
+    nested_dir.mkdir()
+    nested_key = nested_dir / "id_nested"
+    _write_dummy_key(nested_key)
+
+    script = textwrap.dedent(
+        """
+        import sys
+        from pathlib import Path
+        from sshpilot.key_manager import KeyManager
+        km = KeyManager(Path(sys.argv[1]))
+        for k in km.discover_keys():
+            print(k.private_path)
+        """
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.getcwd()
+    proc = subprocess.run(
+        ["/usr/bin/python3", "-c", script, str(ssh_dir)],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    paths = set(proc.stdout.strip().splitlines())
+    assert str(root_key) in paths
+    assert str(nested_key) in paths


### PR DESCRIPTION
## Summary
- Discover SSH keys recursively under `~/.ssh`
- Display key paths relative to `~/.ssh` in connection dialog
- Add regression test for recursive key discovery

## Testing
- `PYTHONPATH=. /usr/bin/python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd548867988328a874668174a1cc54