### PR TITLE
Add configurable SSH directory utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - Light/Dark interface themes
 - Customizable terminal font and color schemes
 - Load/save standard .ssh/config entries (Or use dedicated configuration file)
+- Configurable SSH directory via `SSHPILOT_SSH_DIR` environment variable
 - Free software (GPL v3 license)
 
 

--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -15,7 +15,7 @@ from typing import Optional, Dict, Any
 
 from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango, PangoFT2
 from .port_utils import get_port_checker
-from .platform_utils import is_macos
+from .platform_utils import is_macos, get_ssh_dir
 
 # Initialize gettext
 try:
@@ -1840,9 +1840,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             names = []
             paths = []
             
-            # Look for certificate files in ~/.ssh directory
-            ssh_dir = os.path.expanduser("~/.ssh")
-            if os.path.exists(ssh_dir) and os.path.isdir(ssh_dir):
+            # Look for certificate files in the SSH directory
+            ssh_dir = get_ssh_dir()
+            if os.path.isdir(ssh_dir):
                 for filename in os.listdir(ssh_dir):
                     if filename.endswith('-cert.pub'):
                         cert_path = os.path.join(ssh_dir, filename)
@@ -2662,9 +2662,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
             dialog.add_button(_("Open"), Gtk.ResponseType.ACCEPT)
 
-            # Default to ~/.ssh directory when available
+            # Default to SSH directory when available
             try:
-                ssh_dir = os.path.expanduser('~/.ssh')
+                ssh_dir = get_ssh_dir()
                 if os.path.isdir(ssh_dir):
                     try:
                         dialog.set_current_folder(Gio.File.new_for_path(ssh_dir))
@@ -2679,7 +2679,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             except Exception:
                 pass
 
-            # No filters: list all files in ~/.ssh
+            # No filters: list all files in the SSH directory
 
             dialog.connect("response", self.on_key_file_selected)
             dialog.show()
@@ -2704,9 +2704,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
             dialog.add_button(_("Open"), Gtk.ResponseType.ACCEPT)
 
-            # Default to ~/.ssh directory when available
+            # Default to SSH directory when available
             try:
-                ssh_dir = os.path.expanduser('~/.ssh')
+                ssh_dir = get_ssh_dir()
                 if os.path.isdir(ssh_dir):
                     try:
                         dialog.set_current_folder(Gio.File.new_for_path(ssh_dir))

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -15,7 +15,7 @@ import re
 from typing import Dict, List, Optional, Any, Tuple, Union
 
 from .ssh_config_utils import resolve_ssh_config_files, get_effective_ssh_config
-from .platform_utils import is_macos, get_config_dir
+from .platform_utils import is_macos, get_config_dir, get_ssh_dir
 
 try:
     import secretstorage
@@ -680,8 +680,9 @@ class ConnectionManager(GObject.Object):
                 if not os.path.exists(path):
                     open(path, 'a').close()
         else:
-            self.ssh_config_path = os.path.expanduser('~/.ssh/config')
-            self.known_hosts_path = os.path.expanduser('~/.ssh/known_hosts')
+            ssh_dir = get_ssh_dir()
+            self.ssh_config_path = os.path.join(ssh_dir, 'config')
+            self.known_hosts_path = os.path.join(ssh_dir, 'known_hosts')
 
         # Reload SSH config to reflect new paths
         self.load_ssh_config()
@@ -1069,10 +1070,10 @@ class ConnectionManager(GObject.Object):
             return None
 
     def load_ssh_keys(self):
-        """Auto-detect SSH keys in ~/.ssh/"""
-        ssh_dir = os.path.expanduser('~/.ssh')
-        if not os.path.exists(ssh_dir):
-            return
+        """Auto-detect SSH keys in the SSH directory."""
+        ssh_dir = get_ssh_dir()
+        if not os.path.isdir(ssh_dir):
+            return []
         
         try:
             keys = []

--- a/sshpilot/key_manager.py
+++ b/sshpilot/key_manager.py
@@ -9,6 +9,8 @@ from typing import Optional, List
 
 from gi.repository import GObject
 
+from .platform_utils import get_ssh_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,8 +38,9 @@ class KeyManager(GObject.Object):
 
     def __init__(self, ssh_dir: Optional[Path] = None):
         super().__init__()
