### PR TITLE
Use libsecret for credential storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,12 @@ Install GTK4/libadwaita/VTE system packages
 
 **Debian/Ubuntu:**
 ```bash
-sudo apt install python3-gi python3-gi-cairo libgtk-4-1 gir1.2-gtk-4.0 libadwaita-1-0 gir1.2-adw-1 libvte-2.91-gtk4-0 gir1.2-vte-3.91 python3-paramiko python3-cryptography python3-secretstorage sshpass ssh-askpass
+sudo apt install python3-gi python3-gi-cairo libgtk-4-1 gir1.2-gtk-4.0 libadwaita-1-0 gir1.2-adw-1 libvte-2.91-gtk4-0 gir1.2-vte-3.91 libsecret-1-0 gir1.2-secret-1 python3-paramiko python3-cryptography sshpass ssh-askpass
 ```
 
 **Fedora/RHEL/CentOS:**
 ```bash
-sudo dnf install python3-gobject gtk4 libadwaita vte291-gtk4 libsecret python3-paramiko python3-cryptography python3-secretstorage sshpass openssh-askpass
+sudo dnf install python3-gobject gtk4 libadwaita vte291-gtk4 libsecret python3-paramiko python3-cryptography sshpass openssh-askpass
 ```
 
 ### Python Dependencies
@@ -33,7 +33,7 @@ sudo dnf install python3-gobject gtk4 libadwaita vte291-gtk4 libsecret python3-p
 - pycairo >= 1.20.0
 - paramiko >= 3.4
 - cryptography >= 42.0
-- secretstorage >= 3.3 (Linux only)
+- libsecret (via PyGObject) for credential storage on Linux
 - keyring >= 24.3
 - psutil >= 5.9.0
 
@@ -63,7 +63,7 @@ sudo dnf install python3-gobject gtk4 libadwaita vte291-gtk4 libsecret python3-p
 ## Security Guidelines
 
 - Never store passwords in plain text
-- Use `secretstorage` on Linux for credential storage
+- Use `libsecret` (via PyGObject) on Linux for credential storage
 - Use `keyring` for cross-platform credential management
 - The app uses askpass for private key passphrases and sshpass for ssh passwords
 ## Build and Packaging

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - SCP support for quicly uploading a file to remote server
 - Keypair generation and copying to remote servers (ssh-copy-id)
 - Support for running remote and local commands upon login
-- Secure storage for credentials, no secret (password or passphrase) is copied to clipboard or saved to plain text
+- Secure storage for credentials via libsecret on Linux; no secret (password or passphrase) is copied to clipboard or saved to plain text
 - Privacy toggle to show/hide ip addresses/hostnames in the main window
 - Light/Dark interface themes
 - Customizable terminal font and color schemes
@@ -80,7 +80,8 @@ sudo apt install \
   libgtk-4-1 (>= 4.6) gir1.2-gtk-4.0 (>= 4.6) \
   libadwaita-1-0 (>= 1.4) gir1.2-adw-1 (>= 1.4) \
   libvte-2.91-gtk4-0 (>= 0.70) gir1.2-vte-3.91 (>= 0.70) \
-  python3-paramiko python3-cryptography python3-secretstorage sshpass ssh-askpass
+  libsecret-1-0 gir1.2-secret-1 \
+  python3-paramiko python3-cryptography sshpass ssh-askpass
 ```
 
 Fedora / RHEL / CentOS
@@ -92,8 +93,10 @@ sudo dnf install \
   gtk4 libadwaita \
   vte291-gtk4 \
   libsecret \
-  python3-paramiko python3-cryptography python3-secretstorage sshpass openssh-askpass
+  python3-paramiko python3-cryptography sshpass openssh-askpass
 ```
+
+libsecret handles secure credential storage on Linux via the Secret Service API.
 
 Run from source
 

--- a/io.github.mfat.sshpilot.yaml
+++ b/io.github.mfat.sshpilot.yaml
@@ -76,7 +76,7 @@ modules:
   - name: python3-deps
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} cryptography==42.0.8 paramiko==3.4.1 secretstorage==3.3.3 --no-build-isolation
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} cryptography==42.0.8 paramiko==3.4.1 --no-build-isolation
     sources:
       # cryptography (pre-built wheel)
       - type: file
@@ -121,7 +121,6 @@ modules:
         only-arches:
           - aarch64
 
-      # secretstorage
       - type: file
         url: https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
         sha256: f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99

