### PR TITLE
Add macOS external terminal support

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -6,6 +6,7 @@ Primary UI with connection list, tabs, and terminal management
 import os
 import logging
 import math
+import shlex
 from typing import Optional, Dict, Any, List, Tuple, Callable
 
 import gi
@@ -4250,77 +4251,70 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
     def open_in_system_terminal(self, connection):
         """Open the connection in the system's default terminal"""
         try:
-            # Build the SSH command
             port_text = f" -p {connection.port}" if hasattr(connection, 'port') and connection.port != 22 else ""
             ssh_command = f"ssh{port_text} {connection.username}@{connection.host}"
-            
-            # Check if user prefers external terminal
+
             use_external = self.config.get_setting('use-external-terminal', False)
-            
             if use_external:
-                # Use user's preferred external terminal
                 terminal_command = self._get_user_preferred_terminal()
             else:
-                # Use built-in terminal (fallback to system default)
                 terminal_command = self._get_default_terminal_command()
-            
+
             if not terminal_command:
-                # Fallback to common terminals
                 common_terminals = [
-                    'gnome-terminal', 'konsole', 'xterm', 'alacritty', 
+                    'gnome-terminal', 'konsole', 'xterm', 'alacritty',
                     'kitty', 'terminator', 'tilix', 'xfce4-terminal'
                 ]
-                
                 for term in common_terminals:
                     try:
                         result = subprocess.run(['which', term], capture_output=True, text=True, timeout=2)
                         if result.returncode == 0:
-                            terminal_command = term
+                            terminal_command = [term]
                             break
                     except Exception:
                         continue
-            
+
             if not terminal_command:
-                # Last resort: try xdg-terminal
                 try:
                     result = subprocess.run(['which', 'xdg-terminal'], capture_output=True, text=True, timeout=2)
                     if result.returncode == 0:
-                        terminal_command = 'xdg-terminal'
+                        terminal_command = ['xdg-terminal']
                 except Exception:
                     pass
-            
+
             if not terminal_command:
-                # Show error dialog
                 self._show_terminal_error_dialog()
                 return
-            
-            # Get the basename for terminal type detection
-            import os
-            terminal_basename = os.path.basename(terminal_command)
-            
-            # Launch the terminal with SSH command
-            if terminal_basename in ['gnome-terminal', 'tilix', 'xfce4-terminal']:
-                # These terminals use -- to separate options from command
-                cmd = [terminal_command, '--', 'bash', '-c', f'{ssh_command}; exec bash']
-            elif terminal_basename in ['konsole', 'terminator', 'guake']:
-                # These terminals use -e for command execution
-                cmd = [terminal_command, '-e', f'bash -c "{ssh_command}; exec bash"']
-            elif terminal_basename in ['alacritty', 'kitty']:
-                # These terminals use -e for command execution
-                cmd = [terminal_command, '-e', 'bash', '-c', f'{ssh_command}; exec bash']
-            elif terminal_basename == 'xterm':
-                # xterm uses -e for command execution
-                cmd = [terminal_command, '-e', f'bash -c "{ssh_command}; exec bash"']
-            elif terminal_basename == 'xdg-terminal':
-                # xdg-terminal opens the default terminal
-                cmd = [terminal_command, ssh_command]
+
+            self._open_system_terminal(terminal_command, ssh_command)
+
+        except Exception as e:
+            logger.error(f"Failed to open system terminal: {e}")
+            self._show_terminal_error_dialog()
+
+    def _open_system_terminal(self, terminal_command: List[str], ssh_command: str):
+        """Launch a terminal command with an SSH command."""
+        try:
+            if is_macos():
+                cmd = terminal_command + ['--args', 'bash', '-lc', f'{ssh_command}; exec bash']
             else:
-                # Generic fallback
-                cmd = [terminal_command, ssh_command]
-            
+                terminal_basename = os.path.basename(terminal_command[0])
+                if terminal_basename in ['gnome-terminal', 'tilix', 'xfce4-terminal']:
+                    cmd = terminal_command + ['--', 'bash', '-c', f'{ssh_command}; exec bash']
+                elif terminal_basename in ['konsole', 'terminator', 'guake']:
+                    cmd = terminal_command + ['-e', f'bash -c "{ssh_command}; exec bash"']
+                elif terminal_basename in ['alacritty', 'kitty']:
+                    cmd = terminal_command + ['-e', 'bash', '-c', f'{ssh_command}; exec bash']
+                elif terminal_basename == 'xterm':
+                    cmd = terminal_command + ['-e', f'bash -c "{ssh_command}; exec bash"']
+                elif terminal_basename == 'xdg-terminal':
+                    cmd = terminal_command + [ssh_command]
+                else:
+                    cmd = terminal_command + [ssh_command]
+
             logger.info(f"Launching system terminal: {' '.join(cmd)}")
             subprocess.Popen(cmd, start_new_session=True)
