### PR TITLE
test: simulate local terminal to verify idle close

### DIFF
--- a/tests/test_single_idle_local_terminal.py
+++ b/tests/test_single_idle_local_terminal.py
@@ -1,3 +1,6 @@
+import os
+import signal
+import subprocess
 import sys
 import types
 
@@ -14,15 +17,24 @@ def test_single_idle_local_terminal_allows_close():
             return Module()
 
     repo = Module()
-    repo.Gtk = Module(ApplicationWindow=type("ApplicationWindow", (), {}))
-    repo.Adw = Module()
+    repo.Gtk = Module(
+        ApplicationWindow=type("ApplicationWindow", (), {}),
+        Box=type("Box", (), {}),
+        Orientation=types.SimpleNamespace(VERTICAL=0),
+        ScrolledWindow=type("ScrolledWindow", (), {}),
+        PolicyType=types.SimpleNamespace(AUTOMATIC=0),
+    )
+    repo.Adw = Module(ApplicationWindow=type("ApplicationWindow", (), {}))
     repo.Gio = Module()
-    repo.GLib = Module()
+    repo.GLib = Module(
+        SpawnFlags=types.SimpleNamespace(DEFAULT=0),
+        source_remove=lambda *a, **k: None,
+    )
     repo.GObject = Module()
     repo.Gdk = Module()
     repo.Pango = Module()
     repo.PangoFT2 = Module()
-    repo.Vte = Module()
+    repo.Vte = Module(PtyFlags=types.SimpleNamespace(DEFAULT=0))
 
     gi_module.repository = repo
     original_gi = {
@@ -60,20 +72,94 @@ def test_single_idle_local_terminal_allows_close():
 
     Gtk = repo.Gtk
 
+    import sshpilot.terminal as terminal
+
+    class StubPty:
+        def __init__(self, fd):
+            self._fd = fd
+
+        def get_slave_fd(self):
+            return os.dup(self._fd)
+
+    class StubVteTerminal:
+        def __init__(self, widget):
+            self.widget = widget
+            self._pty = None
+            self.child = None
+
+        def get_pty(self):
+            return self._pty
+
+        def spawn_async(
+            self,
+            flags,
+            working_dir,
+            argv,
+            envv,
+            spawn_flags,
+            child_setup,
+            child_setup_data,
+            timeout,
+            cancellable,
+            callback,
+            user_data,
+        ):
+            master, slave = os.openpty()
+            env = {k.split("=", 1)[0]: k.split("=", 1)[1] for k in envv}
+            proc = subprocess.Popen(
+                argv,
+                stdin=slave,
+                stdout=slave,
+                stderr=slave,
+                preexec_fn=os.setsid,
+                env=env,
+            )
+            os.close(master)
+            self.child = proc
+            self._pty = StubPty(slave)
+            callback(self.widget, proc.pid, None, user_data)
+
+        def grab_focus(self):
+            pass
+
+    class DummyTerminal:
+        has_active_foreground_job = terminal.TerminalWidget.has_active_foreground_job
+        setup_local_shell = terminal.TerminalWidget.setup_local_shell
+        _on_spawn_complete = terminal.TerminalWidget._on_spawn_complete
+
+        def __init__(self):
+            self.config = object()
+            self.connection_manager = object()
+            self.connection = types.SimpleNamespace(host="localhost")
+            self.vte = StubVteTerminal(self)
+            self.emit = lambda *a, **k: None
+            self.setup_terminal = lambda: None
+            self._set_connecting_overlay_visible = lambda *a, **k: None
+            self.apply_theme = lambda: None
+            self._set_disconnected_banner_visible = lambda *a, **k: None
+            self.is_connected = False
+            self._is_quitting = False
+            self.session_id = "dummy"
 
     stub_modules = {
-        'sshpilot.terminal': types.SimpleNamespace(TerminalWidget=object),
         'sshpilot.terminal_manager': types.SimpleNamespace(TerminalManager=lambda window: None),
         'sshpilot.connection_manager': types.SimpleNamespace(ConnectionManager=lambda: None, Connection=object),
         'sshpilot.config': types.SimpleNamespace(Config=lambda: types.SimpleNamespace(get_setting=lambda *a, **k: False)),
         'sshpilot.key_manager': types.SimpleNamespace(KeyManager=lambda: None, SSHKey=object),
         'sshpilot.connection_dialog': types.SimpleNamespace(ConnectionDialog=object),
-        'sshpilot.preferences': types.SimpleNamespace(PreferencesWindow=object, is_running_in_flatpak=lambda: False,
-                                                      should_hide_external_terminal_options=lambda: False,
-                                                      should_hide_file_manager_options=lambda: False),
+        'sshpilot.preferences': types.SimpleNamespace(
+            PreferencesWindow=object,
+            is_running_in_flatpak=lambda: False,
+            should_hide_external_terminal_options=lambda: False,
+            should_hide_file_manager_options=lambda: False,
+        ),
         'sshpilot.sshcopyid_window': types.SimpleNamespace(SshCopyIdWindow=object),
         'sshpilot.groups': types.SimpleNamespace(GroupManager=lambda config: None),
-        'sshpilot.sidebar': types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
+        'sshpilot.sidebar': types.SimpleNamespace(
+            GroupRow=object,
+            ConnectionRow=object,
+            build_sidebar=lambda *a, **k: None,
+        ),
         'sshpilot.sftp_utils': types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
         'sshpilot.welcome_page': types.SimpleNamespace(WelcomePage=object),
         'sshpilot.actions': types.SimpleNamespace(WindowActions=object, register_window_actions=lambda window: None),
@@ -90,26 +176,23 @@ def test_single_idle_local_terminal_allows_close():
 
     import sshpilot.window as window
 
-    class DummyTerm:
-        is_connected = False
-
-        def has_active_foreground_job(self):
-            return False
+    term = DummyTerminal()
+    term.setup_local_shell()
 
     class DummyConn:
-        nickname = 'Local Terminal'
+        nickname = "Local Terminal"
 
     class DummyWindow(Gtk.ApplicationWindow):
         on_close_request = window.MainWindow.on_close_request
 
     win = DummyWindow()
     win._is_quitting = False
-    win.connection_to_terminals = {DummyConn(): [DummyTerm()]}
+    win.connection_to_terminals = {DummyConn(): [term]}
 
-    called = {'dialog': False}
+    called = {"dialog": False}
 
     def fake_show(self):
-        called['dialog'] = True
+        called["dialog"] = True
 
     original_show = window.MainWindow.show_quit_confirmation_dialog
     window.MainWindow.show_quit_confirmation_dialog = fake_show
@@ -128,7 +211,9 @@ def test_single_idle_local_terminal_allows_close():
                 del sys.modules[name]
             else:
                 sys.modules[name] = old
-
+        if term.vte.child:
+            os.killpg(term.process_pgid, signal.SIGTERM)
 
     assert result is False
-    assert called['dialog'] is False
+    assert called["dialog"] is False
+


### PR DESCRIPTION
## Summary
- stub GTK/VTE dependencies to import real TerminalWidget
- run local shell setup to provide PTY and pgid
- verify idle local terminal closes without confirmation

## Testing
- `pytest tests/test_single_idle_local_terminal.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b31dda6c832882b43f0894b22931