### PR TITLE
Use platform-aware modifier label for shortcuts

### DIFF
--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -87,7 +87,7 @@ class SshPilotApplication(Adw.Application):
         # Tab navigation accelerators
         self.create_action('tab-next', self.on_tab_next, ['<alt>Right'])
         self.create_action('tab-prev', self.on_tab_prev, ['<alt>Left'])
-        # Close tab accelerator (use Ctrl+F4 to avoid conflicts with TUI editors like nano/vim)
+        # Close tab accelerator (use Ctrl or ⌘+F4 to avoid conflicts with TUI editors like nano/vim)
         self.create_action('tab-close', self.on_tab_close, ['<primary>F4'])
         # Broadcast command to all SSH terminals
         self.create_action('broadcast-command', self.on_broadcast_command, ['<primary><shift>b'])
@@ -96,7 +96,7 @@ class SshPilotApplication(Adw.Application):
         self.connect('shutdown', self.on_shutdown)
         self.connect('activate', self.on_activate)
 
-        # Ensure Ctrl+C (SIGINT) follows the SAME path as clicking the window close button
+        # Ensure Ctrl (⌘ on macOS)+C (SIGINT) follows the SAME path as clicking the window close button
         try:
             import signal
 
@@ -217,7 +217,7 @@ class SshPilotApplication(Adw.Application):
         super().quit()
 
     def on_quit_action(self, action=None, param=None):
-        """Handle Ctrl+Q by routing through the application quit path."""
+        """Handle Ctrl (⌘ on macOS)+Q by routing through the application quit path."""
         self.quit()
 
     def do_activate(self):
@@ -234,7 +234,7 @@ class SshPilotApplication(Adw.Application):
             self.props.active_window.show_connection_dialog()
 
     def on_open_new_connection_tab(self, action, param):
-        """Handle open new connection tab action (Ctrl+Alt+N)"""
+        """Handle open new connection tab action (Ctrl/⌘+Alt+N)"""
         logging.debug("Open new connection tab action triggered")
         if self.props.active_window:
             # Forward to the window's action
@@ -308,7 +308,7 @@ class SshPilotApplication(Adw.Application):
             pass
 
     def on_broadcast_command(self, action, param):
-        """Handle broadcast command action (Ctrl+Shift+B)"""
+        """Handle broadcast command action (Ctrl/⌘+Shift+B)"""
         logging.debug("Broadcast command action triggered")
         if self.props.active_window:
             # Forward to the window's action

--- a/sshpilot/shortcut_utils.py
+++ b/sshpilot/shortcut_utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+
+
+def get_primary_modifier_label() -> str:
+    """Return the label for the primary modifier key.
+
+    Uses "⌘" on macOS and "Ctrl" on other platforms.
+    """
+    return "\u2318" if sys.platform == "darwin" else "Ctrl"
+
+
+__all__ = ["get_primary_modifier_label"]

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -6,6 +6,8 @@ gi.require_version('Gtk', '4.0')
 
 from gi.repository import Gtk, Gdk
 
+from .shortcut_utils import get_primary_modifier_label
+
 
 class WelcomePage(Gtk.Box):
     """Welcome page shown when no tabs are open."""
@@ -45,17 +47,18 @@ class WelcomePage(Gtk.Box):
         shortcuts_title.set_markup('<b>Keyboard Shortcuts</b>')
         shortcuts_box.append(shortcuts_title)
 
+        primary = get_primary_modifier_label()
         shortcuts = [
-            ('Ctrl+N', 'New Connection'),
-            ('Ctrl+Alt+N', 'Open  Selected Host in a New Tab'),
+            (f'{primary}+N', 'New Connection'),
+            (f'{primary}+Alt+N', 'Open  Selected Host in a New Tab'),
             ('F9', 'Toggle Sidebar'),
-            ('Ctrl+L', 'Focus connection list to select server'),
-            ('Ctrl+Shift+K', 'Copy SSH Key to Server'),
+            (f'{primary}+L', 'Focus connection list to select server'),
+            (f'{primary}+Shift+K', 'Copy SSH Key to Server'),
             ('Alt+Right', 'Next Tab'),
             ('Alt+Left', 'Previous Tab'),
-            ('Ctrl+F4', 'Close Tab'),
-            ('Ctrl+Shift+T', 'New Local Terminal'),
-            ('Ctrl+,', 'Preferences'),
+            (f'{primary}+F4', 'Close Tab'),
+            (f'{primary}+Shift+T', 'New Local Terminal'),
+            (f'{primary}+,', 'Preferences'),
         ]
 
         for shortcut, description in shortcuts:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -46,6 +46,7 @@ from .welcome_page import WelcomePage
 from .actions import WindowActions, register_window_actions
 from . import shutdown
 from .search_utils import connection_matches
+from .shortcut_utils import get_primary_modifier_label
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +310,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         # Track if this is the initial startup focus
         self._is_initial_focus = True
         
-        # When list gains keyboard focus (e.g., after Ctrl+L)
+        # When list gains keyboard focus (e.g., after Ctrl/⌘+L)
         focus_ctl = Gtk.EventControllerFocus()
         def on_focus_enter(*args):
             # Don't pulse on initial startup focus
