### PR TITLE
Handle GObject.Value in sidebar drop to restore connection reordering

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -508,6 +508,13 @@ def _on_connection_list_drop(window, target, value, x, y):
             window._drag_in_progress = False
             window.connection_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
 
+        # Extract Python object from GObject.Value drops
+        if isinstance(value, GObject.Value):
+            try:
+                value = value.get_boxed()
+            except Exception:
+                value = None
+
         if not isinstance(value, dict):
             return False
 


### PR DESCRIPTION
## Summary
- unwrap `GObject.Value` payloads in sidebar drop handler so drag-and-drop reordering works again

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3232bb62483289f3e7149f6413414