### PR TITLE
Remove askpass fallbacks to allow interactive SSH prompts

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -289,8 +289,17 @@ def get_ssh_env_with_askpass(require: str = "prefer") -> dict:
     return env
 
 def get_ssh_env_with_askpass_for_password(host: str, username: str) -> dict:
-    """Get SSH environment with askpass for password authentication"""
-    env = get_ssh_env_with_askpass("force")
+    """Return a copy of the environment without SSH_ASKPASS variables.
+
+    Previously this helper forced use of the askpass script for password
+    authentication.  We now want the OpenSSH client to prompt the user
+    directly when sshpass is unavailable, so we explicitly strip any
+    askpass related variables that might interfere with interactive
+    prompts.
+    """
+    env = os.environ.copy()
+    env.pop("SSH_ASKPASS", None)
+    env.pop("SSH_ASKPASS_REQUIRE", None)
     return env
 
 def get_ssh_env_with_forced_askpass() -> dict:

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -28,7 +28,6 @@ except Exception:
 import socket
 import time
 from gi.repository import GObject, GLib
-from .askpass_utils import get_ssh_env_with_askpass, get_ssh_env_with_askpass_for_password
 
 # Set up asyncio event loop for GTK integration
 if os.name == 'posix':
@@ -418,11 +417,10 @@ class Connection:
             # Log the full command (without sensitive data)
             logger.debug(f"SSH command: {' '.join(ssh_cmd[:10])}...")
             
-            # Set up askpass environment to prevent Flatpak from using system askpass
-            from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
-            ensure_askpass_script()
+            # Ensure ssh can prompt interactively by removing any askpass settings
             env = os.environ.copy()
-            env.update(get_ssh_env_with_askpass_for_password(self.host, self.username))
+            env.pop("SSH_ASKPASS", None)
+            env.pop("SSH_ASKPASS_REQUIRE", None)
             
             # Start the SSH process
             logger.info(f"Starting dynamic port forwarding with command: {' '.join(ssh_cmd)}")
@@ -502,11 +500,10 @@ class Connection:
                 '-L', f"{listen_addr}:{listen_port}:{remote_host}:{remote_port}"
             ]
             
-            # Set up askpass environment to prevent Flatpak from using system askpass
-            from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
-            ensure_askpass_script()
+            # Ensure ssh can prompt interactively by removing any askpass settings
             env = os.environ.copy()
-            env.update(get_ssh_env_with_askpass_for_password(self.host, self.username))
+            env.pop("SSH_ASKPASS", None)
+            env.pop("SSH_ASKPASS_REQUIRE", None)
             
             # Start the SSH process
             self.process = await asyncio.create_subprocess_exec(
@@ -552,11 +549,10 @@ class Connection:
                 '-R', f"{listen_addr}:{listen_port}:{remote_host}:{remote_port}"
             ]
             
-            # Set up askpass environment to prevent Flatpak from using system askpass
-            from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
-            ensure_askpass_script()
+            # Ensure ssh can prompt interactively by removing any askpass settings
             env = os.environ.copy()