-            
+
         except Exception as e:
             logger.error(f"Failed to open system terminal: {e}")
             self._show_terminal_error_dialog()
@@ -4328,121 +4322,108 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
     def _open_connection_in_external_terminal(self, connection):
         """Open the connection in the user's preferred external terminal"""
         try:
-            # Build the SSH command
             port_text = f" -p {connection.port}" if hasattr(connection, 'port') and connection.port != 22 else ""
             ssh_command = f"ssh{port_text} {connection.username}@{connection.host}"
-            
-            # Get user's preferred terminal
+
             terminal_command = self._get_user_preferred_terminal()
-            
             if not terminal_command:
-                # Fallback to default terminal
                 terminal_command = self._get_default_terminal_command()
-            
+
             if not terminal_command:
-                # Show error dialog
                 self._show_terminal_error_dialog()
                 return
-            
-            # Get the basename for terminal type detection
-            import os
-            terminal_basename = os.path.basename(terminal_command)
-            
-            # Launch the terminal with SSH command
-            if terminal_basename in ['gnome-terminal', 'tilix', 'xfce4-terminal']:
-                # These terminals use -- to separate options from command
-                cmd = [terminal_command, '--', 'bash', '-c', f'{ssh_command}; exec bash']
-            elif terminal_basename in ['konsole', 'terminator', 'guake']:
-                # These terminals use -e for command execution
-                cmd = [terminal_command, '-e', f'bash -c "{ssh_command}; exec bash"']
-            elif terminal_basename in ['alacritty', 'kitty']:
-                # These terminals use -e for command execution
-                cmd = [terminal_command, '-e', 'bash', '-c', f'{ssh_command}; exec bash']
-            elif terminal_basename == 'xterm':
-                # xterm uses -e for command execution
-                cmd = [terminal_command, '-e', f'bash -c "{ssh_command}; exec bash"']
-            elif terminal_basename == 'xdg-terminal':
-                # xdg-terminal opens the default terminal
-                cmd = [terminal_command, ssh_command]
-            else:
-                # Generic fallback
-                cmd = [terminal_command, ssh_command]
-            
-            logger.info(f"Opening connection in external terminal: {' '.join(cmd)}")
-            subprocess.Popen(cmd, start_new_session=True)
-            
+
+            self._open_system_terminal(terminal_command, ssh_command)
+
         except Exception as e:
             logger.error(f"Failed to open connection in external terminal: {e}")
             self._show_terminal_error_dialog()
 
-    def _get_default_terminal_command(self):
+    def _get_default_terminal_command(self) -> Optional[List[str]]:
         """Get the default terminal command from desktop environment"""
         try:
-            # Check for desktop-specific terminals
+            if is_macos():
+                mac_terms = ['iTerm', 'Warp', 'WezTerm', 'Alacritty', 'Terminal']
+                for app in mac_terms:
+                    try:
+                        result = subprocess.run(['open', '-Ra', app], capture_output=True, text=True, timeout=2)
+                        if result.returncode == 0:
+                            return ['open', '-a', app]
+                    except Exception:
+                        continue
+                return None
+
             desktop = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
-            
+
             if 'gnome' in desktop:
-                return 'gnome-terminal'
+                return ['gnome-terminal']
             elif 'kde' in desktop or 'plasma' in desktop:
-                return 'konsole'
+                return ['konsole']
             elif 'xfce' in desktop:
-                return 'xfce4-terminal'
+                return ['xfce4-terminal']
             elif 'cinnamon' in desktop:
-                return 'gnome-terminal'  # Cinnamon uses gnome-terminal
+                return ['gnome-terminal']
             elif 'mate' in desktop:
-                return 'mate-terminal'
+                return ['mate-terminal']
             elif 'lxqt' in desktop:
-                return 'qterminal'
+                return ['qterminal']
             elif 'lxde' in desktop:
-                return 'lxterminal'
-            
-            # Check for common terminals in PATH
+                return ['lxterminal']
+
             common_terminals = [
-                'gnome-terminal', 'konsole', 'xfce4-terminal', 'alacritty', 
+                'gnome-terminal', 'konsole', 'xfce4-terminal', 'alacritty',
                 'kitty', 'terminator', 'tilix', 'guake'
             ]
-            
+
             for term in common_terminals:
                 try:
                     result = subprocess.run(['which', term], capture_output=True, text=True, timeout=2)
                     if result.returncode == 0:
-                        return term
+                        return [term]
                 except Exception:
                     continue
-            
+
             return None
-            
+
         except Exception as e:
             logger.error(f"Failed to get default terminal: {e}")
             return None
     
-    def _get_user_preferred_terminal(self):
+    def _get_user_preferred_terminal(self) -> Optional[List[str]]:
         """Get the user's preferred terminal from settings"""
         try:
-            # Get the user's preferred terminal
             preferred_terminal = self.config.get_setting('external-terminal', 'gnome-terminal')
-            
+
             if preferred_terminal == 'custom':
-                # Use custom path
                 custom_path = self.config.get_setting('custom-terminal-path', '')
                 if custom_path:
-                    return custom_path
+                    if is_macos():
+                        return ['open', '-a', custom_path]
+                    return [custom_path]
                 else:
                     logger.warning("Custom terminal path is not set, falling back to built-in terminal")
                     return None
-            
-            # Check if the preferred terminal is available
+
+            if is_macos():
+                # Preferences may store either an app name ("iTerm") or a full
+                # command ("open -a iTerm").  If the value already starts with
+                # "open" use it verbatim, otherwise build an "open -a" command
+                # for the specified app.
+                if preferred_terminal.startswith('open'):
+                    return shlex.split(preferred_terminal)
+                return ['open', '-a', preferred_terminal]
+
             try:
                 result = subprocess.run(['which', preferred_terminal], capture_output=True, text=True, timeout=2)
                 if result.returncode == 0:
-                    return preferred_terminal
+                    return [preferred_terminal]
                 else:
                     logger.warning(f"Preferred terminal '{preferred_terminal}' not found, falling back to built-in terminal")
                     return None
             except Exception as e:
                 logger.error(f"Failed to check preferred terminal '{preferred_terminal}': {e}")
                 return None
-                
+
         except Exception as e:
             logger.error(f"Failed to get user preferred terminal: {e}")
             return None