@@ -407,7 +408,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         sidebar_visible = True
         
         self.sidebar_toggle_button.set_icon_name('sidebar-show-symbolic')
-        self.sidebar_toggle_button.set_tooltip_text('Hide Sidebar (F9, Ctrl/Command+B)')
+        self.sidebar_toggle_button.set_tooltip_text(
+            f'Hide Sidebar (F9, {get_primary_modifier_label()}+B)'
+        )
         self.sidebar_toggle_button.set_active(sidebar_visible)
         self.sidebar_toggle_button.connect('toggled', self.on_sidebar_toggle)
         self.header_bar.pack_start(self.sidebar_toggle_button)
@@ -514,7 +517,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         
         # Add connection button
         add_button = Gtk.Button.new_from_icon_name('list-add-symbolic')
-        add_button.set_tooltip_text('Add Connection (Ctrl+N)')
+        add_button.set_tooltip_text(
+            f'Add Connection ({get_primary_modifier_label()}+N)'
+        )
         add_button.connect('clicked', self.on_add_connection_clicked)
         try:
             add_button.set_can_focus(False)
@@ -755,7 +760,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         except Exception:
             pass
         
-        # Add keyboard controller for Ctrl/Command+Enter to open new connection
+        # Add keyboard controller for Ctrl/⌘+Enter to open new connection
         try:
             key_controller = Gtk.ShortcutController()
             key_controller.set_scope(Gtk.ShortcutScope.LOCAL)
@@ -767,7 +772,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         connection = selected_row.connection
                         self.terminal_manager.connect_to_host(connection, force_new=True)
                 except Exception as e:
-                    logger.error(f"Failed to open new connection with Ctrl/Command+Enter: {e}")
+                    logger.error(
+                        f"Failed to open new connection with {get_primary_modifier_label()}+Enter: {e}"
+                    )
                 return True
             
             key_controller.add_shortcut(Gtk.Shortcut.new(
@@ -777,7 +784,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             
             self.connection_list.add_controller(key_controller)
         except Exception as e:
-            logger.debug(f"Failed to add Ctrl/Command+Enter shortcut: {e}")
+            logger.debug(
+                f"Failed to add {get_primary_modifier_label()}+Enter shortcut: {e}"
+            )
         
         scrolled.set_child(self.connection_list)
         sidebar_box.append(scrolled)
@@ -1218,7 +1227,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 
                 # Show toast notification
                 toast = Adw.Toast.new(
-                    "Switched to connection list — ↑/↓ navigate, Enter open, Ctrl/Command+Enter new tab"
+                    f"Switched to connection list — ↑/↓ navigate, Enter open, {get_primary_modifier_label()}+Enter new tab"
                 )
                 toast.set_timeout(3)  # seconds
                 if hasattr(self, 'toast_overlay'):
@@ -1269,7 +1278,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         
                         # Show toast notification
                         toast = Adw.Toast.new(
-                            "Search hidden — Ctrl+F to search again"
+                            f"Search hidden — {get_primary_modifier_label()}+F to search again"
                         )
                         toast.set_timeout(2)  # seconds
                         if hasattr(self, 'toast_overlay'):
@@ -1900,10 +1909,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             # Update button icon and tooltip
             if is_visible:
                 button.set_icon_name('sidebar-show-symbolic')
-                button.set_tooltip_text('Hide Sidebar (F9, Ctrl/Command+B)')
+                button.set_tooltip_text(
+                    f'Hide Sidebar (F9, {get_primary_modifier_label()}+B)'
+                )
             else:
                 button.set_icon_name('sidebar-show-symbolic')
-                button.set_tooltip_text('Show Sidebar (F9, Ctrl/Command+B)')
+                button.set_tooltip_text(
+                    f'Show Sidebar (F9, {get_primary_modifier_label()}+B)'
+                )
             
             # No need to save state - sidebar always starts visible
                 
@@ -3458,7 +3471,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             logger.error(f"Failed to open new connection tab: {e}")
 
     def on_open_new_connection_tab_action(self, action, param=None):
-        """Open a new tab for the selected connection via global shortcut (Ctrl+Alt+N)."""
+        """Open a new tab for the selected connection via global shortcut (Ctrl/⌘+Alt+N)."""
         try:
             # Get the currently selected connection
             row = self.connection_list.get_selected_row()
@@ -3467,10 +3480,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 self.terminal_manager.connect_to_host(connection, force_new=True)
             else:
                 # If no connection is selected, show a message or fall back to new connection dialog
-                logger.debug("No connection selected for Ctrl+Alt+N, opening new connection dialog")
+                logger.debug(
+                    f"No connection selected for {get_primary_modifier_label()}+Alt+N, opening new connection dialog"
+                )
                 self.show_connection_dialog()
         except Exception as e:
-            logger.error(f"Failed to open new connection tab with Ctrl+Alt+N: {e}")
+            logger.error(
+                f"Failed to open new connection tab with {get_primary_modifier_label()}+Alt+N: {e}"
+            )
 
     def on_manage_files_action(self, action, param=None):
         """Handle manage files action from context menu"""


### PR DESCRIPTION
## Summary
- add helper for selecting primary modifier label
- use helper to show Cmd on macOS in tooltips, welcome shortcuts and toasts
- clarify comments to mention macOS equivalents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c063f0be4083289a085cefa271283a