### PR TITLE
Store isolated-mode keys in config dir

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -8,6 +8,7 @@ import logging
 import math
 import shlex
 import time
+from pathlib import Path
 from typing import Optional, Dict, Any, List, Tuple, Callable
 
 import gi
@@ -54,7 +55,7 @@ from .actions import WindowActions, register_window_actions
 from . import shutdown
 from .search_utils import connection_matches
 from .shortcut_utils import get_primary_modifier_label
-from .platform_utils import is_macos
+from .platform_utils import is_macos, get_config_dir
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +72,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         # Initialize managers
         self.config = Config()
         effective_isolated = isolated or bool(self.config.get_setting('ssh.use_isolated_config', False))
+        key_dir = Path(get_config_dir()) if effective_isolated else None
         self.connection_manager = ConnectionManager(self.config, isolated_mode=effective_isolated)
-        self.key_manager = KeyManager()
+        self.key_manager = KeyManager(key_dir)
         self.group_manager = GroupManager(self.config)
         
         # UI state

--- a/tests/test_key_discovery.py
+++ b/tests/test_key_discovery.py
@@ -52,3 +52,56 @@ def test_discover_keys_recurses(tmp_path):
     paths = set(proc.stdout.strip().splitlines())
     assert str(root_key) in paths
     assert str(nested_key) in paths
+
+
+def test_generate_key_uses_config_dir_when_isolated(tmp_path):
+    # Skip if gi (PyGObject) is unavailable in system python
+    gi_check = subprocess.run([
+        "/usr/bin/python3", "-c", "import gi"
+    ])
+    if gi_check.returncode != 0:
+        pytest.skip("gi not available")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.getcwd()
+    env["XDG_CONFIG_HOME"] = str(tmp_path)
+
+    script = textwrap.dedent(
+        """
+        import subprocess
+        from pathlib import Path
+        from sshpilot.key_manager import KeyManager
+        from sshpilot.platform_utils import get_config_dir
+
+        class DummyResult:
+            def __init__(self):
+                self.returncode = 0
+                self.stdout = ''
+                self.stderr = ''
+
+        def fake_run(cmd, capture_output=True, text=True, check=False):
+            key_path = Path(cmd[cmd.index('-f') + 1])
+            key_path.write_text('dummy')
+            key_path.with_suffix(key_path.suffix + '.pub').write_text('dummy')
+            return DummyResult()
+
+        subprocess.run = fake_run
+
+        km = KeyManager(Path(get_config_dir()))
+        key = km.generate_key('testkey')
+        print(key.private_path)
+        """
+    )
+
+    proc = subprocess.run(
+        ["/usr/bin/python3", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+
+    key_path = tmp_path / "sshpilot" / "testkey"
+    assert proc.stdout.strip() == str(key_path)
+    assert key_path.exists()
+    assert key_path.with_suffix(".pub").exists()


### PR DESCRIPTION
## Summary
- store ssh keys in config directory when isolated mode is enabled
- test isolated mode key generation uses config dir

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7b6ce44388328948b93c6cfc5022f