### PR TITLE
Include aliases in SSH config preview

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -485,6 +485,7 @@ class SSHConfigAdvancedTab(Gtk.Box):
                         
                         config_data = {
                             'nickname': getattr(connection, 'nickname', 'your-host-name'),
+                            'aliases': getattr(connection, 'aliases', []),
                             'host': getattr(connection, 'host', ''),
                             'username': getattr(connection, 'username', ''),
                             'port': getattr(connection, 'port', 22),


### PR DESCRIPTION
## Summary
- Pass connection aliases to config preview so generated SSH config shows all host aliases
- Confirm ConnectionManager combines nickname and aliases on Host line

## Testing
- `pytest -q`
- Manual verification of host line formatting with aliases

------
https://chatgpt.com/codex/tasks/task_e_68c0816f8c7c8328b542cb2b1087f659