### PR TITLE
Use navigation style for connection list

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -635,6 +635,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         scrolled.set_vexpand(True)
         
         self.connection_list = Gtk.ListBox()
+        self.connection_list.add_css_class("navigation-sidebar")
         self.connection_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
         try:
             self.connection_list.set_can_focus(True)


### PR DESCRIPTION
## Summary
- style the connection list as a navigation sidebar to get default spacing and selection highlight

## Testing
- `pytest`
- `python -m sshpilot.main` *(fails: ModuleNotFoundError: No module named 'gi')*


------
https://chatgpt.com/codex/tasks/task_e_68c27bd60fa48328b0fd2299c0510234