### PR TITLE
Add known hosts editor window with menu and welcome page entry

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -278,6 +278,14 @@ class WindowActions:
             except Exception:
                 pass
 
+    def on_edit_known_hosts_action(self, action, param=None):
+        """Open the known hosts editor window."""
+        try:
+            if hasattr(self, 'show_known_hosts_editor'):
+                self.show_known_hosts_editor()
+        except Exception as e:
+            logger.error(f"Failed to open known hosts editor: {e}")
+
     def on_create_group_action(self, action, param=None):
         """Handle create group action"""
         try:
@@ -722,6 +730,12 @@ def register_window_actions(window):
     window.broadcast_command_action = Gio.SimpleAction.new('broadcast-command', None)
     window.broadcast_command_action.connect('activate', window.on_broadcast_command_action)
     window.add_action(window.broadcast_command_action)
+
+    # Action for editing known hosts
+    if hasattr(window, 'on_edit_known_hosts_action'):
+        window.edit_known_hosts_action = Gio.SimpleAction.new('edit-known-hosts', None)
+        window.edit_known_hosts_action.connect('activate', window.on_edit_known_hosts_action)
+        window.add_action(window.edit_known_hosts_action)
 
     # Group management actions
     window.create_group_action = Gio.SimpleAction.new('create-group', None)

--- a/sshpilot/known_hosts_editor.py
+++ b/sshpilot/known_hosts_editor.py
@@ -1,0 +1,111 @@
+import os
+import logging
+from typing import Callable, Optional
+
+from gettext import gettext as _
+from gi.repository import Gtk, Adw
+
+
+logger = logging.getLogger(__name__)
+
+
+class KnownHostsEditorWindow(Adw.Window):
+    """Simple window for viewing and removing entries from known_hosts."""
+
+    def __init__(self, parent, connection_manager, on_saved: Optional[Callable] = None):
+        super().__init__()
+        self.set_transient_for(parent)
+        self.set_modal(True)
+        self.set_default_size(600, 400)
+        self.set_title(_("Known Hosts Editor"))
+
+        self._cm = connection_manager
+        self._on_saved = on_saved
+        self._known_hosts_path = getattr(
+            connection_manager,
+            'known_hosts_path',
+            os.path.expanduser('~/.ssh/known_hosts'),
+        )
+
+        tv = Adw.ToolbarView()
+        self.set_content(tv)
+
+        header = Adw.HeaderBar()
+        header.set_title_widget(Gtk.Label(label=_("Known Hosts Editor")))
+        tv.add_top_bar(header)
+
+        cancel_btn = Gtk.Button(label=_("Cancel"))
+        cancel_btn.connect("clicked", lambda *_: self.close())
+        header.pack_start(cancel_btn)
+
+        save_btn = Gtk.Button(label=_("Save"))
+        save_btn.add_css_class("suggested-action")
+        save_btn.connect("clicked", self._on_save_clicked)
+        header.pack_end(save_btn)
+
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(self.listbox)
+        tv.set_content(scrolled)
+
+        self._load_entries()
+
+    def _load_entries(self):
+        """Load known_hosts entries into the listbox."""
+        try:
+            with open(self._known_hosts_path, 'r') as f:
+                lines = [line.rstrip('\n') for line in f]
+        except Exception as e:
+            logger.error(f"Failed to load known_hosts: {e}")
+            lines = []
+
+        for line in lines:
+            if not line.strip():
+                continue
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            label = Gtk.Label(label=line, xalign=0)
+            label.set_hexpand(True)
+            remove_btn = Gtk.Button.new_from_icon_name('user-trash-symbolic')
+            remove_btn.set_valign(Gtk.Align.CENTER)
+            remove_btn.connect('clicked', self._on_remove_clicked, row)
+            row.append(label)
+            row.append(remove_btn)
+            self.listbox.append(row)
+
+    def _on_remove_clicked(self, _btn, row):
+        try:
+            self.listbox.remove(row)
+        except Exception as e:
+            logger.error(f"Failed to remove known_host entry: {e}")
+
+    def _on_save_clicked(self, _btn):
+        lines = []
+        child = self.listbox.get_first_child()
+        while child:
+            if isinstance(child, Gtk.ListBoxRow):
+                row = child.get_child()
+            else:
+                row = child
+            label = row.get_first_child()
+            if isinstance(label, Gtk.Label):
+                text = label.get_text()
+                if text:
+                    lines.append(text)
+            child = child.get_next_sibling()
+
+        try:
+            os.makedirs(os.path.dirname(self._known_hosts_path), exist_ok=True)
+            with open(self._known_hosts_path, 'w') as f:
+                if lines:
+                    f.write('\n'.join(lines) + '\n')
+                else:
+                    f.write('')
+            if self._on_saved:
+                self._on_saved()
+            self.close()
+        except Exception as e:
+            logger.error(f"Failed to save known_hosts: {e}")
+

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -88,15 +88,22 @@ class WelcomePage(Gtk.Box):
         local_button.set_icon_name('utilities-terminal-symbolic')
         local_button.set_tooltip_text(_('Local Terminal'))
         local_button.connect('clicked', lambda *_: window.terminal_manager.show_local_terminal())
-        
+
+        # Known hosts editor button
+        known_hosts_button = Gtk.Button()
+        known_hosts_button.set_icon_name('view-list-symbolic')
+        known_hosts_button.set_tooltip_text(_('Known Hosts Editor'))
+        known_hosts_button.connect('clicked', lambda *_: window.show_known_hosts_editor())
+
         # Preferences button
         prefs_button = Gtk.Button()
         prefs_button.set_icon_name('preferences-system-symbolic')
         prefs_button.set_tooltip_text(_('Preferences'))
         prefs_button.connect('clicked', lambda *_: window.show_preferences())
-        
+
         buttons_box.append(search_button)
         buttons_box.append(local_button)
+        buttons_box.append(known_hosts_button)
         buttons_box.append(prefs_button)
         self.append(buttons_box)
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1005,6 +1005,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         menu.append('Create Group', 'win.create-group')
         menu.append('Local Terminal', 'app.local-terminal')
         menu.append('Copy Key to Server', 'app.new-key')
+        menu.append('Known Hosts Editor', 'win.edit-known-hosts')
         menu.append('Broadcast Command', 'app.broadcast-command')
         menu.append('Preferences', 'app.preferences')
 
@@ -1704,6 +1705,16 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 md.present()
             except Exception:
                 pass
+
+    def show_known_hosts_editor(self):
+        """Show known hosts editor window"""
+        logger.info("Show known hosts editor window")
+        try:
+            from .known_hosts_editor import KnownHostsEditorWindow
+            editor = KnownHostsEditorWindow(self, self.connection_manager)
+            editor.present()
+        except Exception as e:
+            logger.error(f"Failed to open known hosts editor: {e}")
 
     def show_preferences(self):
         """Show preferences dialog"""


### PR DESCRIPTION
## Summary
- Introduce `KnownHostsEditorWindow` for in-place editing of the operation-mode known_hosts file.
- Register `edit-known-hosts` window action and surface it via application menu and welcome page button.
- Support removing individual known host entries and saving or cancelling edits.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ab53ab588328ac2c2a7c0525172a