### PR TITLE
Add Flatpak detection utility

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -6,7 +6,6 @@ from gettext import gettext as _
 
 from .sftp_utils import open_remote_in_file_manager
 from .preferences import (
-    is_running_in_flatpak,
     should_hide_external_terminal_options,
     should_hide_file_manager_options,
 )

--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -1,8 +1,14 @@
 """Platform-related utility functions."""
 
+import os
 import platform
 
 
 def is_macos() -> bool:
     """Return True if running on macOS."""
     return platform.system() == "Darwin"
+
+
+def is_flatpak() -> bool:
+    """Return True if running inside a Flatpak sandbox."""
+    return os.environ.get("FLATPAK_ID") is not None or os.path.exists("/.flatpak-info")

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import shutil
 
-from .platform_utils import is_macos
+from .platform_utils import is_macos, is_flatpak
 
 import gi
 gi.require_version('Gtk', '4.0')
@@ -14,10 +14,6 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Gdk, Adw, Pango, PangoFT2
 
 logger = logging.getLogger(__name__)
-
-def is_running_in_flatpak() -> bool:
-    """Check if running inside Flatpak sandbox"""
-    return os.path.exists("/.flatpak-info") or os.environ.get("FLATPAK_ID") is not None
 
 def macos_third_party_terminal_available() -> bool:
     """Check if a third-party terminal is available on macOS."""
@@ -57,7 +53,7 @@ def should_hide_external_terminal_options() -> bool:
     Returns True when running in Flatpak or when on macOS without a supported
     third-party terminal.
     """
-    return is_running_in_flatpak() or (
+    return is_flatpak() or (
         is_macos() and not macos_third_party_terminal_available()
     )
 

--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple, Callable
 
 from gi.repository import Gtk, Adw, Gio, GLib, Gdk
 
-from .preferences import is_running_in_flatpak
+from .platform_utils import is_flatpak
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def open_remote_in_file_manager(
     if host in ("localhost", "127.0.0.1"):
         logger.info("Localhost detected, skipping SSH verification")
         progress_dialog.update_progress(0.3, "Mounting...")
-        if is_running_in_flatpak():
+        if is_flatpak():
             _open_sftp_flatpak_compatible(
                 uri, user, host, port, error_callback, progress_dialog
             )
@@ -66,7 +66,7 @@ def open_remote_in_file_manager(
 
         logger.info(f"SSH connection verified for {user}@{host}")
         progress_dialog.update_progress(0.3, "SSH verified, mounting...")
-        if is_running_in_flatpak():
+        if is_flatpak():
             _open_sftp_flatpak_compatible(
                 uri, user, host, port, error_callback, progress_dialog
             )
@@ -151,7 +151,7 @@ def _mount_and_open_sftp(
                     progress_dialog.show_error(error_msg)
 
                     # Try Flatpak-compatible methods as fallback
-                    if is_running_in_flatpak():
+                    if is_flatpak():
                         logger.info("Falling back to Flatpak-compatible methods")
                         GLib.idle_add(progress_dialog.close)
                         success, msg = _try_flatpak_compatible_mount(
@@ -195,7 +195,7 @@ def _mount_and_open_sftp(
         GLib.timeout_add(1500, lambda: GLib.idle_add(progress_dialog.close))
 
         # Try Flatpak-compatible methods as fallback
-        if is_running_in_flatpak():
+        if is_flatpak():
             logger.info(
                 "Primary mount failed, trying Flatpak-compatible methods"
             )

--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -5,7 +5,7 @@ from gi.repository import Gio, GLib, Adw, Gdk
 from gettext import gettext as _
 
 from .terminal import TerminalWidget
-from .preferences import is_running_in_flatpak, should_hide_external_terminal_options
+from .preferences import should_hide_external_terminal_options
 
 logger = logging.getLogger(__name__)
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -41,7 +41,6 @@ from .key_manager import KeyManager, SSHKey
 from .connection_dialog import ConnectionDialog
 from .preferences import (
     PreferencesWindow,
-    is_running_in_flatpak,
     should_hide_external_terminal_options,
     should_hide_file_manager_options,
 )

--- a/tests/test_macos_terminal.py
+++ b/tests/test_macos_terminal.py
@@ -47,7 +47,6 @@ stub_modules = {
     "sshpilot.askpass_utils": types.SimpleNamespace(ensure_askpass_script=lambda: None),
     "sshpilot.preferences": types.SimpleNamespace(
         PreferencesWindow=object,
-        is_running_in_flatpak=lambda: False,
         should_hide_external_terminal_options=lambda: False,
         should_hide_file_manager_options=lambda: False,
     ),

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -1,0 +1,20 @@
+import os
+from sshpilot import platform_utils
+
+
+def test_is_flatpak_env(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "io.github.mfat.sshpilot")
+    monkeypatch.setattr(platform_utils.os.path, "exists", lambda path: False)
+    assert platform_utils.is_flatpak() is True
+
+
+def test_is_flatpak_file(monkeypatch):
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    monkeypatch.setattr(platform_utils.os.path, "exists", lambda path: path == "/.flatpak-info")
+    assert platform_utils.is_flatpak() is True
+
+
+def test_is_flatpak_false(monkeypatch):
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    monkeypatch.setattr(platform_utils.os.path, "exists", lambda path: False)
+    assert platform_utils.is_flatpak() is False

--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -23,8 +23,11 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
         'sshpilot.key_manager': types.SimpleNamespace(KeyManager=lambda: None, SSHKey=object),
         'sshpilot.connection_dialog': types.SimpleNamespace(ConnectionDialog=object),
         'sshpilot.askpass_utils': types.SimpleNamespace(ensure_askpass_script=lambda: None),
-        'sshpilot.preferences': types.SimpleNamespace(PreferencesWindow=object, is_running_in_flatpak=lambda: False,
-                                                      should_hide_external_terminal_options=lambda: False),
+        'sshpilot.preferences': types.SimpleNamespace(
+            PreferencesWindow=object,
+            should_hide_external_terminal_options=lambda: False,
+            should_hide_file_manager_options=lambda: False,
+        ),
         'sshpilot.sshcopyid_window': types.SimpleNamespace(SshCopyIdWindow=object),
         'sshpilot.groups': types.SimpleNamespace(GroupManager=lambda config: None),
         'sshpilot.sidebar': types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),


### PR DESCRIPTION
## Summary
- detect Flatpak environment with new `is_flatpak` helper
- gate external terminal preference on `is_flatpak`
- use `is_flatpak` in SFTP utilities for Flatpak-specific handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5fb6523248328a25edc2d7bae6828