### PR TITLE
Optimize SSH process cleanup

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -159,11 +159,42 @@ class SSHProcessManager:
                 # Atomically extract and clear all processes
                 processes_to_clean = dict(self.processes)
                 self.processes.clear()
-            
+
             # Clean up processes without holding the lock
+            pgid_map = {}
             for pid, info in processes_to_clean.items():
-                logger.debug(f"Cleaning up process {pid} (command: {info.get('command', 'unknown')})")
-                self._terminate_process_by_pid(pid)
+                try:
+                    pgid = os.getpgid(pid)
+                    pgid_map[pid] = pgid
+                    os.killpg(pgid, signal.SIGTERM)
+                    logger.debug(
+                        f"Sent SIGTERM to process {pid} (command: {info.get('command', 'unknown')})"
+                    )
+                except Exception as e:
+                    logger.debug(f"Failed to send SIGTERM to {pid}: {e}")
+
+            # Wait for all processes to exit collectively
+            remaining = set(pgid_map.keys())
+            end_time = time.time() + 1.0  # 1 second max for all processes
+            while remaining and time.time() < end_time:
+                try:
+                    waited_pid, _ = os.waitpid(-1, os.WNOHANG)
+                    if waited_pid == 0:
+                        time.sleep(0.05)
+                        continue
+                    if waited_pid in remaining:
+                        remaining.remove(waited_pid)
+                except ChildProcessError:
+                    # No child processes remain
+                    break
+
+            # Force kill any remaining processes
+            for pid in remaining:
+                try:
+                    os.killpg(pgid_map.get(pid, pid), signal.SIGKILL)
+                    logger.debug(f"Force killed process {pid}")
+                except Exception as e:
+                    logger.debug(f"Failed to force kill {pid}: {e}")
             
             # Clean up terminals separately
             for terminal in list(self.terminals):


### PR DESCRIPTION
## Summary
- Improve SSHProcessManager cleanup by sending SIGTERM to all tracked processes and polling them collectively before forcing termination

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d3a778b48328bd24d9749da0697b