### PR TITLE
Improve welcome view focus behavior

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -28,10 +28,7 @@ class WelcomePage(Gtk.Box):
         self.set_margin_end(24)
         self.set_margin_top(24)
         self.set_margin_bottom(24)
-
-
-
-       
+        self.set_focus_on_click(False)
 
         # Quick connect box
         self.quick_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1210,7 +1210,8 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             except Exception:
                 pass
         self.content_stack.set_visible_child_name("welcome")
-        
+        GLib.idle_add(self._focus_connection_list_first_row)
+
         # Update view toggle button
         if hasattr(self, 'view_toggle_button'):
             # Check if there are any active tabs


### PR DESCRIPTION
## Summary
- Disable focus-on-click for the welcome page container so it no longer steals keyboard focus from its children
- Focus the connection list after displaying the welcome view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1db7b75c88328ad62ff3ddc072b78