### PR TITLE
Rename proxy group to ProxyJump and reorder connection groups

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -2082,23 +2082,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         self.port_row.set_text("22")
         basic_group.add(self.port_row)
 
-        # Proxy Group
-        proxy_group = Adw.PreferencesGroup(title=_("Proxy"))
-
-        # ProxyJump hosts (comma-separated for multiple hops)
-        self.proxy_jump_row = Adw.EntryRow(title=_("Proxy Jump"))
-        try:
-            self.proxy_jump_row.set_subtitle(_("Comma-separated hosts"))
-        except Exception:
-            pass
-        proxy_group.add(self.proxy_jump_row)
-
-        # Agent forwarding toggle
-        self.forward_agent_row = Adw.SwitchRow()
-        self.forward_agent_row.set_title(_("Agent Forwarding"))
-        self.forward_agent_row.set_active(False)
-        proxy_group.add(self.forward_agent_row)
-
         # Authentication Group
         auth_group = Adw.PreferencesGroup(title=_("Authentication"))
         
@@ -2243,9 +2226,30 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         self.pubkey_auth_row.set_title(_("Disable public key authentication (force password only)"))
         self.pubkey_auth_row.set_active(False)
         auth_group.add(self.pubkey_auth_row)
-        
 
-        
+        # ProxyJump Group
+        proxy_group = Adw.PreferencesGroup(title=_("ProxyJump"))
+
+        # ProxyJump hosts (comma-separated for multiple hops)
+        self.proxy_jump_row = Adw.EntryRow(title=_("ProxyJump"))
+        try:
+            self.proxy_jump_row.set_subtitle(_("Comma-separated hosts"))
+        except Exception:
+            pass
+        self.proxy_jump_row.set_placeholder_text(
+            _(
+                "multiple, comma-separated hostnames supported  "
+                "example: bastion1,bastion2,bastion3"
+            )
+        )
+        proxy_group.add(self.proxy_jump_row)
+
+        # Agent forwarding toggle
+        self.forward_agent_row = Adw.SwitchRow()
+        self.forward_agent_row.set_title(_("Agent Forwarding"))
+        self.forward_agent_row.set_active(False)
+        proxy_group.add(self.forward_agent_row)
+
         # Remove unused advanced label group from this page
         advanced_group = Adw.PreferencesGroup()
         advanced_group.set_visible(False)
@@ -2460,7 +2464,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # X11 Forwarding moved to Port Forwarding view
         
         # Return groups for PreferencesPage
-        return [basic_group, proxy_group, auth_group, advanced_group]
+        return [basic_group, auth_group, proxy_group, advanced_group]
     
     def build_port_forwarding_groups(self):
         """Build PreferencesGroups for the Advanced page (Port Forwarding first, X11 last)"""


### PR DESCRIPTION
## Summary
- rename Proxy group and entry to ProxyJump
- add descriptive placeholder for ProxyJump hosts
- reorder connection groups and return order to Basic, Auth, ProxyJump, Advanced

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5741e029883289ba73f55585f91a5