### PR TITLE
Add keyboard shortcuts help overlay

### DIFF
--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -115,6 +115,8 @@ class SshPilotApplication(Adw.Application):
         
         self.create_action('about', self.on_about)
         self.create_action('help', self.on_help, ['F1'])
+        shortcuts_accel = ['<Meta><Shift>slash'] if mac else ['<primary><Shift>slash']
+        self.create_action('shortcuts', self.on_shortcuts, shortcuts_accel)
         # Tab navigation accelerators
         self.create_action('tab-next', self.on_tab_next, ['<Alt>Right'])
         self.create_action('tab-prev', self.on_tab_prev, ['<Alt>Left'])
@@ -331,6 +333,12 @@ class SshPilotApplication(Adw.Application):
         logging.debug("Help action triggered")
         if self.props.active_window:
             self.props.active_window.open_help_url()
+
+    def on_shortcuts(self, action, param):
+        """Handle keyboard shortcuts overlay action"""
+        logging.debug("Shortcuts action triggered")
+        if self.props.active_window:
+            self.props.active_window.show_shortcuts_window()
 
     def on_tab_next(self, action, param):
         """Switch to next tab"""


### PR DESCRIPTION
## Summary
- add Help submenu with keyboard shortcuts and documentation
- implement platform-aware shortcuts overlay using Gtk.ShortcutsWindow
- expose new `shortcuts` action with Cmd/Ctrl+Shift+/ binding

## Testing
- `pytest`
- `python -m py_compile sshpilot/window.py sshpilot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1f287188328971f3a88d3ea41b3