### PR TITLE
Use Adw radio buttons for operation mode selection

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -553,28 +553,33 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.default_mode_row = Adw.ActionRow()
             self.default_mode_row.set_title("Default Mode")
             self.default_mode_row.set_subtitle("sshPilot loads and modifies ~/.ssh/config")
-            self.default_mode_toggle = Gtk.CheckButton()
-
-            self.default_mode_row.add_suffix(self.default_mode_toggle)
-            self.default_mode_row.set_activatable_widget(self.default_mode_toggle)
-            operation_group.add(self.default_mode_row)
+            self.default_mode_radio = Gtk.CheckButton()
 
             # Isolated mode row
             self.isolated_mode_row = Adw.ActionRow()
             self.isolated_mode_row.set_title("Isolated Mode")
             self.isolated_mode_row.set_subtitle("sshPilot stores its own configuration file in ~/.config/sshpilot/")
-            self.isolated_mode_toggle = Gtk.CheckButton()
+            self.isolated_mode_radio = Gtk.CheckButton()
 
-            self.isolated_mode_row.add_suffix(self.isolated_mode_toggle)
-            self.isolated_mode_row.set_activatable_widget(self.isolated_mode_toggle)
+            # Group the radios for exclusive selection
+            self.isolated_mode_radio.set_group(self.default_mode_radio)
+
+            self.default_mode_row.add_prefix(self.default_mode_radio)
+            self.default_mode_row.set_activatable_widget(self.default_mode_radio)
+            operation_group.add(self.default_mode_row)
+
+            self.isolated_mode_row.add_prefix(self.isolated_mode_radio)
+            self.isolated_mode_row.set_activatable_widget(self.isolated_mode_radio)
             operation_group.add(self.isolated_mode_row)
 
             use_isolated = bool(self.config.get_setting('ssh.use_isolated_config', False))
-            self.isolated_mode_toggle.set_active(use_isolated)
-            self.default_mode_toggle.set_active(not use_isolated)
+            self.isolated_mode_radio.set_active(use_isolated)
+            self.default_mode_radio.set_active(not use_isolated)
 
-            self.default_mode_toggle.connect('toggled', self.on_operation_mode_toggled)
-            self.isolated_mode_toggle.connect('toggled', self.on_operation_mode_toggled)
+            self.default_mode_radio.connect('toggled', self.on_operation_mode_toggled)
+            self.isolated_mode_radio.connect('toggled', self.on_operation_mode_toggled)
+
+            self._update_operation_mode_styles()
 
             advanced_page.add(operation_group)
 
@@ -847,15 +852,34 @@ class PreferencesWindow(Adw.PreferencesWindow):
             if not button.get_active():
                 return
 
-            use_isolated = button is getattr(self, 'isolated_mode_toggle', None)
+            use_isolated = self.isolated_mode_radio.get_active()
             self.config.set_setting('ssh.use_isolated_config', bool(use_isolated))
+
+            self._update_operation_mode_styles()
 
             parent_window = self.get_transient_for()
             if parent_window and hasattr(parent_window, 'connection_manager'):
                 parent_window.connection_manager.set_isolated_mode(bool(use_isolated))
 
+            # Inform user that restart is required for changes
+            if parent_window and hasattr(parent_window, 'toast_overlay'):
+                toast = Adw.Toast.new(
+                    "Restart sshPilot to apply the new operation mode"
+                )
+                toast.set_timeout(5)
+                parent_window.toast_overlay.add_toast(toast)
+
         except Exception as e:
             logger.error(f"Failed to toggle isolated SSH mode: {e}")
+
+    def _update_operation_mode_styles(self):
+        """Visually de-emphasize the inactive operation mode"""
+        if self.isolated_mode_radio.get_active():
+            self.default_mode_row.add_css_class('dim-label')
+            self.isolated_mode_row.remove_css_class('dim-label')
+        else:
+            self.isolated_mode_row.add_css_class('dim-label')
+            self.default_mode_row.remove_css_class('dim-label')
 
     def get_theme_name_mapping(self):
         """Get mapping between display names and config keys"""


### PR DESCRIPTION
## Summary
- Switch operation mode choices to Adw radio buttons with exclusive grouping
- Dim the inactive row and read radio state in the toggle handler
- Notify users that a restart is required after changing operation mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a6f11c8c83288ab51a78b5ac0303