### PR TITLE
Handle alias-only SSH hosts

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1310,13 +1310,15 @@ class ConnectionManager(GObject.Object):
                 return f'"{token}"'
             return token
 
+        host = data.get('host', '')
         nickname = data.get('nickname', '')
         aliases = data.get('aliases', []) or []
         host_tokens = [_quote_token(nickname)] + [_quote_token(a) for a in aliases]
         lines = ["Host " + " ".join(host_tokens)]
-        
+
         # Add basic connection info
-        lines.append(f"    HostName {data.get('host', '')}")
+        if host and host != nickname:
+            lines.append(f"    HostName {host}")
         lines.append(f"    User {data.get('username', '')}")
         
         # Add port if specified and not default


### PR DESCRIPTION
## Summary
- Avoid writing `HostName` when host is empty or matches the nickname
- Cover alias-only host entries to prevent adding unnecessary `HostName`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c07ea934b48328ae480c9c1af7d4e4