### PR TITLE
feat: centralize SSH directory lookup

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -15,7 +15,7 @@ from typing import Optional, Dict, Any
 
 from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango, PangoFT2
 from .port_utils import get_port_checker
-from .platform_utils import is_macos
+from .platform_utils import is_macos, get_ssh_dir
 
 # Initialize gettext
 try:
@@ -1840,8 +1840,8 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             names = []
             paths = []
             
-            # Look for certificate files in ~/.ssh directory
-            ssh_dir = os.path.expanduser("~/.ssh")
+            # Look for certificate files in the SSH directory
+            ssh_dir = get_ssh_dir()
             if os.path.exists(ssh_dir) and os.path.isdir(ssh_dir):
                 for filename in os.listdir(ssh_dir):
                     if filename.endswith('-cert.pub'):
@@ -2662,9 +2662,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
             dialog.add_button(_("Open"), Gtk.ResponseType.ACCEPT)
 
-            # Default to ~/.ssh directory when available
+            # Default to SSH directory when available
             try:
-                ssh_dir = os.path.expanduser('~/.ssh')
+                ssh_dir = get_ssh_dir()
                 if os.path.isdir(ssh_dir):
                     try:
                         dialog.set_current_folder(Gio.File.new_for_path(ssh_dir))
@@ -2679,7 +2679,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             except Exception:
                 pass
 
-            # No filters: list all files in ~/.ssh
+            # No filters: list all files in SSH directory
 
             dialog.connect("response", self.on_key_file_selected)
             dialog.show()
@@ -2704,9 +2704,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
             dialog.add_button(_("Open"), Gtk.ResponseType.ACCEPT)
 
-            # Default to ~/.ssh directory when available
+            # Default to SSH directory when available
             try:
-                ssh_dir = os.path.expanduser('~/.ssh')
+                ssh_dir = get_ssh_dir()
                 if os.path.isdir(ssh_dir):
                     try:
                         dialog.set_current_folder(Gio.File.new_for_path(ssh_dir))

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -15,7 +15,7 @@ import re
 from typing import Dict, List, Optional, Any, Tuple, Union
 
 from .ssh_config_utils import resolve_ssh_config_files, get_effective_ssh_config
-from .platform_utils import is_macos, get_config_dir
+from .platform_utils import is_macos, get_config_dir, get_ssh_dir
 
 try:
     from gi.repository import Secret
@@ -701,8 +701,9 @@ class ConnectionManager(GObject.Object):
                 if not os.path.exists(path):
                     open(path, 'a').close()
         else:
-            self.ssh_config_path = os.path.expanduser('~/.ssh/config')
-            self.known_hosts_path = os.path.expanduser('~/.ssh/known_hosts')
+            ssh_dir = get_ssh_dir()
+            self.ssh_config_path = os.path.join(ssh_dir, 'config')
+            self.known_hosts_path = os.path.join(ssh_dir, 'known_hosts')
 
         # Reload SSH config to reflect new paths
         self.load_ssh_config()
@@ -1070,7 +1071,7 @@ class ConnectionManager(GObject.Object):
         search_dirs = []
         if getattr(self, 'isolated_mode', False):
             search_dirs.append(get_config_dir())
-        search_dirs.append(os.path.expanduser('~/.ssh'))
+        search_dirs.append(get_ssh_dir())
 
         keys: List[str] = []
         seen = set()

--- a/sshpilot/known_hosts_editor.py
+++ b/sshpilot/known_hosts_editor.py
@@ -5,6 +5,8 @@ from typing import Callable, Optional
 from gettext import gettext as _
 from gi.repository import Gtk, Adw, GLib
 
+from .platform_utils import get_ssh_dir
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +26,7 @@ class KnownHostsEditorWindow(Adw.Window):
         self._known_hosts_path = getattr(
             connection_manager,
             'known_hosts_path',
-            os.path.expanduser('~/.ssh/known_hosts'),
+            os.path.join(get_ssh_dir(), 'known_hosts'),
         )
         self._all_entries = []  # Store all entries for filtering
 