-            env.update(get_ssh_env_with_askpass_for_password(self.host, self.username))
+            env.pop("SSH_ASKPASS", None)
+            env.pop("SSH_ASKPASS_REQUIRE", None)
             
             # Start the SSH process
             self.process = await asyncio.create_subprocess_exec(

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -18,7 +18,6 @@ import weakref
 import subprocess
 import pwd
 from datetime import datetime
-from .askpass_utils import ensure_askpass_script, get_ssh_env_with_askpass_for_password
 from .port_utils import get_port_checker
 from .platform_utils import is_macos
 
@@ -796,10 +795,10 @@ class TerminalWidget(Gtk.Box):
                     # Store tmpdir for cleanup
                     self._sshpass_tmpdir = tmpdir
                 else:
-                    # sshpass not available, fallback to askpass for password prompts
-                    ensure_askpass_script()
-                    askpass_env = get_ssh_env_with_askpass_for_password(self.connection.host, self.connection.username)
-                    env.update(askpass_env)
+                    # sshpass not available – allow interactive password prompt
+                    env.pop("SSH_ASKPASS", None)
+                    env.pop("SSH_ASKPASS_REQUIRE", None)
+                    logger.warning("sshpass not available; falling back to interactive password prompt")
             elif (password_auth_selected or auth_method == 0) and not has_saved_password:
                 # Password may be required but none saved - allow interactive prompt
                 logger.debug("No saved password - using interactive prompt if required")
@@ -888,25 +887,21 @@ class TerminalWidget(Gtk.Box):
             self._on_connection_failed(str(e))
     
     def _fallback_to_askpass(self, ssh_cmd, env_list):
-        """Fallback method when sshpass fails - use askpass instead"""
+        """Fallback when sshpass fails - allow interactive prompting"""
         try:
-            logger.info("Falling back to askpass method for password authentication")
-            
+            logger.info("Falling back to interactive password prompt")
+
             # Remove sshpass from the command
-            if ssh_cmd[0] == 'sshpass':
+            if ssh_cmd and ssh_cmd[0] == 'sshpass':
                 ssh_cmd = ssh_cmd[3:]  # Remove sshpass, -f, and fifo_path
-            
-            # Set up askpass environment
-            from .askpass_utils import get_ssh_env_with_askpass_for_password
-            askpass_env = get_ssh_env_with_askpass_for_password(self.connection.host, self.connection.username)
-            
-            # Update environment list
-            for key, value in askpass_env.items():
-                env_list.append(f"{key}={value}")
-            
+
+            # Strip any askpass variables from the environment list
+            env_list = [e for e in env_list if not e.startswith('SSH_ASKPASS')]
+            env_list = [e for e in env_list if not e.startswith('SSH_ASKPASS_REQUIRE')]
+
             logger.debug(f"Fallback SSH command: {ssh_cmd}")
-            
-            # Try spawning again with askpass
+
+            # Try spawning again without askpass
             self.vte.spawn_async(
                 Vte.PtyFlags.DEFAULT,
                 os.path.expanduser('~') or '/',
@@ -920,9 +915,8 @@ class TerminalWidget(Gtk.Box):
                 self._on_spawn_complete,
                 ()
             )
-            
         except Exception as e:
-            logger.error(f"Fallback to askpass also failed: {e}")
+            logger.error(f"Fallback to interactive prompt failed: {e}")
             self._on_connection_failed(str(e))
     
     def _on_spawn_complete(self, terminal, pid, error, user_data=None):

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -39,7 +39,6 @@ from .config import Config
 from .key_manager import KeyManager, SSHKey
 # Port forwarding UI is now integrated into connection_dialog.py
 from .connection_dialog import ConnectionDialog
-from .askpass_utils import ensure_askpass_script
 from .preferences import (
     PreferencesWindow,
     is_running_in_flatpak,
@@ -2618,12 +2617,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     import atexit
                     atexit.register(cleanup_tmpdir)
                 else:
-                    # sshpass not available, fallback to askpass
-                    logger.debug("Main window: sshpass not available, falling back to askpass")
-                    from .askpass_utils import get_ssh_env_with_askpass
-                    askpass_env = get_ssh_env_with_askpass()
-                    logger.debug(f"Main window: Askpass environment variables: {list(askpass_env.keys())}")
-                    env.update(askpass_env)
+                    # sshpass not available – allow interactive password prompt
+                    logger.warning("Main window: sshpass not available, falling back to interactive prompt")
+                    env.pop("SSH_ASKPASS", None)
+                    env.pop("SSH_ASKPASS_REQUIRE", None)
             elif (prefer_password or combined_auth) and not has_saved_password:
                 # Password may be required but none saved - let SSH prompt interactively
                 # Don't set any askpass environment variables
@@ -3054,13 +3051,20 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
             # Handle environment variables for authentication
             env = os.environ.copy()
-            
+
             # Check if we have stored askpass environment from key passphrase handling
             if hasattr(self, '_scp_askpass_env') and self._scp_askpass_env:
                 env.update(self._scp_askpass_env)
                 logger.debug(f"SCP: Using askpass environment for key passphrase: {list(self._scp_askpass_env.keys())}")
                 # Clear the stored environment after use
                 self._scp_askpass_env = {}
+
+            # If sshpass was unavailable earlier, ensure askpass is cleared
+            if getattr(self, '_scp_strip_askpass', False):
+                env.pop("SSH_ASKPASS", None)
+                env.pop("SSH_ASKPASS_REQUIRE", None)
+                logger.debug("SCP: Removed SSH_ASKPASS variables for interactive password prompt")
+                self._scp_strip_askpass = False
                 
                 # For key-based auth, ensure the key is loaded in SSH agent first
                 try:
@@ -3305,14 +3309,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                             import atexit
                             atexit.register(cleanup_tmpdir)
                         else:
-                            # sshpass not available → use askpass env (same pattern as in ssh-copy-id path)
-                            from .askpass_utils import get_ssh_env_with_askpass
-                            askpass_env = get_ssh_env_with_askpass("force")
-                            # Store for later use in the main execution
-                            if not hasattr(self, '_scp_askpass_env'):
-                                self._scp_askpass_env = {}
-                            self._scp_askpass_env.update(askpass_env)
-                            logger.debug("SCP: sshpass unavailable, using SSH_ASKPASS fallback")
+                            # sshpass not available – allow interactive password prompt
+                            logger.warning("SCP: sshpass unavailable, falling back to interactive prompt")
+                            self._scp_strip_askpass = True
                     else:
                         # No saved password - will use interactive prompt
                         logger.debug("SCP: Password auth selected but no saved password - using interactive prompt")


### PR DESCRIPTION
## Summary
- avoid forcing askpass when sshpass is unavailable so OpenSSH can prompt interactively
- clear `SSH_ASKPASS` variables across terminal, window operations and port forwarding
- repurpose helper utilities to strip askpass settings and simplify password exec helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5694dcc308328b1be6b601a5761c0