### PR TITLE
Hide Manage Files option on macOS

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -5,7 +5,11 @@ from gi.repository import Gio, Gtk, Adw, GLib
 from gettext import gettext as _
 
 from .sftp_utils import open_remote_in_file_manager
-from .preferences import is_running_in_flatpak, should_hide_external_terminal_options
+from .preferences import (
+    is_running_in_flatpak,
+    should_hide_external_terminal_options,
+    should_hide_file_manager_options,
+)
 from .shortcut_utils import get_primary_modifier_label
 
 HAS_OVERLAY_SPLIT = hasattr(Adw, 'OverlaySplitView')
@@ -690,10 +694,11 @@ def register_window_actions(window):
     window.open_new_connection_tab_action.connect('activate', window.on_open_new_connection_tab_action)
     window.add_action(window.open_new_connection_tab_action)
 
-    # Action for managing files on remote server
-    window.manage_files_action = Gio.SimpleAction.new('manage-files', None)
-    window.manage_files_action.connect('activate', window.on_manage_files_action)
-    window.add_action(window.manage_files_action)
+    # Action for managing files on remote server (skip on macOS)
+    if not should_hide_file_manager_options():
+        window.manage_files_action = Gio.SimpleAction.new('manage-files', None)
+        window.manage_files_action.connect('activate', window.on_manage_files_action)
+        window.add_action(window.manage_files_action)
 
     # Action for editing connections via context menu
     window.edit_connection_action = Gio.SimpleAction.new('edit-connection', None)

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -19,6 +19,11 @@ def should_hide_external_terminal_options() -> bool:
     """Check if external terminal options should be hidden (Flatpak or macOS)"""
     return is_running_in_flatpak() or os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin'
 
+
+def should_hide_file_manager_options() -> bool:
+    """Check if file manager options should be hidden (macOS)"""
+    return os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin'
+
 class MonospaceFontDialog(Adw.Window):
     def __init__(self, parent=None, current_font="Monospace 12"):
         super().__init__()

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -1,0 +1,105 @@
+import types
+import sys
+import importlib
+
+
+def setup_gi(monkeypatch):
+    gi = types.ModuleType("gi")
+    def require_version(*args, **kwargs):
+        pass
+    gi.require_version = require_version
+    repository = types.ModuleType("repository")
+    gi.repository = repository
+    monkeypatch.setitem(sys.modules, "gi", gi)
+    monkeypatch.setitem(sys.modules, "gi.repository", repository)
+    for name in ["Gtk", "Adw", "Pango", "PangoFT2", "Gio", "GLib", "Gdk"]:
+        module = types.ModuleType(name)
+        setattr(repository, name, module)
+        monkeypatch.setitem(sys.modules, f"gi.repository.{name}", module)
+    repository.Adw.Window = type("Window", (), {})
+    repository.Adw.PreferencesWindow = type("PreferencesWindow", (), {})
+    class SimpleAction:
+        def __init__(self, name=None, parameter_type=None):
+            self.name = name
+        @classmethod
+        def new(cls, name, parameter_type):
+            return cls(name, parameter_type)
+        def connect(self, *args, **kwargs):
+            pass
+    repository.Gio.SimpleAction = SimpleAction
+
+
+def reload_module(name):
+    if name in sys.modules:
+        del sys.modules[name]
+    return importlib.import_module(name)
+
+
+def prepare_actions(monkeypatch):
+    setup_gi(monkeypatch)
+    sftp_stub = types.ModuleType("sshpilot.sftp_utils")
+    def open_remote_in_file_manager(*args, **kwargs):
+        return True, None
+    sftp_stub.open_remote_in_file_manager = open_remote_in_file_manager
+    monkeypatch.setitem(sys.modules, "sshpilot.sftp_utils", sftp_stub)
+    return reload_module("sshpilot.actions")
+
+
+def create_window():
+    class DummyWindow:
+        def add_action(self, action):
+            pass
+        def on_open_new_connection_action(self, *args):
+            pass
+        def on_open_new_connection_tab_action(self, *args):
+            pass
+        def on_manage_files_action(self, *args):
+            pass
+        def on_edit_connection_action(self, *args):
+            pass
+        def on_delete_connection_action(self, *args):
+            pass
+        def on_open_in_system_terminal_action(self, *args):
+            pass
+        def on_broadcast_command_action(self, *args):
+             pass
+        def on_create_group_action(self, *args):
+             pass
+        def on_edit_group_action(self, *args):
+             pass
+        def on_delete_group_action(self, *args):
+             pass
+        def on_move_to_ungrouped_action(self, *args):
+             pass
+        def on_move_to_group_action(self, *args):
+             pass
+        def on_toggle_sidebar_action(self, *args):
+             pass
+    return DummyWindow()
+
+
+def test_manage_files_action_hidden_on_macos(monkeypatch):
+    actions = prepare_actions(monkeypatch)
+    monkeypatch.setattr(actions, "should_hide_file_manager_options", lambda: True)
+    monkeypatch.setattr(actions, "should_hide_external_terminal_options", lambda: True)
+    window = create_window()
+    actions.register_window_actions(window)
+    assert not hasattr(window, "manage_files_action")
+
+
+def test_manage_files_action_visible_on_other_platforms(monkeypatch):
+    actions = prepare_actions(monkeypatch)
+    monkeypatch.setattr(actions, "should_hide_file_manager_options", lambda: False)
+    monkeypatch.setattr(actions, "should_hide_external_terminal_options", lambda: True)
+    window = create_window()
+    actions.register_window_actions(window)
+    assert hasattr(window, "manage_files_action")
+
+
+def test_should_hide_file_manager_options(monkeypatch):
+    setup_gi(monkeypatch)
+    prefs = reload_module("sshpilot.preferences")
+    monkeypatch.setattr(prefs.os, "uname", lambda: types.SimpleNamespace(sysname="Darwin"))
+    assert prefs.should_hide_file_manager_options()
+    monkeypatch.setattr(prefs.os, "uname", lambda: types.SimpleNamespace(sysname="Linux"))
+    assert not prefs.should_hide_file_manager_options()


### PR DESCRIPTION
## Summary
- add should_hide_file_manager_options helper for detecting macOS
- hide Manage Files toolbar and menu on macOS and skip action registration
- test Manage Files visibility across platforms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b6f43828832888b0981396ffc619