### PR TITLE
Detect macOS third-party terminals to show external options

### DIFF
--- a/PYINSTALLER-GUIDE.md
+++ b/PYINSTALLER-GUIDE.md
@@ -80,4 +80,4 @@ open dist/SSHPilot.app
 
 - The bundle is built with ad-hoc code signing (`-`) for development
 - For distribution, you may want to use a proper Apple Developer certificate
-- The application hides external terminal options on macOS (similar to Flatpak behavior)
+- The application hides external terminal options on macOS unless a third-party terminal is available

--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -711,7 +711,7 @@ def register_window_actions(window):
     window.delete_connection_action.connect('activate', window.on_delete_connection_action)
     window.add_action(window.delete_connection_action)
 
-    # Action for opening connections in system terminal (only when not in Flatpak or macOS)
+    # Action for opening connections in system terminal (only when external terminals are available)
     if not should_hide_external_terminal_options():
         window.open_in_system_terminal_action = Gio.SimpleAction.new('open-in-system-terminal', None)
         window.open_in_system_terminal_action.connect('activate', window.on_open_in_system_terminal_action)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -714,7 +714,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                             files_row.connect('activated', lambda *_: (self.on_manage_files_action(None, None), pop.popdown()))
                             listbox.append(files_row)
 
-                        # Only show system terminal option when not in Flatpak or macOS
+                        # Only show system terminal option when external terminals are available
                         if not should_hide_external_terminal_options():
                             terminal_row = Adw.ActionRow(title=_('Open in System Terminal'))
                             terminal_icon = Gtk.Image.new_from_icon_name('utilities-terminal-symbolic')
@@ -856,7 +856,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             self.manage_files_button.connect('clicked', self.on_manage_files_button_clicked)
             self.connection_toolbar.append(self.manage_files_button)
         
-        # System terminal button (only when not in Flatpak or macOS)
+        # System terminal button (only when external terminals are available)
         if not should_hide_external_terminal_options():
             self.system_terminal_button = Gtk.Button.new_from_icon_name('utilities-terminal-symbolic')
             self.system_terminal_button.set_tooltip_text('Open connection in system terminal')


### PR DESCRIPTION
## Summary
- detect common third-party terminals on macOS
- show external terminal options on macOS only when one is available
- refresh comments and docs for the new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0bebf28008328ba960212b4033873