### PR TITLE
Ensure quit dialog closes only once before releasing hold

### DIFF
--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -45,6 +45,7 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
     class DummyWindow(Gtk.ApplicationWindow):
         show_quit_confirmation_dialog = window.MainWindow.show_quit_confirmation_dialog
         on_quit_confirmation_response = window.MainWindow.on_quit_confirmation_response
+        on_quit_confirmation_closed = window.MainWindow.on_quit_confirmation_closed
 
     class DummyApp(Gtk.Application):
         def quit(self):
@@ -55,7 +56,7 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
             super().quit()
 
     app = DummyApp()
-    holder = {'released': False, 'visible': False}
+    holder = {'released': 0, 'closed': 0, 'closed_before_release': 0, 'visible': False}
 
     original_alert = Adw.AlertDialog
 
@@ -63,6 +64,7 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             holder['dialog'] = self
+            self.connect('closed', lambda *_: holder.__setitem__('closed', holder['closed'] + 1))
 
 
     Adw.AlertDialog = CaptureDialog
@@ -70,7 +72,8 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
     original_release = app.release
 
     def capture_release():
-        holder['released'] = True
+        holder['released'] += 1
+        holder['closed_before_release'] = holder['closed']
         return original_release()
 
     app.release = capture_release
@@ -115,6 +118,8 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
             sys.modules[name] = old
 
     assert result['done']
-    assert holder['released']
+    assert holder['released'] == 1
+    assert holder['closed'] == 1
+    assert holder['closed_before_release'] == 1
     assert holder['visible']
 


### PR DESCRIPTION
## Summary
- track active quit confirmation dialog to avoid multiple instances
- release application hold only after the dialog has been removed
- test quit flow verifies dialog closed once before release

## Testing
- `pytest -q`
- `strace -e signal bash ./sshpilot-launcher.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bf2d1c53108328b4d8f517549109f2