### PR TITLE
Force isolated mode by default on Flatpak

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -9,7 +9,7 @@ import os
 from typing import Dict, Any, Optional
 
 from gi.repository import Gio, GLib, GObject
-from .platform_utils import get_config_dir
+from .platform_utils import get_config_dir, is_flatpak
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ class Config(GObject.Object):
                 'auto_add_host_keys': True,
                 'verbosity': 0,
                 'debug_enabled': False,
-                'use_isolated_config': False,
+                'use_isolated_config': is_flatpak(),
             },
             'security': {
                 'store_passwords': True,

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -42,7 +42,7 @@ if not load_resources():
     sys.exit(1)
 
 from .window import MainWindow
-from .platform_utils import is_macos, get_data_dir
+from .platform_utils import is_macos, get_data_dir, is_flatpak
 
 class SshPilotApplication(Adw.Application):
     """Main application class for sshPilot"""
@@ -74,10 +74,17 @@ class SshPilotApplication(Adw.Application):
             
             # Apply color overrides
             self.apply_color_overrides(cfg)
-            
-            self.isolated_mode = isolated or bool(cfg.get_setting('ssh.use_isolated_config', False))
+
+            flatpak = is_flatpak()
+            self.isolated_mode = (
+                True
+                if flatpak
+                else isolated or bool(cfg.get_setting('ssh.use_isolated_config', False))
+            )
+            if flatpak:
+                cfg.set_setting('ssh.use_isolated_config', True)
         except Exception:
-            self.isolated_mode = isolated
+            self.isolated_mode = True if is_flatpak() else isolated
         
         # Create actions with keyboard shortcuts
         # Use platform-specific shortcuts for better macOS compatibility

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -686,9 +686,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.isolated_mode_row.set_activatable_widget(self.isolated_mode_radio)
             operation_group.add(self.isolated_mode_row)
 
-            use_isolated = bool(self.config.get_setting('ssh.use_isolated_config', False))
+            flatpak = is_flatpak()
+            use_isolated = True if flatpak else bool(self.config.get_setting('ssh.use_isolated_config', False))
             self.isolated_mode_radio.set_active(use_isolated)
             self.default_mode_radio.set_active(not use_isolated)
+            if flatpak:
+                self.default_mode_row.set_sensitive(False)
 
             self.default_mode_radio.connect('toggled', self.on_operation_mode_toggled)
             self.isolated_mode_radio.connect('toggled', self.on_operation_mode_toggled)

--- a/tests/test_flatpak_isolated_config.py
+++ b/tests/test_flatpak_isolated_config.py
@@ -1,0 +1,11 @@
+import importlib
+
+import sshpilot.config as config
+
+
+def test_isolated_config_default_on_flatpak(monkeypatch, tmp_path):
+    importlib.reload(config)
+    monkeypatch.setattr(config, "is_flatpak", lambda: True)
+    monkeypatch.setattr(config, "get_config_dir", lambda: str(tmp_path))
+    cfg = config.Config()
+    assert cfg.get_setting('ssh.use_isolated_config', False) is True


### PR DESCRIPTION
## Summary
- Default configuration enables isolated SSH mode when running inside Flatpak
- Application now forces isolated mode and disables selection of default mode in preferences
- Add test ensuring Flatpak builds default to isolated configuration

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'SchemaAttributeType')*


------
https://chatgpt.com/codex/tasks/task_e_68c7c93c8bc08328b58f7a808d4798cc