### PR TITLE
test: mock libsecret in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,19 @@ if 'gi' not in sys.modules:
     repository = types.ModuleType('gi.repository')
     gi.repository = repository
     repository.GObject = types.SimpleNamespace(Object=object, SignalFlags=types.SimpleNamespace(RUN_FIRST=None))
-    repository.GLib = types.SimpleNamespace()
+    repository.GLib = types.SimpleNamespace(idle_add=lambda *a, **k: None)
     repository.Gtk = types.SimpleNamespace()
+    repository.Secret = types.SimpleNamespace(
+        Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+        SchemaFlags=types.SimpleNamespace(NONE=0),
+        password_store_sync=lambda *a, **k: True,
+        password_lookup_sync=lambda *a, **k: None,
+        password_clear_sync=lambda *a, **k: None,
+        COLLECTION_DEFAULT=None,
+    )
     sys.modules['gi'] = gi
     sys.modules['gi.repository'] = repository
     sys.modules['gi.repository.GObject'] = repository.GObject
     sys.modules['gi.repository.GLib'] = repository.GLib
     sys.modules['gi.repository.Gtk'] = repository.Gtk
+    sys.modules['gi.repository.Secret'] = repository.Secret

--- a/tests/test_advanced_host_aliases.py
+++ b/tests/test_advanced_host_aliases.py
@@ -3,9 +3,7 @@ import sys
 import types
 import asyncio
 
