### PR TITLE
Preserve connection group on rename

### DIFF
--- a/sshpilot/groups.py
+++ b/sshpilot/groups.py
@@ -136,6 +136,26 @@ class GroupManager:
 
         self._save_groups()
 
+    def rename_connection(self, old_nickname: str, new_nickname: str):
+        """Rename a connection while preserving its group membership."""
+        if old_nickname == new_nickname:
+            return
+
+        group_id = self.connections.pop(old_nickname, None)
+        self.connections[new_nickname] = group_id
+
+        if group_id and group_id in self.groups:
+            conn_list = self.groups[group_id].get('connections', [])
+            if old_nickname in conn_list:
+                idx = conn_list.index(old_nickname)
+                conn_list[idx] = new_nickname
+        else:
+            if old_nickname in self.root_connections:
+                idx = self.root_connections.index(old_nickname)
+                self.root_connections[idx] = new_nickname
+
+        self._save_groups()
+
     def get_group_hierarchy(self) -> List[Dict]:
         """Get the complete group hierarchy"""
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -5037,10 +5037,20 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 except Exception:
                     connection_data['auth_method'] = 0
 
+                original_nickname = old_connection.nickname
+
                 # Update connection in manager first
                 if not self.connection_manager.update_connection(old_connection, connection_data):
                     logger.error("Failed to update connection in SSH config")
                     return
+
+                # Preserve group assignment if nickname changed
+                new_nickname = connection_data['nickname']
+                if original_nickname != new_nickname:
+                    try:
+                        self.group_manager.rename_connection(original_nickname, new_nickname)
+                    except Exception:
+                        pass
 
                 # Update connection attributes in memory (ensure forwarding rules kept)
                 old_connection.nickname = connection_data['nickname']

--- a/tests/test_group_connection_rename.py
+++ b/tests/test_group_connection_rename.py
@@ -1,0 +1,40 @@
+import sys
+import types
+
+# Ensure Gio stub for Config import
+if 'gi.repository' in sys.modules:
+    repo = sys.modules['gi.repository']
+    if not hasattr(repo, 'Gio'):
+        class DummySettingsSchemaSource:
+            @staticmethod
+            def get_default():
+                return None
+        repo.Gio = types.SimpleNamespace(SettingsSchemaSource=DummySettingsSchemaSource)
+        sys.modules['gi.repository.Gio'] = repo.Gio
+
+from sshpilot.groups import GroupManager
+
+
+class DummyConfig:
+    def __init__(self):
+        self.settings = {}
+
+    def get_setting(self, key, default=None):
+        return self.settings.get(key, default)
+
+    def set_setting(self, key, value):
+        self.settings[key] = value
+
+
+def test_rename_connection_preserves_group():
+    cfg = DummyConfig()
+    gm = GroupManager(cfg)
+    gid = gm.create_group("Test")
+    gm.move_connection("old", gid)
+    assert gm.get_connection_group("old") == gid
+
+    gm.rename_connection("old", "new")
+
+    assert gm.get_connection_group("new") == gid
+    assert "new" in gm.groups[gid]['connections']
+    assert "old" not in gm.groups[gid]['connections']


### PR DESCRIPTION
## Summary
- keep group membership when renaming a connection
- cover rename behavior with a dedicated test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3d5468cf483289da3cfd68219221c