### PR TITLE
Refactor welcome page with quick connect and search

### DIFF
--- a/sshpilot/search_utils.py
+++ b/sshpilot/search_utils.py
@@ -6,8 +6,9 @@ from typing import Any
 def connection_matches(connection: Any, query: str) -> bool:
     """Return True if connection matches the search query.
 
-    The search checks the connection's nickname, host alias (``hname``), and
-    host/IP address in a case-insensitive manner.
+    The search checks the connection's nickname, host alias (``hname``),
+    any additional aliases, and host/IP address in a case-insensitive
+    manner.
     """
     if not query:
         return True
@@ -17,6 +18,8 @@ def connection_matches(connection: Any, query: str) -> bool:
         getattr(connection, "host", ""),
         getattr(connection, "hname", ""),
     ]
+    aliases = getattr(connection, "aliases", []) or []
+    fields.extend(aliases)
     return any(text in (field or "").lower() for field in fields)
 
 

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -5,21 +5,26 @@ import gi
 gi.require_version('Gtk', '4.0')
 
 from gi.repository import Gtk, Gdk
+from gettext import gettext as _
 
-from .shortcut_utils import get_primary_modifier_label
+from .connection_manager import Connection
+from .search_utils import connection_matches
 
 
 class WelcomePage(Gtk.Box):
     """Welcome page shown when no tabs are open."""
 
-    def __init__(self) -> None:
+    def __init__(self, window) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=24)
-        self.set_valign(Gtk.Align.CENTER)
-        self.set_halign(Gtk.Align.CENTER)
-        self.set_margin_start(48)
-        self.set_margin_end(48)
-        self.set_margin_top(48)
-        self.set_margin_bottom(48)
+        self.window = window
+        self.connection_manager = window.connection_manager
+        self.set_valign(Gtk.Align.START)
+        self.set_halign(Gtk.Align.FILL)
+        self.set_hexpand(True)
+        self.set_margin_start(24)
+        self.set_margin_end(24)
+        self.set_margin_top(24)
+        self.set_margin_bottom(24)
 
         # Welcome icon
         try:
@@ -30,54 +35,137 @@ class WelcomePage(Gtk.Box):
             icon = Gtk.Image.new_from_icon_name('network-workgroup-symbolic')
             icon.set_icon_size(Gtk.IconSize.LARGE)
             icon.set_pixel_size(128)
+        icon.set_halign(Gtk.Align.CENTER)
         self.append(icon)
 
-        # Welcome message
-        message = Gtk.Label()
-        message.set_text('Select a host from the list, double-click or press Enter to connect')
-        message.set_halign(Gtk.Align.CENTER)
-        message.add_css_class('dim-label')
-        self.append(message)
+        # Quick connect box
+        quick_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        quick_box.set_halign(Gtk.Align.FILL)
+        quick_box.set_hexpand(True)
+        self.quick_entry = Gtk.Entry()
+        self.quick_entry.set_hexpand(True)
+        self.quick_entry.set_placeholder_text(_('user@host'))
+        self.quick_entry.connect('activate', self.on_quick_connect)
+        connect_button = Gtk.Button(label=_('Connect'))
+        connect_button.connect('clicked', self.on_quick_connect)
+        quick_box.append(self.quick_entry)
+        quick_box.append(connect_button)
+        self.append(quick_box)
+
+        # Search box and results
+        search_container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        search_container.set_halign(Gtk.Align.FILL)
+        search_container.set_hexpand(True)
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.set_hexpand(True)
+        self.search_entry.set_placeholder_text(_('Search connections'))
+        self.search_entry.connect('activate', self.on_search_activate)
+        self.search_entry.connect('search-changed', self.on_search_changed)
+        search_container.append(self.search_entry)
+
+        self.results_list = Gtk.ListBox()
+        self.results_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        self.results_list.set_hexpand(True)
+        self.results_list.connect('row-activated', self.on_result_activated)
+        search_container.append(self.results_list)
+        self.append(search_container)
+
+        # Action buttons
+        buttons_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        buttons_box.set_halign(Gtk.Align.START)
+        local_button = Gtk.Button(label=_('Local Terminal'))
+        local_button.connect('clicked', lambda *_: window.terminal_manager.show_local_terminal())
+        prefs_button = Gtk.Button(label=_('Preferences'))
+        prefs_button.connect('clicked', lambda *_: window.show_preferences())
+        buttons_box.append(local_button)
+        buttons_box.append(prefs_button)
+        self.append(buttons_box)
 
         # Shortcuts box
-        shortcuts_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        shortcuts_box.set_halign(Gtk.Align.CENTER)
+        shortcuts_container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        shortcuts_container.set_halign(Gtk.Align.FILL)
+        shortcuts_title = Gtk.Label(label=_('Keyboard Shortcuts'))
+        shortcuts_title.set_halign(Gtk.Align.START)
+        shortcuts_container.append(shortcuts_title)
 
-        shortcuts_title = Gtk.Label()
-        shortcuts_title.set_markup('<b>Keyboard Shortcuts</b>')
-        shortcuts_box.append(shortcuts_title)
+        shortcuts_scroller = Gtk.ScrolledWindow()
+        shortcuts_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        shortcuts_scroller.set_min_content_height(120)
+        shortcuts_scroller.set_max_content_height(200)
+        shortcuts_scroller.set_hexpand(True)
+        shortcuts_scroller.set_vexpand(False)
 