-# Stub external dependencies required by connection_dialog/manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
-
+# Provide minimal gi.repository.Secret mock
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(
     SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
@@ -22,12 +20,21 @@ gi_repo.Gio = types.SimpleNamespace()
 gi_repo.Gdk = types.SimpleNamespace()
 gi_repo.Pango = types.SimpleNamespace()
 gi_repo.PangoFT2 = types.SimpleNamespace()
+gi_repo.Secret = types.SimpleNamespace(
+    Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+    SchemaFlags=types.SimpleNamespace(NONE=0),
+    password_store_sync=lambda *a, **k: True,
+    password_lookup_sync=lambda *a, **k: None,
+    password_clear_sync=lambda *a, **k: None,
+    COLLECTION_DEFAULT=None,
+)
 
 gi_mod = types.ModuleType('gi')
 gi_mod.repository = gi_repo
 gi_mod.require_version = lambda *args, **kwargs: None
 sys.modules['gi'] = gi_mod
 sys.modules['gi.repository'] = gi_repo
+sys.modules['gi.repository.Secret'] = gi_repo.Secret
 
 # Ensure the project package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_certificate_persistence.py
+++ b/tests/test_certificate_persistence.py
@@ -2,9 +2,7 @@ import os
 import sys
 import types
 
-# Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
-
+# Provide minimal gi.repository.Secret mock
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(
     SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
@@ -12,12 +10,21 @@ gi_repo.GObject = types.SimpleNamespace(
 )
 gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
 gi_repo.Gtk = types.SimpleNamespace()
+gi_repo.Secret = types.SimpleNamespace(
+    Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+    SchemaFlags=types.SimpleNamespace(NONE=0),
+    password_store_sync=lambda *a, **k: True,
+    password_lookup_sync=lambda *a, **k: None,
+    password_clear_sync=lambda *a, **k: None,
+    COLLECTION_DEFAULT=None,
+)
 
 gi_mod = types.ModuleType('gi')
 gi_mod.repository = gi_repo
 gi_mod.require_version = lambda *args, **kwargs: None
 sys.modules['gi'] = gi_mod
 sys.modules['gi.repository'] = gi_repo
+sys.modules['gi.repository.Secret'] = gi_repo.Secret
 
 # Ensure the project package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_certificate_support.py
+++ b/tests/test_certificate_support.py
@@ -28,19 +28,21 @@ if 'gi' not in sys.modules:
     repository.GLib = DummyGLib
     repository.GObject = DummyGObject
     repository.Gtk = types.SimpleNamespace()
+    repository.Secret = types.SimpleNamespace(
+        Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+        SchemaFlags=types.SimpleNamespace(NONE=0),
+        password_store_sync=lambda *a, **k: True,
+        password_lookup_sync=lambda *a, **k: None,
+        password_clear_sync=lambda *a, **k: None,
+        COLLECTION_DEFAULT=None,
+    )
     gi.repository = repository
     sys.modules['gi'] = gi
     sys.modules['gi.repository'] = repository
     sys.modules['gi.repository.GLib'] = repository.GLib
     sys.modules['gi.repository.GObject'] = repository.GObject
     sys.modules['gi.repository.Gtk'] = repository.Gtk
-
-# Stub 'secretstorage' module
-if 'secretstorage' not in sys.modules:
-    secretstorage = types.ModuleType('secretstorage')
-    secretstorage.dbus_init = lambda: None
-    secretstorage.get_default_collection = lambda bus: None
-    sys.modules['secretstorage'] = secretstorage
+    sys.modules['gi.repository.Secret'] = repository.Secret
 
 # Ensure the project root is on sys.path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -3,9 +3,7 @@ import sys
 import types
 import asyncio
 
-# Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
-
+# Provide minimal gi.repository.Secret mock
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(
     SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
@@ -13,12 +11,21 @@ gi_repo.GObject = types.SimpleNamespace(
 )
 gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
 gi_repo.Gtk = types.SimpleNamespace()
+gi_repo.Secret = types.SimpleNamespace(
+    Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+    SchemaFlags=types.SimpleNamespace(NONE=0),
+    password_store_sync=lambda *a, **k: True,
+    password_lookup_sync=lambda *a, **k: None,
+    password_clear_sync=lambda *a, **k: None,
+    COLLECTION_DEFAULT=None,
+)
 
 gi_mod = types.ModuleType('gi')
 gi_mod.repository = gi_repo
 gi_mod.require_version = lambda *args, **kwargs: None
 sys.modules['gi'] = gi_mod
 sys.modules['gi.repository'] = gi_repo
+sys.modules['gi.repository.Secret'] = gi_repo.Secret
 
 # Ensure the project package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_match_block_preservation.py
+++ b/tests/test_match_block_preservation.py
@@ -3,10 +3,7 @@ import sys
 import types
 import asyncio
 
-# Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
-
-# Minimal gi stub
+# Minimal gi stub with Secret mock
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(
     SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
@@ -14,12 +11,21 @@ gi_repo.GObject = types.SimpleNamespace(
 )
 gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
 gi_repo.Gtk = types.SimpleNamespace()
+gi_repo.Secret = types.SimpleNamespace(
+    Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+    SchemaFlags=types.SimpleNamespace(NONE=0),
+    password_store_sync=lambda *a, **k: True,
+    password_lookup_sync=lambda *a, **k: None,
+    password_clear_sync=lambda *a, **k: None,
+    COLLECTION_DEFAULT=None,
+)
 
 gi_mod = types.ModuleType('gi')
 gi_mod.repository = gi_repo
 gi_mod.require_version = lambda *args, **kwargs: None
 sys.modules['gi'] = gi_mod
 sys.modules['gi.repository'] = gi_repo
+sys.modules['gi.repository.Secret'] = gi_repo.Secret
 
 # Ensure the project package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_wildcard_rules.py
+++ b/tests/test_wildcard_rules.py
@@ -3,9 +3,7 @@ import sys
 import types
 import asyncio
 
-# Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
-
+# Provide minimal gi.repository.Secret mock
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(
     SignalFlags=types.SimpleNamespace(RUN_FIRST=0),
@@ -13,12 +11,21 @@ gi_repo.GObject = types.SimpleNamespace(
 )
 gi_repo.GLib = types.SimpleNamespace(idle_add=lambda *args, **kwargs: None)
 gi_repo.Gtk = types.SimpleNamespace()
+gi_repo.Secret = types.SimpleNamespace(
+    Schema=types.SimpleNamespace(new=lambda *a, **k: object()),
+    SchemaFlags=types.SimpleNamespace(NONE=0),
+    password_store_sync=lambda *a, **k: True,
+    password_lookup_sync=lambda *a, **k: None,
+    password_clear_sync=lambda *a, **k: None,
+    COLLECTION_DEFAULT=None,
+)
 
 gi_mod = types.ModuleType('gi')
 gi_mod.repository = gi_repo
 gi_mod.require_version = lambda *args, **kwargs: None
 sys.modules['gi'] = gi_mod
 sys.modules['gi.repository'] = gi_repo
+sys.modules['gi.repository.Secret'] = gi_repo.Secret
 
 # Ensure the project package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
## Summary
- replace legacy secretstorage stubs with minimal libsecret mocks
- extend global test fixtures with gi.repository.Secret stub for libsecret API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7bd8cd08083288f327b1fae15e621