### PR TITLE
Hold app during quit confirmation

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -3423,15 +3423,19 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         dialog.set_close_response('cancel')
         
         dialog.connect('response', self.on_quit_confirmation_response)
+        app = self.get_application()
+        if app is not None:
+            app.hold()
         dialog.present(self)
     
     def on_quit_confirmation_response(self, dialog, response):
         """Handle quit confirmation dialog response"""
-        dialog.close()
-        
         if response == 'quit':
             # Start cleanup process
             shutdown.cleanup_and_quit(self)
+        app = self.get_application()
+        if app is not None:
+            app.release()
 
 
     def on_open_new_connection_action(self, action, param=None):

--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -1,0 +1,88 @@
+import sys
+import types
+import importlib
+
+
+def test_application_quit_with_confirmation_dialog_does_not_crash():
+    # Stub heavy application modules before importing window
+    stub_modules = {
+        'sshpilot.terminal': types.SimpleNamespace(TerminalWidget=object),
+        'sshpilot.terminal_manager': types.SimpleNamespace(TerminalManager=lambda window: None),
+        'sshpilot.connection_manager': types.SimpleNamespace(ConnectionManager=lambda: None, Connection=object),
+        'sshpilot.config': types.SimpleNamespace(Config=lambda: types.SimpleNamespace(get_setting=lambda *a, **k: False)),
+        'sshpilot.key_manager': types.SimpleNamespace(KeyManager=lambda: None, SSHKey=object),
+        'sshpilot.connection_dialog': types.SimpleNamespace(ConnectionDialog=object),
+        'sshpilot.askpass_utils': types.SimpleNamespace(ensure_askpass_script=lambda: None),
+        'sshpilot.preferences': types.SimpleNamespace(PreferencesWindow=object, is_running_in_flatpak=lambda: False,
+                                                      should_hide_external_terminal_options=lambda: False),
+        'sshpilot.sshcopyid_window': types.SimpleNamespace(SshCopyIdWindow=object),
+        'sshpilot.groups': types.SimpleNamespace(GroupManager=lambda config: None),
+        'sshpilot.sidebar': types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
+        'sshpilot.sftp_utils': types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+        'sshpilot.welcome_page': types.SimpleNamespace(WelcomePage=object),
+        'sshpilot.actions': types.SimpleNamespace(WindowActions=object, register_window_actions=lambda window: None),
+        'sshpilot.shutdown': types.SimpleNamespace(cleanup_and_quit=lambda w: None),
+        'sshpilot.search_utils': types.SimpleNamespace(connection_matches=lambda *a, **k: False),
+    }
+    old_modules = {}
+    for name, mod in stub_modules.items():
+        old_modules[name] = sys.modules.get(name)
+        sys.modules[name] = mod
+
+    # Ensure real GTK bindings are loaded
+    for name in list(sys.modules):
+        if name == 'gi' or name.startswith('gi.'):
+            sys.modules.pop(name, None)
+    gi = importlib.import_module('gi')
+    gi.require_version('Gtk', '4.0')
+    gi.require_version('Adw', '1')
+    from gi.repository import Gtk, Adw, GLib
+
+    import sshpilot.window as window
+
+    class DummyWindow(Gtk.ApplicationWindow):
+        show_quit_confirmation_dialog = window.MainWindow.show_quit_confirmation_dialog
+        on_quit_confirmation_response = window.MainWindow.on_quit_confirmation_response
+
+    app = Gtk.Application()
+    holder = {}
+    original_alert = Adw.AlertDialog
+
+    class CaptureDialog(original_alert):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            holder['dialog'] = self
+
+    Adw.AlertDialog = CaptureDialog
+
+    result = {'done': False}
+
+    def on_activate(app):
+        win = DummyWindow(application=app)
+        class Conn: nickname = 'conn'
+        class Term: is_connected = True
+        win.connection_to_terminals = {Conn(): [Term()]}
+        win.present()
+        win.show_quit_confirmation_dialog()
+
+        def respond():
+            dialog = holder.get('dialog')
+            if dialog is None:
+                return True  # try again shortly
+            win.on_quit_confirmation_response(dialog, 'cancel')
+            result['done'] = True
+            return False
+        GLib.timeout_add(50, respond)
+        GLib.timeout_add(10, lambda: (app.quit(), False))
+
+    app.connect('activate', on_activate)
+    app.run(None)
+
+    Adw.AlertDialog = original_alert
+    for name, old in old_modules.items():
+        if old is None:
+            del sys.modules[name]
+        else:
+            sys.modules[name] = old
+
+    assert result['done']


### PR DESCRIPTION
## Summary
- keep application alive while the quit confirmation dialog is shown
- release application hold after the dialog closes
- add regression test for quitting with a window open

## Testing
- `xvfb-run -a /usr/bin/python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdcdaaf2e883289fbed00e04c623b7