### PR TITLE
feat: add omnibox search to welcome page

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -5,13 +5,15 @@ import shlex
 import re
 
 gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk, Gdk, Adw
 from gettext import gettext as _
 
 
 from .connection_manager import Connection
 from .platform_utils import is_macos
+from .search_utils import connection_matches
 
 
 class WelcomePage(Gtk.Box):
@@ -43,6 +45,12 @@ class WelcomePage(Gtk.Box):
 
         self.quick_entry.set_placeholder_text(_('ssh -p 2222 user@host'))
         self.quick_entry.connect('activate', self.on_quick_connect)
+        self.quick_entry.connect('changed', self.on_quick_entry_changed)
+
+        # Key controller for navigation to search results
+        entry_key = Gtk.EventControllerKey()
+        entry_key.connect('key-pressed', self.on_quick_entry_key_pressed)
+        self.quick_entry.add_controller(entry_key)
         
         # Add focus controller for auto-expansion
         focus_controller = Gtk.EventControllerFocus()
@@ -54,6 +62,16 @@ class WelcomePage(Gtk.Box):
         self.quick_box.append(self.quick_entry)
         self.quick_box.append(connect_button)
         self.append(self.quick_box)
+
+        # Search results list (omni box)
+        self.search_list = Gtk.ListBox()
+        self.search_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        self.search_list.set_visible(False)
+        self.search_list.connect('row-activated', self.on_search_row_activated)
+        list_key = Gtk.EventControllerKey()
+        list_key.connect('key-pressed', self.on_search_results_key_pressed)
+        self.search_list.add_controller(list_key)
+        self.append(self.search_list)
 
 
         # Action buttons
@@ -119,6 +137,56 @@ class WelcomePage(Gtk.Box):
         if connection_data:
             connection = Connection(connection_data)
             self.window.terminal_manager.connect_to_host(connection, force_new=False)
+
+    def on_quick_entry_changed(self, entry):
+        """Update search results as text changes."""
+        text = entry.get_text().strip().lower()
+        # Clear previous results
+        child = self.search_list.get_first_child()
+        while child is not None:
+            next_child = child.get_next_sibling()
+            self.search_list.remove(child)
+            child = next_child
+        if not text:
+            self.search_list.set_visible(False)
+            return
+        matches = [c for c in self.connection_manager.connections if connection_matches(c, text)]
+        if not matches:
+            self.search_list.set_visible(False)
+            return
+        for conn in matches:
+            row = Adw.ActionRow()
+            row.set_title(conn.nickname)
+            subtitle = f"{conn.username+'@' if conn.username else ''}{conn.host}"
+            row.set_subtitle(subtitle)
+            row.connection = conn
+            self.search_list.append(row)
+        self.search_list.set_visible(True)
+
+    def on_search_row_activated(self, listbox, row):
+        """Connect to the selected connection from search results."""
+        connection = getattr(row, 'connection', None)
+        if connection:
+            self.window.terminal_manager.connect_to_host(connection, force_new=False)
+
+    def on_quick_entry_key_pressed(self, controller, keyval, keycode, state):
+        """Handle navigation from entry to results with arrow keys."""
+        if keyval == Gdk.KEY_Down and self.search_list.get_visible():
+            first = self.search_list.get_row_at_index(0)
+            if first:
+                self.search_list.select_row(first)
+                self.search_list.grab_focus()
+                return True
+        return False
+
+    def on_search_results_key_pressed(self, controller, keyval, keycode, state):
+        """Allow returning to entry when navigating results."""
+        if keyval == Gdk.KEY_Up:
+            selected = self.search_list.get_selected_row()
+            if selected and self.search_list.get_row_at_index(0) == selected:
+                self.quick_entry.grab_focus()
+                return True
+        return False
     
     def _parse_ssh_command(self, command_text):
         """Parse SSH command text and extract connection parameters"""


### PR DESCRIPTION
## Summary
- turn quick connect box into an omnibox that also searches saved connections
- show matching connections in a list and allow navigation with arrow keys and enter to connect
- fix clearing of search results for Gtk4

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1c184e45c8328a681d43940e41723