--- a/packaging/ArchLinux/PKGBUILD
+++ b/packaging/ArchLinux/PKGBUILD
@@ -15,9 +15,9 @@ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz
 _srcdir="${pkgname}-${pkgver}"
 
 package() {
-	depends+=(
-		'python-gobject' 'python-cairo' 'python-paramiko' 'python-cryptography' 'python-secretstorage' 'python-matplotlib'
-		'libadwaita' 'vte4' 'sshpass')
+        depends+=(
+                'python-gobject' 'python-cairo' 'python-paramiko' 'python-cryptography' 'python-matplotlib'
+                'libsecret' 'libadwaita' 'vte4' 'sshpass')
 
 	cd "${_srcdir}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "pycairo>=1.20.0",
     "paramiko>=3.4",
     "cryptography>=42.0",
-    "secretstorage>=3.3; platform_system == \"Linux\"",
     "keyring>=24.3",
     "psutil>=5.9.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pycairo>=1.20.0
 # SSH and crypto
 paramiko>=3.4
 cryptography>=42.0
-secretstorage>=3.3 ; platform_system=="Linux"
 keyring>=24.3
 
 # System utilities

--- a/scripts/install-run-macos.sh
+++ b/scripts/install-run-macos.sh
@@ -56,21 +56,6 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt || true
 
-# Ensure macOS-friendly secret storage fallback when running against upstream clone
-if ! python -c "import secretstorage" >/dev/null 2>&1; then
-  if grep -q "^import secretstorage$" sshpilot/connection_manager.py 2>/dev/null; then
-    echo "Patching secretstorage import for macOS..."
-    python - <<'PY'
-from pathlib import Path
-p = Path('sshpilot/connection_manager.py')
-s = p.read_text()
-s = s.replace('import secretstorage', 'try:\n    import secretstorage\nexcept Exception:\n    secretstorage = None')
-p.write_text(s)
-print('Patched', p)
-PY
-  fi
-fi
-
 echo "[5/6] Writing run wrapper (scripts/run-macos.sh)..."
 mkdir -p scripts
 cat > scripts/run-macos.sh <<'EOF'

--- a/sshpilot.egg-info/PKG-INFO
+++ b/sshpilot.egg-info/PKG-INFO
@@ -36,7 +36,6 @@ Requires-Dist: paramiko>=3.4
 Requires-Dist: cryptography>=42.0
 Requires-Dist: keyring>=24.3
 Requires-Dist: psutil>=5.9.0
-Requires-Dist: secretstorage>=3.3; sys_platform == "linux"
 Provides-Extra: dev
 Requires-Dist: pytest>=7.0.0; extra == "dev"
 Requires-Dist: pytest-cov>=4.0.0; extra == "dev"
@@ -129,7 +128,8 @@ sudo apt install \
   libgtk-4-1 (>= 4.6) gir1.2-gtk-4.0 (>= 4.6) \
   libadwaita-1-0 (>= 1.4) gir1.2-adw-1 (>= 1.4) \
   libvte-2.91-gtk4-0 (>= 0.70) gir1.2-vte-3.91 (>= 0.70) \
-  python3-paramiko python3-cryptography python3-secretstorage sshpass ssh-askpass
+  libsecret-1-0 gir1.2-secret-1 \
+  python3-paramiko python3-cryptography sshpass ssh-askpass
 ```
 
 Fedora / RHEL / CentOS
@@ -141,7 +141,7 @@ sudo dnf install \
   gtk4 libadwaita \
   vte291-gtk4 \
   libsecret \
-  python3-paramiko python3-cryptography python3-secretstorage sshpass openssh-askpass
+  python3-paramiko python3-cryptography sshpass openssh-askpass
 ```
 
 Run from source

--- a/sshpilot.egg-info/requires.txt
+++ b/sshpilot.egg-info/requires.txt
@@ -5,9 +5,6 @@ cryptography>=42.0
 keyring>=24.3
 psutil>=5.9.0
 
-[:sys_platform == "linux"]
-secretstorage>=3.3
-
 [dev]
 pytest>=7.0.0
 pytest-cov>=4.0.0

--- a/sshpilot.spec
+++ b/sshpilot.spec
@@ -75,11 +75,6 @@ if os.path.exists(keyring_package):
     datas.append((keyring_package, "keyring"))
     print(f"Added keyring package: {keyring_package}")
 
-# Add secretstorage package files if available
-secretstorage_package = f"{homebrew}/lib/python3.13/site-packages/secretstorage"
-if os.path.exists(secretstorage_package):
-    datas.append((secretstorage_package, "secretstorage"))
-    print(f"Added secretstorage package: {secretstorage_package}")
 
 # Optional helper binaries
 sshpass = f"{homebrew}/bin/sshpass"
@@ -93,8 +88,8 @@ if os.path.exists(cairo_gi_binding):
 
 hiddenimports = collect_submodules("gi")
 hiddenimports += ["gi._gi_cairo", "gi.repository.cairo", "cairo"]
-# Add keyring and secretstorage for askpass functionality
-hiddenimports += ["keyring", "secretstorage"]
+# Add keyring for askpass functionality
+hiddenimports += ["keyring"]
 # Add all keyring backends
 hiddenimports += ["keyring.backends", "keyring.backends.macOS", "keyring.backends.libsecret", "keyring.backends.SecretService"]
 

--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -33,23 +33,23 @@ def ensure_passphrase_askpass() -> str:
     script_body = r'''#!/usr/bin/env python3
 import sys, re, os, platform
 try:
-    import secretstorage
+    from gi.repository import Secret
 except Exception:
-    secretstorage = None
+    Secret = None
 try:
     import keyring
 except Exception:
     keyring = None
 
-# Log availability of keyring and secretstorage
+# Log availability of keyring and libsecret
 try:
     with open("/tmp/sshpilot-askpass.log", "a") as f:
-        f.write(f"ASKPASS: keyring {'available' if keyring else 'unavailable'}, secretstorage {'available' if secretstorage else 'unavailable'}\n")
+        f.write(f"ASKPASS: keyring {'available' if keyring else 'unavailable'}, libsecret {'available' if Secret else 'unavailable'}\n")
 except Exception:
     pass
 
 def get_passphrase(key_path: str) -> str:
-    """Retrieve passphrase from keyring or secretstorage"""
+    """Retrieve passphrase from keyring or libsecret"""
     # Try keyring first (macOS)
     if keyring and platform.system() == 'Darwin':
         try:
@@ -76,70 +76,45 @@ def get_passphrase(key_path: str) -> str:
             except Exception:
                 pass
 
-    # Fall back to secretstorage (Linux)
-    if secretstorage is None:
+    # Fall back to libsecret (Linux)
+    if Secret is None:
         try:
             with open("/tmp/sshpilot-askpass.log", "a") as f:
-                f.write("ASKPASS: secretstorage module not available\n")
+                f.write("ASKPASS: libsecret module not available\n")
         except Exception:
             pass
         return ""
     try:
         with open("/tmp/sshpilot-askpass.log", "a") as f:
-            f.write("ASKPASS: Trying secretstorage\n")
-        bus = secretstorage.dbus_init()
-        try:
-            with open("/tmp/sshpilot-askpass.log", "a") as f:
-                f.write("ASKPASS: Initialized D-Bus for secretstorage\n")
-        except Exception:
-            pass
-        collection = secretstorage.get_default_collection(bus)
-        if not collection:
-            try:
-                with open("/tmp/sshpilot-askpass.log", "a") as f:
-                    f.write("ASKPASS: No default secretstorage collection\n")
-            except Exception:
-                pass
-            return ""
-        if collection.is_locked():
-            try:
-                with open("/tmp/sshpilot-askpass.log", "a") as f:
-                    f.write("ASKPASS: Secretstorage collection locked, unlocking\n")
-            except Exception:
-                pass
-            collection.unlock()
-        items = list(collection.search_items({
+            f.write("ASKPASS: Trying libsecret\n")
+        schema = Secret.Schema.new("sshPilot", Secret.SchemaFlags.NONE, {
+            "application": Secret.SchemaAttributeType.STRING,
+            "type": Secret.SchemaAttributeType.STRING,
+            "key_path": Secret.SchemaAttributeType.STRING,
+        })
+        attributes = {
             "application": "sshPilot",
             "type": "key_passphrase",
-            "key_path": key_path
-        }))
-        try:
-            with open("/tmp/sshpilot-askpass.log", "a") as f:
-                f.write(f"ASKPASS: secretstorage search found {len(items)} items\n")
-        except Exception:
-            pass
-        if items:
+            "key_path": key_path,
+        }
+        secret = Secret.password_lookup_sync(schema, attributes, None)
+        if secret is not None:
             try:
-                secret = items[0].get_secret().decode("utf-8")
                 with open("/tmp/sshpilot-askpass.log", "a") as f:
-                    f.write("ASKPASS: Retrieved passphrase from secretstorage\n")
-                return secret
-            except Exception as e:
-                try:
-                    with open("/tmp/sshpilot-askpass.log", "a") as f:
-                        f.write(f"ASKPASS: Error retrieving secret: {e}\n")
-                except Exception:
-                    pass
+                    f.write("ASKPASS: Retrieved passphrase from libsecret\n")
+            except Exception:
+                pass
+            return secret
         else:
             try:
                 with open("/tmp/sshpilot-askpass.log", "a") as f:
-                    f.write("ASKPASS: No matching secretstorage item found\n")
+                    f.write("ASKPASS: No matching libsecret item found\n")
             except Exception:
                 pass
     except Exception as e:
         try:
             with open("/tmp/sshpilot-askpass.log", "a") as f:
-                f.write(f"ASKPASS: secretstorage error: {e}\n")
+                f.write(f"ASKPASS: libsecret error: {e}\n")
         except Exception:
             pass
     return ""
@@ -172,11 +147,11 @@ def extract_key_path(prompt: str) -> str:
     return ""
 
 if __name__ == "__main__":
-    # Disable GNOME keyring interference but keep D-Bus for secretstorage
+    # Disable GNOME keyring interference but keep D-Bus for libsecret
     os.environ["GNOME_KEYRING_CONTROL"] = ""
     os.environ["GNOME_KEYRING_PID"] = ""
     os.environ["GNOME_KEYRING_SOCKET"] = ""
-    # Don't disable DBUS_SESSION_BUS_ADDRESS - secretstorage needs it
+    # Don't disable DBUS_SESSION_BUS_ADDRESS - libsecret needs it
     
     prompt = sys.argv[1] if len(sys.argv) > 1 else ""
     pl = prompt.lower()
@@ -281,11 +256,11 @@ def get_ssh_env_with_askpass(require: str = "prefer") -> dict:
     # Ensure DISPLAY is set for SSH_ASKPASS to work properly
     if "DISPLAY" not in env:
         env["DISPLAY"] = ":0"
-    # Disable GNOME keyring interference with SSH but keep D-Bus for secretstorage
+    # Disable GNOME keyring interference with SSH but keep D-Bus for libsecret
     env["GNOME_KEYRING_CONTROL"] = ""
     env["GNOME_KEYRING_PID"] = ""
     env["GNOME_KEYRING_SOCKET"] = ""
-    # Don't disable DBUS_SESSION_BUS_ADDRESS - secretstorage needs it
+    # Don't disable DBUS_SESSION_BUS_ADDRESS - libsecret needs it
     return env
 
 def get_ssh_env_with_askpass_for_password(host: str, username: str) -> dict:

--- a/tests/test_advanced_host_aliases.py
+++ b/tests/test_advanced_host_aliases.py
@@ -4,7 +4,6 @@ import types
 import asyncio
 
 # Stub external dependencies required by connection_dialog/manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
 
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(

--- a/tests/test_certificate_persistence.py
+++ b/tests/test_certificate_persistence.py
@@ -3,7 +3,6 @@ import sys
 import types
 
 # Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
 
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(

--- a/tests/test_certificate_support.py
+++ b/tests/test_certificate_support.py
@@ -35,13 +35,6 @@ if 'gi' not in sys.modules:
     sys.modules['gi.repository.GObject'] = repository.GObject
     sys.modules['gi.repository.Gtk'] = repository.Gtk
 
-# Stub 'secretstorage' module
-if 'secretstorage' not in sys.modules:
-    secretstorage = types.ModuleType('secretstorage')
-    secretstorage.dbus_init = lambda: None
-    secretstorage.get_default_collection = lambda bus: None
-    sys.modules['secretstorage'] = secretstorage
-
 # Ensure the project root is on sys.path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -4,7 +4,6 @@ import types
 import asyncio
 
 # Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
 
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(

--- a/tests/test_match_block_preservation.py
+++ b/tests/test_match_block_preservation.py
@@ -4,7 +4,6 @@ import types
 import asyncio
 
 # Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
 
 # Minimal gi stub
 gi_repo = types.ModuleType('gi.repository')

--- a/tests/test_wildcard_rules.py
+++ b/tests/test_wildcard_rules.py
@@ -4,7 +4,6 @@ import types
 import asyncio
 
 # Stub external dependencies required by connection_manager
-sys.modules['secretstorage'] = types.ModuleType('secretstorage')
 
 gi_repo = types.ModuleType('gi.repository')
 gi_repo.GObject = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- remove secretstorage dependency and rely on libsecret via PyGObject
- update credential storage code to use libsecret
- document libsecret requirement and update packaging scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7bd9323008328b66b74ffc312013c