### PR TITLE
Use Primary shortcuts for macOS compatibility

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -738,6 +738,6 @@ def register_window_actions(window):
         window.add_action(sidebar_action)
         app = window.get_application()
         if app:
-            app.set_accels_for_action('win.toggle_sidebar', ['F9', '<Control>b'])
+            app.set_accels_for_action('win.toggle_sidebar', ['F9', '<Primary>b'])
     except Exception as e:
         logger.error(f"Failed to register sidebar toggle action: {e}")

--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -857,9 +857,9 @@ class ConnectionDialog(Adw.Window):
         
         shortcut_controller = Gtk.ShortcutController()
         
-        # Ctrl+S to save
+        # Ctrl/Command+S to save
         save_shortcut = Gtk.Shortcut()
-        save_shortcut.set_trigger(Gtk.ShortcutTrigger.parse_string("<Control>s"))
+        save_shortcut.set_trigger(Gtk.ShortcutTrigger.parse_string("<Primary>s"))
         save_shortcut.set_action(Gtk.CallbackAction.new(
             lambda widget, args: self.on_save_clicked(None)
         ))

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -407,7 +407,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         sidebar_visible = True
         
         self.sidebar_toggle_button.set_icon_name('sidebar-show-symbolic')
-        self.sidebar_toggle_button.set_tooltip_text('Hide Sidebar (F9, Ctrl+B)')
+        self.sidebar_toggle_button.set_tooltip_text('Hide Sidebar (F9, Ctrl/Command+B)')
         self.sidebar_toggle_button.set_active(sidebar_visible)
         self.sidebar_toggle_button.connect('toggled', self.on_sidebar_toggle)
         self.header_bar.pack_start(self.sidebar_toggle_button)
@@ -755,7 +755,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         except Exception:
             pass
         
-        # Add keyboard controller for Ctrl+Enter to open new connection
+        # Add keyboard controller for Ctrl/Command+Enter to open new connection
         try:
             key_controller = Gtk.ShortcutController()
             key_controller.set_scope(Gtk.ShortcutScope.LOCAL)
@@ -767,17 +767,17 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         connection = selected_row.connection
                         self.terminal_manager.connect_to_host(connection, force_new=True)
                 except Exception as e:
-                    logger.error(f"Failed to open new connection with Ctrl+Enter: {e}")
+                    logger.error(f"Failed to open new connection with Ctrl/Command+Enter: {e}")
                 return True
             
             key_controller.add_shortcut(Gtk.Shortcut.new(
-                Gtk.ShortcutTrigger.parse_string('<Control>Return'),
+                Gtk.ShortcutTrigger.parse_string('<Primary>Return'),
                 Gtk.CallbackAction.new(_on_ctrl_enter)
             ))
             
             self.connection_list.add_controller(key_controller)
         except Exception as e:
-            logger.debug(f"Failed to add Ctrl+Enter shortcut: {e}")
+            logger.debug(f"Failed to add Ctrl/Command+Enter shortcut: {e}")
         
         scrolled.set_child(self.connection_list)
         sidebar_box.append(scrolled)
@@ -1218,7 +1218,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 
                 # Show toast notification
                 toast = Adw.Toast.new(
-                    "Switched to connection list — ↑/↓ navigate, Enter open, Ctrl+Enter new tab"
+                    "Switched to connection list — ↑/↓ navigate, Enter open, Ctrl/Command+Enter new tab"
                 )
                 toast.set_timeout(3)  # seconds
                 if hasattr(self, 'toast_overlay'):
@@ -1900,10 +1900,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             # Update button icon and tooltip
             if is_visible:
                 button.set_icon_name('sidebar-show-symbolic')
-                button.set_tooltip_text('Hide Sidebar (F9, Ctrl+B)')
+                button.set_tooltip_text('Hide Sidebar (F9, Ctrl/Command+B)')
             else:
                 button.set_icon_name('sidebar-show-symbolic')
-                button.set_tooltip_text('Show Sidebar (F9, Ctrl+B)')
+                button.set_tooltip_text('Show Sidebar (F9, Ctrl/Command+B)')
             
             # No need to save state - sidebar always starts visible
                 


### PR DESCRIPTION
## Summary
- Swap control-modifier shortcuts to Primary so Command works on macOS
- Replace Ctrl+Return shortcut with Primary+Return for new connections
- Map sidebar toggle accelerator to Primary+B and update tooltips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04e459d788328aba8e95e3af2964b