### PR TITLE
Remove Ctrl+B sidebar shortcut

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -687,7 +687,9 @@ def register_window_actions(window):
         window.add_action(sidebar_action)
         app = window.get_application()
         if app:
-            sidebar_shortcut = '<Meta>b' if is_macos() else '<Primary>b'
-            app.set_accels_for_action('win.toggle_sidebar', ['F9', sidebar_shortcut])
+            shortcuts = ['F9']
+            if is_macos():
+                shortcuts.append('<Meta>b')
+            app.set_accels_for_action('win.toggle_sidebar', shortcuts)
     except Exception as e:
         logger.error(f"Failed to register sidebar toggle action: {e}")

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1899,8 +1899,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         group_general = Gtk.ShortcutsGroup()
         group_general.add_shortcut(Gtk.ShortcutsShortcut(
             title=_('Toggle Sidebar'), accelerator='F9'))
-        group_general.add_shortcut(Gtk.ShortcutsShortcut(
-            title=_('Toggle Sidebar'), accelerator=f"{primary}b"))
+        if mac:
+            group_general.add_shortcut(Gtk.ShortcutsShortcut(
+                title=_('Toggle Sidebar'), accelerator=f"{primary}b"))
         group_general.add_shortcut(Gtk.ShortcutsShortcut(
             title=_('Preferences'), accelerator=f"{primary}comma"))
         group_general.add_shortcut(Gtk.ShortcutsShortcut(


### PR DESCRIPTION
## Summary
- avoid conflicts with tmux by removing the Ctrl+B sidebar shortcut
- keep F9 on all platforms and Cmd+B only on macOS; update shortcuts overlay accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c567594c4083288776fb8929ed471d