### PR TITLE
Centralize macOS platform detection

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -11,6 +11,7 @@ from .preferences import (
     should_hide_file_manager_options,
 )
 from .shortcut_utils import get_primary_modifier_label
+from .platform_utils import is_macos
 
 HAS_OVERLAY_SPLIT = hasattr(Adw, 'OverlaySplitView')
 
@@ -751,9 +752,7 @@ def register_window_actions(window):
         window.add_action(sidebar_action)
         app = window.get_application()
         if app:
-            import platform
-            is_macos = platform.system() == 'Darwin'
-            sidebar_shortcut = '<Meta>b' if is_macos else '<Primary>b'
+            sidebar_shortcut = '<Meta>b' if is_macos() else '<Primary>b'
             app.set_accels_for_action('win.toggle_sidebar', ['F9', sidebar_shortcut])
     except Exception as e:
         logger.error(f"Failed to register sidebar toggle action: {e}")

--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -31,7 +31,7 @@ def ensure_passphrase_askpass() -> str:
     logger.debug(f"Generating askpass script at {path}")
 
     script_body = r'''#!/usr/bin/env python3
-import sys, re, os
+import sys, re, os, platform
 try:
     import secretstorage
 except Exception:
@@ -51,7 +51,7 @@ except Exception:
 def get_passphrase(key_path: str) -> str:
     """Retrieve passphrase from keyring or secretstorage"""
     # Try keyring first (macOS)
-    if keyring and os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin':
+    if keyring and platform.system() == 'Darwin':
         try:
             with open("/tmp/sshpilot-askpass.log", "a") as f:
                 f.write(f"ASKPASS: Trying keyring for {key_path}\n")

--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -15,6 +15,7 @@ from typing import Optional, Dict, Any
 
 from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango, PangoFT2
 from .port_utils import get_port_checker
+from .platform_utils import is_macos
 
 # Initialize gettext
 try:
@@ -934,9 +935,7 @@ class ConnectionDialog(Adw.Window):
         shortcut_controller = Gtk.ShortcutController()
         
         # Ctrl/Command+S to save
-        import platform
-        is_macos = platform.system() == 'Darwin'
-        save_trigger = "<Meta>s" if is_macos else "<Primary>s"
+        save_trigger = "<Meta>s" if is_macos() else "<Primary>s"
         
         save_shortcut = Gtk.Shortcut()
         save_shortcut.set_trigger(Gtk.ShortcutTrigger.parse_string(save_trigger))

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -14,6 +14,7 @@ import signal
 from typing import Dict, List, Optional, Any, Tuple, Union
 
 from .ssh_config_utils import resolve_ssh_config_files, get_effective_ssh_config
+from .platform_utils import is_macos
 
 try:
     import secretstorage
@@ -51,10 +52,6 @@ if os.name == 'posix':
 
 logger = logging.getLogger(__name__)
 _SERVICE_NAME = "sshPilot"
-
-def _is_macos():
-    """Check if running on macOS"""
-    return os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin'
 
 class Connection:
     """Represents an SSH connection"""
@@ -1172,7 +1169,7 @@ class ConnectionManager(GObject.Object):
         """Store key passphrase securely in system keyring"""
         try:
             # Use keyring on macOS, secretstorage on Linux
-            if keyring and _is_macos():
+            if keyring and is_macos():
                 # macOS: use keyring
                 keyring.set_password('sshPilot', key_path, passphrase)
                 logger.debug(f"Stored key passphrase for {key_path} using keyring")
@@ -1208,7 +1205,7 @@ class ConnectionManager(GObject.Object):
         """Retrieve key passphrase from system keyring"""
         try:
             # Use keyring on macOS, secretstorage on Linux
-            if keyring and _is_macos():
+            if keyring and is_macos():
                 # macOS: use keyring
                 passphrase = keyring.get_password('sshPilot', key_path)
                 if passphrase:
@@ -1236,7 +1233,7 @@ class ConnectionManager(GObject.Object):
         """Delete stored key passphrase from system keyring"""
         try:
             # Use keyring on macOS, secretstorage on Linux
-            if keyring and _is_macos():
+            if keyring and is_macos():
                 # macOS: use keyring
                 try:
                     keyring.delete_password('sshPilot', key_path)

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -42,6 +42,7 @@ if not load_resources():
     sys.exit(1)
 
 from .window import MainWindow
+from .platform_utils import is_macos
 
 class SshPilotApplication(Adw.Application):
     """Main application class for sshPilot"""
@@ -76,10 +77,9 @@ class SshPilotApplication(Adw.Application):
         
         # Create actions with keyboard shortcuts
         # Use platform-specific shortcuts for better macOS compatibility
-        import platform
-        is_macos = platform.system() == 'Darwin'
-        
-        if is_macos:
+        mac = is_macos()
+
+        if mac:
             # macOS-specific shortcuts using Meta key (Command key)
             self.create_action('quit', self.on_quit_action, ['<Meta>q'])
             self.create_action('new-connection', self.on_new_connection, ['<Meta>n'])
@@ -102,7 +102,7 @@ class SshPilotApplication(Adw.Application):
         logging.info("Registered keyboard shortcuts:")
         logging.info("  Cmd+N: new-connection")
         logging.info("  Cmd+Shift+K: new-key")
-        if is_macos:
+        if mac:
             self.create_action('local-terminal', self.on_local_terminal, ['<Meta><Shift>t'])
             self.create_action('preferences', self.on_preferences, ['<Meta>comma'])
             self.create_action('tab-close', self.on_tab_close, ['<Meta>F4'])

--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -1,0 +1,8 @@
+"""Platform-related utility functions."""
+
+import platform
+
+
+def is_macos() -> bool:
+    """Return True if running on macOS."""
+    return platform.system() == "Darwin"

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -4,6 +4,8 @@ import os
 import logging
 import subprocess
 
+from .platform_utils import is_macos
+
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
@@ -17,12 +19,12 @@ def is_running_in_flatpak() -> bool:
 
 def should_hide_external_terminal_options() -> bool:
     """Check if external terminal options should be hidden (Flatpak or macOS)"""
-    return is_running_in_flatpak() or os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin'
+    return is_running_in_flatpak() or is_macos()
 
 
 def should_hide_file_manager_options() -> bool:
     """Check if file manager options should be hidden (macOS)"""
-    return os.name == 'posix' and hasattr(os, 'uname') and os.uname().sysname == 'Darwin'
+    return is_macos()
 
 class MonospaceFontDialog(Adw.Window):
     def __init__(self, parent=None, current_font="Monospace 12"):

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -20,6 +20,7 @@ import pwd
 from datetime import datetime
 from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
 from .port_utils import get_port_checker
+from .platform_utils import is_macos
 
 gi.require_version('Gtk', '4.0')
 gi.require_version('Vte', '3.91')
@@ -1322,10 +1323,8 @@ class TerminalWidget(Gtk.Box):
 
             # Menu model with keyboard shortcuts
             self._menu_model = Gio.Menu()
-            import platform
-            is_macos = platform.system() == 'Darwin'
-            
-            if is_macos:
+
+            if is_macos():
                 self._menu_model.append(_("Copy\t⌘C"), "term.copy")
                 self._menu_model.append(_("Paste\t⌘V"), "term.paste")
                 self._menu_model.append(_("Select All\t⌘A"), "term.select_all")
@@ -1416,9 +1415,7 @@ class TerminalWidget(Gtk.Box):
                     pass
                 return True
             
-            import platform
-            is_macos = platform.system() == 'Darwin'
-            if is_macos:
+            if is_macos():
                 # macOS: Use standard Cmd+C/V for copy/paste, Cmd+Shift+C/V for terminal-specific operations
                 copy_trigger = "<Meta>c"
                 paste_trigger = "<Meta>v"
@@ -1502,17 +1499,16 @@ class TerminalWidget(Gtk.Box):
     def _setup_mouse_wheel_zoom(self):
         """Set up mouse wheel zoom functionality with Cmd+MouseWheel"""
         try:
-            import platform
-            is_macos = platform.system() == 'Darwin'
-            
+            mac = is_macos()
+
             scroll_controller = Gtk.EventControllerScroll()
             scroll_controller.set_flags(Gtk.EventControllerScrollFlags.VERTICAL)
-            
+
             def _on_scroll(controller, dx, dy):
                 try:
                     # Check if Command key (macOS) or Ctrl key (Linux/Windows) is pressed
                     modifiers = controller.get_current_event_state()
-                    if is_macos:
+                    if mac:
                         # Check for Command key (Meta modifier)
                         if modifiers & Gdk.ModifierType.META_MASK:
                             if dy > 0:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -52,6 +52,7 @@ from .actions import WindowActions, register_window_actions
 from . import shutdown
 from .search_utils import connection_matches
 from .shortcut_utils import get_primary_modifier_label
+from .platform_utils import is_macos
 
 logger = logging.getLogger(__name__)
 
@@ -784,9 +785,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     )
                 return True
             
-            import platform
-            is_macos = platform.system() == 'Darwin'
-            trigger = '<Meta>Return' if is_macos else '<Primary>Return'
+            trigger = '<Meta>Return' if is_macos() else '<Primary>Return'
             
             key_controller.add_shortcut(Gtk.Shortcut.new(
                 Gtk.ShortcutTrigger.parse_string(trigger),

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -99,7 +99,7 @@ def test_manage_files_action_visible_on_other_platforms(monkeypatch):
 def test_should_hide_file_manager_options(monkeypatch):
     setup_gi(monkeypatch)
     prefs = reload_module("sshpilot.preferences")
-    monkeypatch.setattr(prefs.os, "uname", lambda: types.SimpleNamespace(sysname="Darwin"))
+    monkeypatch.setattr(prefs, "is_macos", lambda: True)
     assert prefs.should_hide_file_manager_options()
-    monkeypatch.setattr(prefs.os, "uname", lambda: types.SimpleNamespace(sysname="Linux"))
+    monkeypatch.setattr(prefs, "is_macos", lambda: False)
     assert not prefs.should_hide_file_manager_options()


### PR DESCRIPTION
## Summary
- add `is_macos()` platform helper
- replace scattered Darwin checks with the new helper in core modules
- adjust tests to mock `is_macos`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0bb302cb883288a2b892587984c91