### PR TITLE
Ensure main window stays visible after closing connection dialog

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1319,6 +1319,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
         # Create connection dialog
         dialog = ConnectionDialog(self, connection, self.connection_manager)
+        dialog.connect("close-request", lambda *a: (self.present(), False))
         dialog.connect('connection-saved', self.on_connection_saved)
         dialog.present()
 


### PR DESCRIPTION
## Summary
- Re-present the main window when the connection dialog closes by handling the `close-request` signal.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c073fda3d483289c3488faf3cd205f