### PR TITLE
Handle read-only ~/.ssh for ssh-copy-id in Flatpak

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -56,6 +56,7 @@ from . import shutdown
 from .search_utils import connection_matches
 from .shortcut_utils import get_primary_modifier_label
 from .platform_utils import is_macos, get_config_dir
+from .ssh_utils import ensure_writable_ssh_home
 
 logger = logging.getLogger(__name__)
 
@@ -2658,6 +2659,8 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 askpass_env = get_ssh_env_with_askpass()
                 logger.debug(f"Main window: Askpass environment variables: {list(askpass_env.keys())}")
                 env.update(askpass_env)
+
+            ensure_writable_ssh_home(env)
 
             # Ensure /app/bin is first in PATH for Flatpak compatibility
             logger.debug("Main window: Setting up PATH for Flatpak compatibility")

--- a/tests/test_sshcopyid_temp_home.py
+++ b/tests/test_sshcopyid_temp_home.py
@@ -1,0 +1,18 @@
+from sshpilot.ssh_utils import ensure_writable_ssh_home
+
+
+def test_ensure_writable_home_flatpak(monkeypatch, tmp_path):
+    monkeypatch.setenv("FLATPAK_ID", "io.github.mfat.sshpilot")
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    env = {}
+    ensure_writable_ssh_home(env)
+    expected = tmp_path / "sshcopyid-home"
+    assert env["HOME"] == str(expected)
+    assert (expected / ".ssh").is_dir()
+
+
+def test_ensure_writable_home_non_flatpak(monkeypatch):
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    env = {}
+    ensure_writable_ssh_home(env)
+    assert "HOME" not in env


### PR DESCRIPTION
## Summary
- create temporary writable home for ssh-copy-id when running inside Flatpak
- invoke the workaround in ssh-copy-id launch path
- add tests covering Flatpak home handling

## Testing
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'SchemaAttributeType')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d94495a88328af4f220eebff3f1c