### PR TITLE
Ensure font changes apply to existing local terminals and add Black on White theme

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -189,6 +189,20 @@ class Config(GObject.Object):
                     '#729FCF', '#AD7FA8', '#34E2E2', '#EEEEEC'
                 ]
             },
+            'black_on_white': {
+                'name': 'Black on White',
+                'foreground': '#000000',
+                'background': '#FFFFFF',
+                'cursor_color': '#000000',
+                'highlight_background': '#C4E3F3',
+                'highlight_foreground': '#000000',
+                'palette': [
+                    '#000000', '#CC0000', '#4E9A06', '#C4A000',
+                    '#3465A4', '#75507B', '#06989A', '#D3D7CF',
+                    '#555753', '#EF2929', '#8AE234', '#FCE94F',
+                    '#729FCF', '#AD7FA8', '#34E2E2', '#EEEEEC'
+                ]
+            },
             'solarized_dark': {
                 'name': 'Solarized Dark',
                 'foreground': '#839496',
@@ -484,7 +498,7 @@ class Config(GObject.Object):
 
     def remove_custom_theme(self, name: str):
         """Remove a custom theme"""
-        if name in self.terminal_themes and name not in ['default', 'dark', 'light', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark']:
+        if name in self.terminal_themes and name not in ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark']:
             del self.terminal_themes[name]
             
             # Remove from config
@@ -565,7 +579,7 @@ class Config(GObject.Object):
                 config_data = self.config_data.copy()
             
             # Add custom themes
-            builtin = ['default', 'dark', 'light', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark']
+            builtin = ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark']
             config_data['custom_themes'] = {name: theme for name, theme in self.terminal_themes.items() if name not in builtin}
             
             with open(file_path, 'w') as f:

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -368,6 +368,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             
             color_schemes = Gtk.StringList()
             color_schemes.append("Default")
+            color_schemes.append("Black on White")
             color_schemes.append("Solarized Dark")
             color_schemes.append("Solarized Light")
             color_schemes.append("Monokai")
@@ -389,7 +390,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             
             # Find the index of the current scheme in the dropdown
             scheme_names = [
-                "Default", "Solarized Dark", "Solarized Light",
+                "Default", "Black on White", "Solarized Dark", "Solarized Light",
                 "Monokai", "Dracula", "Nord",
                 "Gruvbox Dark", "One Dark", "Tomorrow Night", "Material Dark"
             ]
@@ -1172,7 +1173,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         """Get mapping between display names and config keys"""
         return {
             "Default": "default",
-            "Solarized Dark": "solarized_dark", 
+            "Black on White": "black_on_white",
+            "Solarized Dark": "solarized_dark",
             "Solarized Light": "solarized_light",
             "Monokai": "monokai",
             "Dracula": "dracula",
@@ -1192,7 +1194,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         """Handle terminal color scheme change"""
         selected = combo_row.get_selected()
         scheme_names = [
-            "Default", "Solarized Dark", "Solarized Light",
+            "Default", "Black on White", "Solarized Dark", "Solarized Light",
             "Monokai", "Dracula", "Nord",
             "Gruvbox Dark", "One Dark", "Tomorrow Night", "Material Dark"
         ]
@@ -1282,6 +1284,16 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 'background': '#000000',
                 'foreground': '#ffffff',
                 'blue': '#0088ff',
+                'green': '#00ff00',
+                'red': '#ff0000',
+                'yellow': '#ffff00',
+                'magenta': '#ff00ff',
+                'cyan': '#00ffff'
+            },
+            'black_on_white': {
+                'background': '#ffffff',
+                'foreground': '#000000',
+                'blue': '#0000ff',
                 'green': '#00ff00',
                 'red': '#ff0000',
                 'yellow': '#ffff00',

--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -165,6 +165,13 @@ class TerminalManager:
             terminal_widget = TerminalWidget(local_connection, self.window.config, self.window.connection_manager)
             terminal_widget.setup_local_shell()
             self._add_terminal_tab(terminal_widget, "Local Terminal")
+
+            # Register terminal so theme/font updates affect existing local tabs
+            window = self.window
+            window.connection_to_terminals.setdefault(local_connection, []).append(terminal_widget)
+            window.terminal_to_connection[terminal_widget] = local_connection
+            window.active_terminals[local_connection] = terminal_widget
+
             GLib.idle_add(terminal_widget.show)
             GLib.idle_add(terminal_widget.vte.show)
             logger.info("Local terminal tab created successfully")


### PR DESCRIPTION
## Summary
- Track local terminals so font and theme changes apply immediately
- Introduce a built-in "Black on White" terminal color scheme and expose it in preferences

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4409252dc8328b0ec759a3e1896e4