### PR TITLE
Add Known Hosts editor and menu entry

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -179,6 +179,16 @@ class WindowActions:
         except Exception as e:
             logger.error(f"Failed to open in system terminal: {e}")
 
+    def on_edit_known_hosts_action(self, action, param=None):
+        """Open the Known Hosts editor window."""
+        try:
+            from .known_hosts_editor import KnownHostsEditorWindow
+
+            win = KnownHostsEditorWindow(self, self.connection_manager)
+            win.present()
+        except Exception as e:
+            logger.error(f"Failed to open known hosts editor: {e}")
+
     def on_broadcast_command_action(self, action, param=None):
         """Handle broadcast command action - shows dialog to input command"""
         try:
@@ -717,6 +727,11 @@ def register_window_actions(window):
         window.open_in_system_terminal_action = Gio.SimpleAction.new('open-in-system-terminal', None)
         window.open_in_system_terminal_action.connect('activate', window.on_open_in_system_terminal_action)
         window.add_action(window.open_in_system_terminal_action)
+
+    # Known hosts editor action
+    window.edit_known_hosts_action = Gio.SimpleAction.new('edit-known-hosts', None)
+    window.edit_known_hosts_action.connect('activate', window.on_edit_known_hosts_action)
+    window.add_action(window.edit_known_hosts_action)
 
     # Action for broadcasting commands to all SSH terminals
     window.broadcast_command_action = Gio.SimpleAction.new('broadcast-command', None)

--- a/sshpilot/known_hosts_editor.py
+++ b/sshpilot/known_hosts_editor.py
@@ -1,0 +1,111 @@
+import os
+import logging
+from gettext import gettext as _
+
+from gi.repository import Gtk, Adw
+
+logger = logging.getLogger(__name__)
+
+
+class KnownHostsEditorWindow(Adw.Window):
+    """Simple editor for the user's known_hosts file."""
+
+    def __init__(self, parent, connection_manager):
+        super().__init__()
+        self.set_transient_for(parent)
+        self.set_modal(True)
+        self.set_default_size(600, 400)
+        self.set_title(_("Edit Known Hosts"))
+
+        self._cm = connection_manager
+        self._known_hosts_path = getattr(
+            connection_manager,
+            "known_hosts_path",
+            os.path.expanduser("~/.ssh/known_hosts"),
+        )
+        self._lines: list[str | None] = []
+
+        tv = Adw.ToolbarView()
+        self.set_content(tv)
+
+        header = Adw.HeaderBar()
+        header.set_title_widget(Gtk.Label(label=_("Edit Known Hosts")))
+        tv.add_top_bar(header)
+
+        cancel_btn = Gtk.Button(label=_("Cancel"))
+        cancel_btn.connect("clicked", lambda *_: self.close())
+        header.pack_start(cancel_btn)
+
+        save_btn = Gtk.Button(label=_("Save"))
+        save_btn.add_css_class("suggested-action")
+        save_btn.connect("clicked", self._on_save_clicked)
+        header.pack_end(save_btn)
+
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_child(self.listbox)
+        tv.set_content(scrolled)
+
+        self._load_entries()
+
+    def _load_entries(self) -> None:
+        """Load known_hosts lines into the listbox."""
+        try:
+            if not os.path.exists(self._known_hosts_path):
+                return
+            with open(self._known_hosts_path, "r", encoding="utf-8") as f:
+                for idx, line in enumerate(f):
+                    line = line.rstrip("\n")
+                    self._lines.append(line)
+                    stripped = line.strip()
+                    if not stripped or stripped.startswith("#"):
+                        continue
+                    parts = stripped.split()
+                    host_field = parts[0]
+                    key_type = parts[1] if len(parts) > 1 else ""
+
+                    row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+                    row.set_margin_top(6)
+                    row.set_margin_bottom(6)
+
+                    host_label = Gtk.Label(label=host_field, xalign=0)
+                    host_label.set_hexpand(True)
+                    row.append(host_label)
+
+                    type_label = Gtk.Label(label=key_type, xalign=0)
+                    type_label.set_hexpand(True)
+                    row.append(type_label)
+
+                    remove_btn = Gtk.Button.new_from_icon_name("list-remove-symbolic")
+                    remove_btn.set_tooltip_text(_("Remove"))
+                    remove_btn.connect("clicked", self._on_remove_clicked, row)
+                    row._line_index = idx  # type: ignore[attr-defined]
+                    row.append(remove_btn)
+
+                    self.listbox.append(row)
+        except Exception as e:
+            logger.error(f"Failed to load known hosts: {e}")
+
+    def _on_remove_clicked(self, _btn: Gtk.Button, row: Gtk.Widget) -> None:
+        idx = getattr(row, "_line_index", None)
+        if idx is not None:
+            self._lines[idx] = None
+        self.listbox.remove(row)
+
+    def _on_save_clicked(self, _btn: Gtk.Button) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._known_hosts_path), exist_ok=True)
+            with open(self._known_hosts_path, "w", encoding="utf-8") as f:
+                for line in self._lines:
+                    if line is not None:
+                        f.write(line + "\n")
+            if getattr(self._cm, "load_known_hosts", None):
+                try:
+                    self._cm.load_known_hosts()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+            self.close()
+        except Exception as e:
+            logger.error(f"Failed to save known hosts: {e}")

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -7,6 +7,7 @@ gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gdk
 
 from .shortcut_utils import get_primary_modifier_label
+from gettext import gettext as _
 
 
 class WelcomePage(Gtk.Box):
@@ -38,6 +39,12 @@ class WelcomePage(Gtk.Box):
         message.set_halign(Gtk.Align.CENTER)
         message.add_css_class('dim-label')
         self.append(message)
+
+        # Known hosts editor button
+        kh_button = Gtk.Button(label=_('Known Hosts Editor'))
+        kh_button.set_halign(Gtk.Align.CENTER)
+        kh_button.connect('clicked', lambda b: b.activate_action('win.edit-known-hosts', None))
+        self.append(kh_button)
 
         # Shortcuts box
         shortcuts_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -997,6 +997,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         menu.append('Local Terminal', 'app.local-terminal')
         menu.append('Copy Key to Server', 'app.new-key')
         menu.append('Broadcast Command', 'app.broadcast-command')
+        menu.append('Known Hosts Editor', 'win.edit-known-hosts')
         menu.append('Preferences', 'app.preferences')
         menu.append('Help', 'app.help')
         menu.append('About', 'app.about')

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -63,6 +63,8 @@ def create_window():
             pass
         def on_broadcast_command_action(self, *args):
              pass
+        def on_edit_known_hosts_action(self, *args):
+             pass
         def on_create_group_action(self, *args):
              pass
         def on_edit_group_action(self, *args):


### PR DESCRIPTION
## Summary
- introduce KnownHostsEditorWindow to manage known_hosts entries with remove, save and cancel actions
- expose Known Hosts Editor via application menu and welcome page button
- register `edit-known-hosts` window action and stub tests accordingly

## Testing
- `pytest` *(4 tests failed: macOS terminal command assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a32474f08328bc13ecf7724ceb28