--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -28,3 +28,16 @@ def get_data_dir() -> str:
     """Return the per-user data directory for sshPilot."""
     return os.path.join(GLib.get_user_data_dir(), APP_NAME)
 
+
+def get_ssh_dir() -> str:
+    """Return the user's SSH directory.
+
+    By default this uses GLib's concept of the home directory and appends
+    ``.ssh``. The location can be overridden by setting the
+    ``SSHPILOT_SSH_DIR`` environment variable.
+    """
+    override = os.environ.get("SSHPILOT_SSH_DIR")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(GLib.get_home_dir(), ".ssh")
+

--- a/sshpilot/ssh_config_editor.py
+++ b/sshpilot/ssh_config_editor.py
@@ -5,6 +5,8 @@ from gettext import gettext as _
 
 from gi.repository import Gtk, Adw
 
+from .platform_utils import get_ssh_dir
+
 logger = logging.getLogger(__name__)
 
 class SSHConfigEditorWindow(Adw.Window):
@@ -19,7 +21,7 @@ class SSHConfigEditorWindow(Adw.Window):
 
         self._cm = connection_manager
         self._on_saved = on_saved
-        self._config_path = getattr(connection_manager, 'ssh_config_path', os.path.expanduser('~/.ssh/config'))
+        self._config_path = getattr(connection_manager, 'ssh_config_path', os.path.join(get_ssh_dir(), 'config'))
 
         # Toolbar view with header bar
         tv = Adw.ToolbarView()

--- a/tests/test_key_discovery.py
+++ b/tests/test_key_discovery.py
@@ -61,7 +61,7 @@ def test_connection_manager_loads_keys_standard(tmp_path, monkeypatch):
     key = ssh_dir / "id_test"
     _write_dummy_key(key)
 
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SSHPILOT_SSH_DIR", str(ssh_dir))
     cm = ConnectionManager.__new__(ConnectionManager)
     cm.isolated_mode = False
     keys = ConnectionManager.load_ssh_keys(cm)
@@ -81,7 +81,7 @@ def test_connection_manager_loads_keys_isolated(tmp_path, monkeypatch):
 
     cm = ConnectionManager.__new__(ConnectionManager)
     cm.isolated_mode = True
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SSHPILOT_SSH_DIR", str(home_ssh))
     monkeypatch.setattr(
         "sshpilot.connection_manager.get_config_dir",
         lambda: str(config_dir),

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -42,3 +42,27 @@ def test_get_data_dir(monkeypatch, tmp_path):
     expected = os.path.join(str(tmp_path / "data"), "sshpilot")
     assert platform_utils.get_data_dir() == expected
 
+
+def test_get_ssh_dir_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("SSHPILOT_SSH_DIR", raising=False)
+    monkeypatch.setattr(
+        platform_utils.GLib,
+        "get_home_dir",
+        lambda: str(tmp_path),
+        raising=False,
+    )
+    expected = os.path.join(str(tmp_path), ".ssh")
+    assert platform_utils.get_ssh_dir() == expected
+
+
+def test_get_ssh_dir_override(monkeypatch, tmp_path):
+    override = tmp_path / "custom_ssh"
+    monkeypatch.setenv("SSHPILOT_SSH_DIR", str(override))
+    monkeypatch.setattr(
+        platform_utils.GLib,
+        "get_home_dir",
+        lambda: "ignored",
+        raising=False,
+    )
+    assert platform_utils.get_ssh_dir() == str(override)
+


### PR DESCRIPTION
## Summary
- add `get_ssh_dir` helper with optional `SSHPILOT_SSH_DIR` override
- use `get_ssh_dir` across connection, key, and configuration dialogs
- expand tests for SSH directory discovery and environment overrides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e98dce788328b11ff6de4f4b76d8