-        self.ssh_dir = Path(ssh_dir or Path.home() / ".ssh")
-        self.ssh_dir.mkdir(parents=True, exist_ok=True)
+        self.ssh_dir = Path(ssh_dir or get_ssh_dir())
+        if not self.ssh_dir.exists():
+            self.ssh_dir.mkdir(parents=True, exist_ok=True)
         try:
             os.chmod(self.ssh_dir, 0o700)
         except Exception:
@@ -51,7 +54,7 @@ class KeyManager(GObject.Object):
         try:
             if not self.ssh_dir.exists():
                 return keys
-            # Recursively walk ~/.ssh for private keys that have a matching .pub
+            # Recursively walk the SSH directory for private keys that have a matching .pub
             for file_path in self.ssh_dir.rglob("*"):
                 if not file_path.is_file():
                     continue

--- a/sshpilot/known_hosts_editor.py
+++ b/sshpilot/known_hosts_editor.py
@@ -5,6 +5,8 @@ from typing import Callable, Optional
 from gettext import gettext as _
 from gi.repository import Gtk, Adw, GLib
 
+from .platform_utils import get_ssh_dir
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +26,7 @@ class KnownHostsEditorWindow(Adw.Window):
         self._known_hosts_path = getattr(
             connection_manager,
             'known_hosts_path',
-            os.path.expanduser('~/.ssh/known_hosts'),
+            os.path.join(get_ssh_dir(), 'known_hosts'),
         )
         self._all_entries = []  # Store all entries for filtering
 

--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -28,3 +28,18 @@ def get_data_dir() -> str:
     """Return the per-user data directory for sshPilot."""
     return os.path.join(GLib.get_user_data_dir(), APP_NAME)
 
+
+SSH_DIR_ENV = "SSHPILOT_SSH_DIR"
+
+
+def get_ssh_dir() -> str:
+    """Return the SSH directory path.
+
+    Defaults to ``GLib.get_home_dir()/.ssh`` but can be overridden by the
+    ``SSHPILOT_SSH_DIR`` environment variable.
+    """
+    override = os.environ.get(SSH_DIR_ENV)
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(GLib.get_home_dir(), ".ssh")
+

--- a/sshpilot/ssh_config_editor.py
+++ b/sshpilot/ssh_config_editor.py
@@ -5,10 +5,12 @@ from gettext import gettext as _
 
 from gi.repository import Gtk, Adw
 
+from .platform_utils import get_ssh_dir
+
 logger = logging.getLogger(__name__)
 
 class SSHConfigEditorWindow(Adw.Window):
-    """Simple window for editing the user's ~/.ssh/config file."""
+    """Simple window for editing the user's SSH config file."""
 
     def __init__(self, parent, connection_manager, on_saved: Optional[Callable] = None):
         super().__init__()
@@ -19,7 +21,11 @@ class SSHConfigEditorWindow(Adw.Window):
 
         self._cm = connection_manager
         self._on_saved = on_saved
-        self._config_path = getattr(connection_manager, 'ssh_config_path', os.path.expanduser('~/.ssh/config'))
+        self._config_path = getattr(
+            connection_manager,
+            'ssh_config_path',
+            os.path.join(get_ssh_dir(), 'config'),
+        )
 
         # Toolbar view with header bar
         tv = Adw.ToolbarView()

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -42,3 +42,27 @@ def test_get_data_dir(monkeypatch, tmp_path):
     expected = os.path.join(str(tmp_path / "data"), "sshpilot")
     assert platform_utils.get_data_dir() == expected
 
+
+def test_get_ssh_dir_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("SSHPILOT_SSH_DIR", raising=False)
+    monkeypatch.setattr(
+        platform_utils.GLib,
+        "get_home_dir",
+        lambda: str(tmp_path / "home"),
+        raising=False,
+    )
+    expected = os.path.join(str(tmp_path / "home"), ".ssh")
+    assert platform_utils.get_ssh_dir() == expected
+
+
+def test_get_ssh_dir_override(monkeypatch, tmp_path):
+    override = tmp_path / "custom_ssh"
+    monkeypatch.setenv("SSHPILOT_SSH_DIR", str(override))
+    monkeypatch.setattr(
+        platform_utils.GLib,
+        "get_home_dir",
+        lambda: str(tmp_path / "home"),
+        raising=False,
+    )
+    assert platform_utils.get_ssh_dir() == str(override)
+


### PR DESCRIPTION
## Summary
- add `get_ssh_dir` helper with env override
- use `get_ssh_dir` throughout connection and key management
- support SSH directory certificates and file chooser defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e5a8cd488328af119d5f2ca4aecb