### PR TITLE
Focus tab when reconnecting after settings change

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -5324,7 +5324,15 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         if not terminal:
             logger.warning("No terminal instance found for reconnection")
             return
-            
+
+        # Ensure the tab for this connection is focused so the user can
+        # observe the reconnection process even if another tab was
+        # previously active.
+        try:
+            self._focus_most_recent_tab(connection)
+        except Exception:
+            pass
+
         # Set controlled reconnect flag
         self._is_controlled_reconnect = True
 


### PR DESCRIPTION
## Summary
- ensure tab is activated when reconnecting after updating connection settings

## Testing
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'SchemaAttributeType')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d804b728832889f2b949531895a7