### PR TITLE
Ignore aliases directive in extra SSH config

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1023,7 +1023,7 @@ class ConnectionManager(GObject.Object):
             extra_config_lines = []
             # Only include options that are explicitly handled by the main UI fields
             standard_options = {
-                'host', 'hostname', 'port', 'user', 'identityfile', 'certificatefile',
+                'host', 'hostname', 'aliases', 'port', 'user', 'identityfile', 'certificatefile',
                 'forwardx11', 'localforward', 'remoteforward', 'dynamicforward',
                 'proxycommand', 'proxyjump', 'localcommand', 'remotecommand', 'requesttty',
                 'identitiesonly', 'permitlocalcommand',

--- a/tests/test_extra_config_aliases.py
+++ b/tests/test_extra_config_aliases.py
@@ -1,0 +1,19 @@
+from sshpilot.connection_manager import ConnectionManager
+
+
+def make_cm():
+    return ConnectionManager.__new__(ConnectionManager)
+
+
+def test_aliases_not_in_extra_config():
+    cm = make_cm()
+    config = {
+        "host": "primary",
+        "aliases": ["alias1", "alias2"],
+        "hostname": "example.com",
+        "compression": "yes",
+    }
+    parsed = ConnectionManager.parse_host_config(cm, config)
+    extra = parsed.get("extra_ssh_config", "") or ""
+    assert "aliases" not in extra.lower()
+    assert "compression yes" in extra.lower()


### PR DESCRIPTION
## Summary
- avoid copying Host aliases into extra SSH config
- add regression test for extra config alias handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c179cd27d08328adbc0a566c0f354e