### PR TITLE
Treat local terminals as idle

### DIFF
--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -160,7 +160,7 @@ class TerminalManager:
                     self.host = "localhost"
                     self.username = os.getenv('USER', 'user')
                     self.port = 22
-                    self.is_connected = True
+                    self.is_connected = False
             local_connection = LocalConnection()
             terminal_widget = TerminalWidget(local_connection, self.window.config, self.window.connection_manager)
             terminal_widget.setup_local_shell()

--- a/tests/test_single_idle_local_terminal.py
+++ b/tests/test_single_idle_local_terminal.py
@@ -91,7 +91,7 @@ def test_single_idle_local_terminal_allows_close():
     import sshpilot.window as window
 
     class DummyTerm:
-        is_connected = True
+        is_connected = False
 
         def has_active_foreground_job(self):
             return False


### PR DESCRIPTION
## Summary
- ensure local terminals remain idle: only remote shells mark `is_connected`
- start local terminals with `is_connected=False`
- test window closes immediately when only an idle local terminal remains

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b22ba6288328a48a688e3c9dcc73