### PR TITLE
Include shortcut in copy key button tooltip

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -824,7 +824,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
         # Copy key to server button (ssh-copy-id)
         self.copy_key_button = Gtk.Button.new_from_icon_name('dialog-password-symbolic')
-        self.copy_key_button.set_tooltip_text('Copy public key to server for passwordless login')
+        self.copy_key_button.set_tooltip_text(
+            f'Copy public key to server for passwordless login ({get_primary_modifier_label()}+Shift+K)'
+        )
         self.copy_key_button.set_sensitive(False)
         self.copy_key_button.connect('clicked', self.on_copy_key_to_server_clicked)
         self.connection_toolbar.append(self.copy_key_button)


### PR DESCRIPTION
## Summary
- show platform-aware shortcut in "Copy public key" tooltip

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06944d33c8328a6b7836b1ffa520f