### PR TITLE
Add isolated SSH configuration support

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -132,6 +132,7 @@ class Config(GObject.Object):
                 'auto_add_host_keys': True,
                 'verbosity': 0,
                 'debug_enabled': False,
+                'use_isolated_config': False,
             },
             'security': {
                 'store_passwords': True,

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -546,6 +546,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
             advanced_group = Adw.PreferencesGroup()
             advanced_group.set_title("SSH Settings")
+
+            self.isolated_config_row = Adw.SwitchRow()
+            self.isolated_config_row.set_title("Use isolated SSH configuration")
+            self.isolated_config_row.set_active(bool(self.config.get_setting('ssh.use_isolated_config', False)))
+            self.isolated_config_row.connect('notify::active', self.on_isolated_mode_changed)
+            advanced_group.add(self.isolated_config_row)
             # Use custom options toggle
             self.apply_advanced_row = Adw.SwitchRow()
             self.apply_advanced_row.set_title("Use custom connection options")
@@ -804,7 +810,18 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 self.debug_enabled_row.set_active(bool(defaults.get('debug_enabled', False)))
         except Exception as e:
             logger.error(f"Failed to reset advanced SSH settings: {e}")
-    
+
+    def on_isolated_mode_changed(self, row, _param):
+        """Handle toggling of isolated SSH configuration"""
+        try:
+            active = bool(row.get_active())
+            self.config.set_setting('ssh.use_isolated_config', active)
+            parent_window = self.get_transient_for()
+            if parent_window and hasattr(parent_window, 'connection_manager'):
+                parent_window.connection_manager.set_isolated_mode(active)
+        except Exception as e:
+            logger.error(f"Failed to toggle isolated SSH mode: {e}")
+
     def get_theme_name_mapping(self):
         """Get mapping between display names and config keys"""
         return {

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -52,17 +52,18 @@ logger = logging.getLogger(__name__)
 
 class MainWindow(Adw.ApplicationWindow, WindowActions):
     """Main application window"""
-    
-    def __init__(self, *args, **kwargs):
+
+    def __init__(self, *args, isolated: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.active_terminals = {}
         self.connections = []
         self._is_quitting = False  # Flag to prevent multiple quit attempts
         self._is_controlled_reconnect = False  # Flag to track controlled reconnection
-        
+
         # Initialize managers
-        self.connection_manager = ConnectionManager()
         self.config = Config()
+        effective_isolated = isolated or bool(self.config.get_setting('ssh.use_isolated_config', False))
+        self.connection_manager = ConnectionManager(self.config, isolated_mode=effective_isolated)
         self.key_manager = KeyManager()
         self.group_manager = GroupManager(self.config)
         


### PR DESCRIPTION
## Summary
- add `ssh.use_isolated_config` default and wire configuration manager paths
- allow launching with `--isolated` or toggling in preferences
- create isolated ssh config/known_hosts files and reload when switching

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c09dc7c8f08328a97525be707109d9