### PR TITLE
Improve local terminal idle detection and quit warnings

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -2181,8 +2181,8 @@ class TerminalWidget(Gtk.Box):
         try:
             if not hasattr(self, 'connection') or not self.connection:
                 return False
-            return (hasattr(self.connection, 'host') and 
-                   self.connection.host == 'localhost')
+            host = getattr(self.connection, 'host', '')
+            return host in ('localhost', '127.0.0.1', '::1')
         except Exception:
             return False
 
@@ -2278,9 +2278,9 @@ class TerminalWidget(Gtk.Box):
                 logger.debug(f"Local terminal PTY job detection: fg_pgid={fg_pgid}, shell_pgid={self._shell_pgid}, idle={idle}")
                 return idle
             
-            # If no shell PGID stored, assume idle (conservative approach)
-            logger.debug(f"Local terminal PTY job detection: fg_pgid={fg_pgid}, no shell_pgid stored, assuming idle")
-            return True
+            # If no shell PGID stored, treat as non-idle (unknown state)
+            logger.debug(f"Local terminal PTY job detection: fg_pgid={fg_pgid}, no shell_pgid stored, treating as active")
+            return False
             
         except Exception as e:
             logger.debug(f"Error in PTY job detection: {e}")

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -3818,14 +3818,12 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             return False  # Already quitting, allow close
             
         # Check for active connections across all tabs
-        actually_connected = {}
         local_terminals = []
         ssh_terminals = []
-        
+
         for conn, terms in self.connection_to_terminals.items():
             for term in terms:
                 if getattr(term, 'is_connected', False):
-                    actually_connected.setdefault(conn, []).append(term)
                     # Categorize terminals
                     if hasattr(term, '_is_local_terminal') and term._is_local_terminal():
                         local_terminals.append(term)
@@ -3863,21 +3861,19 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             logger.debug(f"Failed to bring window to foreground: {e}")
         
         # Categorize connected terminals
-        connected_items = []
-        local_terminals = []
-        ssh_terminals = []
-        
+        local_active: List[Tuple[Connection, TerminalWidget]] = []
+        ssh_terminals: List[Tuple[Connection, TerminalWidget]] = []
+
         for conn, terms in self.connection_to_terminals.items():
             for term in terms:
                 if getattr(term, 'is_connected', False):
-                    connected_items.append((conn, term))
-                    # Categorize terminals
                     if hasattr(term, '_is_local_terminal') and term._is_local_terminal():
-                        local_terminals.append((conn, term))
+                        if getattr(term, 'has_active_job', None) and term.has_active_job():
+                            local_active.append((conn, term))
                     else:
                         ssh_terminals.append((conn, term))
-        
-        active_count = len(connected_items)
+
+        active_count = len(local_active) + len(ssh_terminals)
         
         # Determine dialog content based on terminal types
         if ssh_terminals:

--- a/tests/test_terminal_idle_detection.py
+++ b/tests/test_terminal_idle_detection.py
@@ -1,0 +1,76 @@
+import sys
+import types
+import pytest
+
+
+def _stub_gi():
+    gi = types.ModuleType("gi")
+    gi.require_version = lambda *args, **kwargs: None
+
+    class Dummy(types.SimpleNamespace):
+        def __getattr__(self, name):
+            return Dummy()
+
+        def __call__(self, *args, **kwargs):
+            return Dummy()
+
+    repo = types.SimpleNamespace(
+        Gtk=types.SimpleNamespace(Box=type("Box", (), {})),
+        Vte=Dummy(),
+        Adw=Dummy(),
+        GLib=Dummy(),
+        GObject=Dummy(),
+        Gdk=Dummy(),
+        Pango=Dummy(),
+        PangoFT2=Dummy(),
+        Gio=Dummy(),
+    )
+    gi.repository = repo
+
+    modules = {"gi": gi, "gi.repository": repo}
+    for name in ["Gtk", "Vte", "Adw", "GLib", "GObject", "Gdk", "Pango", "PangoFT2", "Gio"]:
+        modules[f"gi.repository.{name}"] = getattr(repo, name)
+    return modules
+
+
+@pytest.fixture
+def TerminalWidget():
+    modules = _stub_gi()
+    old = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    from sshpilot.terminal import TerminalWidget as TW
+    yield TW
+    for name, mod in old.items():
+        if mod is None:
+            del sys.modules[name]
+        else:
+            sys.modules[name] = mod
+
+
+def test_is_local_terminal_recognizes_loopback(TerminalWidget):
+    class Conn:
+        host = "localhost"
+
+    term = object.__new__(TerminalWidget)
+    term.connection = Conn()
+    assert term._is_local_terminal()
+    term.connection.host = "127.0.0.1"
+    assert term._is_local_terminal()
+    term.connection.host = "::1"
+    assert term._is_local_terminal()
+    term.connection.host = "example.com"
+    assert not term._is_local_terminal()
+
+
+def test_has_active_job_unknown_pgid(TerminalWidget, monkeypatch):
+    class Conn:
+        host = "localhost"
+
+    term = object.__new__(TerminalWidget)
+    term.connection = Conn()
+    term.vte = types.SimpleNamespace(get_pty=lambda: types.SimpleNamespace(get_fd=lambda: 0))
+    term._shell_pgid = None
+    monkeypatch.setattr(sys.modules["os"], "tcgetpgrp", lambda fd: 123)
+    assert term._is_terminal_idle_pty() is False
+    term._job_status = "UNKNOWN"
+    assert term.has_active_job()


### PR DESCRIPTION
## Summary
- count only local terminals with active jobs when warning on quit
- recognize 127.0.0.1 and ::1 as local terminals and treat unknown PGID as active
- add tests for loopback detection and idle fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5cf671d3c8328b13d913fa4b158d2