-        primary = get_primary_modifier_label()
+        grid = Gtk.Grid(column_spacing=12, row_spacing=6)
+        grid.set_halign(Gtk.Align.START)
+
         shortcuts = [
-            (f'{primary}+N', 'New Connection'),
-            (f'{primary}+Alt+N', 'Open  Selected Host in a New Tab'),
-            ('F9', 'Toggle Sidebar'),
-            (f'{primary}+L', 'Focus connection list to select server'),
-            (f'{primary}+Shift+K', 'Copy SSH Key to Server'),
-            ('Alt+Right', 'Next Tab'),
-            ('Alt+Left', 'Previous Tab'),
-            (f'{primary}+F4', 'Close Tab'),
-            (f'{primary}+Shift+T', 'New Local Terminal'),
-            (f'{primary}+Shift+=', 'Zoom In'),
-            (f'{primary}+-', 'Zoom Out'),
-            (f'{primary}+0', 'Reset Zoom'),
-            (f'{primary}+,', 'Preferences'),
+            ("<Primary>N", _('New Connection')),
+            ("<Primary><Alt>N", _('Open Selected Host in a New Tab')),
+            ("F9", _('Toggle Sidebar')),
+            ("<Primary>L", _('Focus connection list to select server')),
+            ("<Primary><Shift>K", _('Copy SSH Key to Server')),
+            ("<Alt>Right", _('Next Tab')),
+            ("<Alt>Left", _('Previous Tab')),
+            ("<Primary>F4", _('Close Tab')),
+            ("<Primary><Shift>T", _('New Local Terminal')),
+            ("<Primary>plus", _('Zoom In')),
+            ("<Primary>minus", _('Zoom Out')),
+            ("<Primary>0", _('Reset Zoom')),
+            ("<Primary>comma", _('Preferences')),
         ]
 
-        for shortcut, description in shortcuts:
-            shortcut_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-
-            key_label = Gtk.Label()
-            key_label.set_markup(f'<tt>{shortcut}</tt>')
-            key_label.set_width_chars(15)
+        for row, (shortcut, description) in enumerate(shortcuts):
+            key_label = Gtk.ShortcutLabel.new(shortcut)
             key_label.set_halign(Gtk.Align.START)
-            shortcut_box.append(key_label)
+            desc_label = Gtk.Label(label=description, xalign=0)
+            grid.attach(key_label, 0, row, 1, 1)
+            grid.attach(desc_label, 1, row, 1, 1)
 
-            desc_label = Gtk.Label()
-            desc_label.set_text(description)
-            desc_label.set_halign(Gtk.Align.START)
-            shortcut_box.append(desc_label)
+        shortcuts_scroller.set_child(grid)
+        shortcuts_container.append(shortcuts_scroller)
+        self.append(shortcuts_container)
 
-            shortcuts_box.append(shortcut_box)
+    # Quick connect handlers
+    def on_quick_connect(self, *_args):
+        text = self.quick_entry.get_text().strip()
+        if not text:
+            return
+        username = ''
+        host = text
+        if '@' in text:
+            username, host = text.split('@', 1)
+        data = {"nickname": host, "host": host, "username": username}
+        connection = Connection(data)
+        self.window.terminal_manager.connect_to_host(connection, force_new=False)
 
-        self.append(shortcuts_box)
+    # Search handlers
+    def _search_results(self, query: str):
+        connections = self.connection_manager.get_connections()
+        matches = [c for c in connections if connection_matches(c, query)]
+        return matches
+
+    def on_search_changed(self, entry):
+        query = entry.get_text().strip().lower()
+        for child in list(self.results_list):
+            self.results_list.remove(child)
+        if not query:
+            return
+        for conn in self._search_results(query):
+            row = Gtk.ListBoxRow()
+            row.connection = conn
+            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            label = Gtk.Label(label=f"{conn.nickname} ({conn.host})", xalign=0)
+            box.append(label)
+            row.set_child(box)
+            self.results_list.append(row)
+        self.results_list.show()
+
+    def on_search_activate(self, entry):
+        query = entry.get_text().strip().lower()
+        matches = self._search_results(query)
+        if matches:
+            self.window.terminal_manager.connect_to_host(matches[0], force_new=False)
+
+    def on_result_activated(self, listbox, row):
+        if hasattr(row, 'connection'):
+            self.window.terminal_manager.connect_to_host(row.connection, force_new=False)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -343,6 +343,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         # Load window geometry
         geometry = self.config.get_window_geometry()
         self.set_default_size(geometry['width'], geometry['height'])
+        self.set_resizable(True)
         
         # Connect window state signals
         self.connect('notify::default-width', self.on_window_size_changed)
@@ -911,7 +912,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         self.content_stack.set_vexpand(True)
         
         # Create welcome/help view
-        self.welcome_view = WelcomePage()
+        self.welcome_view = WelcomePage(self)
         self.content_stack.add_named(self.welcome_view, "welcome")
         
         # Create tab view

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -25,3 +25,10 @@ def test_matches_host():
 def test_matches_alias():
     conn = make_connection("alias", "host", hname="myalias")
     assert connection_matches(conn, "myalias")
+
+
+def test_matches_alias_list():
+    conn = Connection({"nickname": "srv", "host": "host", "username": "user", "aliases": ["alias1", "alias2"]})
+    assert connection_matches(conn, "alias1")
+    assert connection_matches(conn, "alias2")
+    assert not connection_matches(conn, "alias3")


### PR DESCRIPTION
## Summary
- Refactor welcome page to add quick connect entry, connection search, GNOME-style shortcuts, and utility buttons
- Extend search utilities to match connection aliases
- Update tests for macOS terminal handling and alias search
- Fill welcome page horizontally and use accelerator-based shortcut labels
- Show keyboard shortcuts in a compact, scrollable grid and allow window resizing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c16264834083289c72d86a662cd8bc