### PR TITLE
Parse PreferredAuthentications order for auth method

### DIFF
--- a/tests/test_preferred_authentications_parsing.py
+++ b/tests/test_preferred_authentications_parsing.py
@@ -1,0 +1,18 @@
+from sshpilot.connection_manager import ConnectionManager
+
+
+def test_preferred_authentications_parses_order_and_auth_method():
+    cm = ConnectionManager.__new__(ConnectionManager)
+    config = {
+        'host': 'example',
+        'preferredauthentications': 'gssapi-with-mic,hostbased,publickey,keyboard-interactive,password',
+    }
+    parsed = ConnectionManager.parse_host_config(cm, config)
+    assert parsed['preferred_authentications'] == [
+        'gssapi-with-mic',
+        'hostbased',
+        'publickey',
+        'keyboard-interactive',
+        'password',
+    ]
+    assert parsed['auth_method'] == 0


### PR DESCRIPTION
## Summary
- Parse `PreferredAuthentications` into an ordered list when reading SSH config
- Respect pubkey vs password order to select auth method
- Test `PreferredAuthentications` parsing and auth-method selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb34600c08328a1a0e81ab64fd1ac