--- a/tests/test_macos_terminal.py
+++ b/tests/test_macos_terminal.py
@@ -1,0 +1,176 @@
+import types
+import subprocess
+import pytest
+
+import sys
+import types
+
+# Stub out gi modules so window.py can be imported without GTK
+gi_module = types.ModuleType("gi")
+gi_module.require_version = lambda *args, **kwargs: None
+
+
+class Module(types.SimpleNamespace):
+    def __getattr__(self, name):
+        return Module()
+
+    def __call__(self, *args, **kwargs):
+        return Module()
+
+
+repo = Module()
+repo.Gtk = Module(Button=type("Button", (), {}), Dialog=type("Dialog", (), {}), Label=type("Label", (), {}), CssProvider=type("CssProvider", (), {}))
+repo.Adw = Module(ApplicationWindow=type("ApplicationWindow", (), {}), MessageDialog=type("MessageDialog", (), {}))
+repo.Gio = Module(SimpleAction=type("SimpleAction", (), {}), ThemedIcon=type("ThemedIcon", (), {}))
+repo.GLib = Module(idle_add=lambda *a, **k: None)
+repo.GObject = Module(Object=type("Object", (), {}))
+repo.Gdk = Module(Display=Module(get_default=lambda: None), RGBA=type("RGBA", (), {}))
+repo.Pango = Module()
+repo.PangoFT2 = Module()
+repo.Vte = Module()
+
+gi_module.repository = repo
+original_gi = {name: sys.modules.get(name) for name in ["gi", "gi.repository"] + [f"gi.repository.{n}" for n in ["Gtk", "Adw", "Gio", "GLib", "GObject", "Gdk", "Pango", "PangoFT2", "Vte"]]}
+sys.modules["gi"] = gi_module
+sys.modules["gi.repository"] = repo
+for name in ["Gtk", "Adw", "Gio", "GLib", "GObject", "Gdk", "Pango", "PangoFT2", "Vte"]:
+    sys.modules[f"gi.repository.{name}"] = getattr(repo, name)
+
+# Stub internal modules referenced by window.py that aren't needed for these tests
+stub_modules = {
+    "sshpilot.connection_manager": types.SimpleNamespace(ConnectionManager=object, Connection=object),
+    "sshpilot.terminal": types.SimpleNamespace(TerminalWidget=object),
+    "sshpilot.terminal_manager": types.SimpleNamespace(TerminalManager=object),
+    "sshpilot.config": types.SimpleNamespace(Config=object),
+    "sshpilot.key_manager": types.SimpleNamespace(KeyManager=object, SSHKey=object),
+    "sshpilot.connection_dialog": types.SimpleNamespace(ConnectionDialog=object),
+    "sshpilot.askpass_utils": types.SimpleNamespace(ensure_askpass_script=lambda: None),
+    "sshpilot.preferences": types.SimpleNamespace(
+        PreferencesWindow=object,
+        is_running_in_flatpak=lambda: False,
+        should_hide_external_terminal_options=lambda: False,
+        should_hide_file_manager_options=lambda: False,
+    ),
+    "sshpilot.sshcopyid_window": types.SimpleNamespace(SshCopyIdWindow=object),
+    "sshpilot.groups": types.SimpleNamespace(GroupManager=object),
+    "sshpilot.sidebar": types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
+    "sshpilot.sftp_utils": types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+    "sshpilot.welcome_page": types.SimpleNamespace(WelcomePage=object),
+    "sshpilot.actions": types.SimpleNamespace(WindowActions=object, register_window_actions=lambda *a, **k: None),
+    "sshpilot.shutdown": types.SimpleNamespace(),
+    "sshpilot.search_utils": types.SimpleNamespace(connection_matches=lambda *a, **k: False),
+    "sshpilot.shortcut_utils": types.SimpleNamespace(get_primary_modifier_label=lambda: "Ctrl"),
+}
+
+original_stubs = {}
+for name, module in stub_modules.items():
+    original_stubs[name] = sys.modules.get(name)
+    sys.modules[name] = module
+
+import sshpilot.window as window_mod
+from sshpilot.window import MainWindow
+
+# Restore original modules so other tests see real implementations
+for name, mod in original_stubs.items():
+    if mod is None:
+        del sys.modules[name]
+    else:
+        sys.modules[name] = mod
+for name, mod in original_gi.items():
+    if mod is None:
+        del sys.modules[name]
+    else:
+        sys.modules[name] = mod
+
+
+class DummyConfig:
+    def __init__(self, settings=None):
+        self.settings = settings or {}
+
+    def get_setting(self, key, default=None):
+        return self.settings.get(key, default)
+
+
+class DummyWindow:
+    def __init__(self, settings=None):
+        self.config = DummyConfig(settings)
+
+    _get_user_preferred_terminal = MainWindow._get_user_preferred_terminal
+    _get_default_terminal_command = MainWindow._get_default_terminal_command
+    _open_connection_in_external_terminal = MainWindow._open_connection_in_external_terminal
+    _open_system_terminal = MainWindow._open_system_terminal
+
+    def _show_terminal_error_dialog(self):
+        raise AssertionError("error dialog not expected")
+
+
+def test_get_user_preferred_terminal_macos(monkeypatch):
+    monkeypatch.setattr(window_mod, "is_macos", lambda: True)
+    win = DummyWindow({"external-terminal": "iTerm"})
+    assert win._get_user_preferred_terminal() == ["open", "-a", "iTerm"]
+
+
+def test_get_user_preferred_terminal_macos_with_command(monkeypatch):
+    monkeypatch.setattr(window_mod, "is_macos", lambda: True)
+    win = DummyWindow({"external-terminal": "open -a Ghostty"})
+    assert win._get_user_preferred_terminal() == ["open", "-a", "Ghostty"]
+
+
+def test_get_default_terminal_command_macos(monkeypatch):
+    monkeypatch.setattr(window_mod, "is_macos", lambda: True)
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=None):
+        class R:
+            pass
+        r = R()
+        # simulate only Terminal being present
+        r.returncode = 0 if cmd[-1] == "Terminal" else 1
+        return r
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    win = DummyWindow()
+    assert win._get_default_terminal_command() == ["open", "-a", "Terminal"]
+
+
+def test_open_connection_in_external_terminal_macos(monkeypatch):
+    monkeypatch.setattr(window_mod, "is_macos", lambda: True)
+    win = DummyWindow({"external-terminal": "iTerm"})
+
+    captured = {}
+
+    def fake_popen(cmd, start_new_session=False):
+        captured["cmd"] = cmd
+        class P:
+            pass
+        return P()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    connection = types.SimpleNamespace(username="user", host="example.com", port=22)
+    win._open_connection_in_external_terminal(connection)
+
+    assert captured["cmd"][0:3] == ["open", "-a", "iTerm"]
+    assert "--args" in captured["cmd"]
+    assert "ssh user@example.com; exec bash" in captured["cmd"][-1]
+
+
+def test_open_connection_in_external_terminal_macos_with_command(monkeypatch):
+    monkeypatch.setattr(window_mod, "is_macos", lambda: True)
+    win = DummyWindow({"external-terminal": "open -a iTerm"})
+
+    captured = {}
+
+    def fake_popen(cmd, start_new_session=False):
+        captured["cmd"] = cmd
+        class P:
+            pass
+        return P()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    connection = types.SimpleNamespace(username="user", host="example.com", port=22)
+    win._open_connection_in_external_terminal(connection)
+
+    assert captured["cmd"][0:3] == ["open", "-a", "iTerm"]
+    assert "--args" in captured["cmd"]
+    assert "ssh user@example.com; exec bash" in captured["cmd"][-1]


### PR DESCRIPTION
## Summary
- resolve user-preferred and default terminals on macOS by returning `open -a` commands
- build macOS-specific launch commands for external and system terminals
- add tests verifying macOS terminal detection and launch behaviour
- handle preformatted `open -a` preferences to avoid duplicate prefixes

## Testing
- `pytest tests/test_macos_terminal.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c1e513208328bfa276428a62905b