### PR TITLE
Handle recursive SSH config includes safely

### DIFF
--- a/tests/test_include_resolution.py
+++ b/tests/test_include_resolution.py
@@ -1,5 +1,7 @@
 import asyncio
+import logging
 from sshpilot.connection_manager import ConnectionManager
+from sshpilot.ssh_config_utils import resolve_ssh_config_files
 
 # Ensure an event loop for Connection objects
 asyncio.set_event_loop(asyncio.new_event_loop())
@@ -42,3 +44,37 @@ def test_include_directives_parsed(tmp_path):
     cm.update_ssh_config_file(hosta, new_data)
     assert "Port 2222" in a_cfg.read_text()
     assert "Port 2222" not in main_cfg.read_text()
+
+
+def test_include_cycle_detected(tmp_path, caplog):
+    a_cfg = tmp_path / "a.conf"
+    b_cfg = tmp_path / "b.conf"
+    a_cfg.write_text("Include b.conf\n")
+    b_cfg.write_text("Include a.conf\n")
+    caplog.set_level(logging.WARNING)
+    files = resolve_ssh_config_files(str(a_cfg))
+    assert files == [str(a_cfg.resolve()), str(b_cfg.resolve())]
+    assert any("cycle" in msg for msg in caplog.messages)
+
+
+def test_directory_only_include(tmp_path):
+    main_cfg = tmp_path / "config"
+    inc_dir = tmp_path / "conf.d"
+    inc_dir.mkdir()
+    (inc_dir / "a").write_text("Host a\n    HostName a.example.com\n")
+    (inc_dir / "b").write_text("Host b\n    HostName b.example.com\n")
+    main_cfg.write_text("Include conf.d\n")
+    files = resolve_ssh_config_files(str(main_cfg))
+    assert files == [str(main_cfg.resolve()), str((inc_dir / 'a').resolve()), str((inc_dir / 'b').resolve())]
+
+
+def test_env_var_expansion(tmp_path, monkeypatch):
+    inc_dir = tmp_path / "envdir"
+    inc_dir.mkdir()
+    cfg = inc_dir / "c.conf"
+    cfg.write_text("Host c\n    HostName c.example.com\n")
+    main_cfg = tmp_path / "config"
+    monkeypatch.setenv("EXTRA", str(inc_dir))
+    main_cfg.write_text("Include $EXTRA/c.conf\n")
+    files = resolve_ssh_config_files(str(main_cfg))
+    assert files == [str(main_cfg.resolve()), str(cfg.resolve())]


### PR DESCRIPTION
## Summary
- Detect and warn about recursive SSH config include cycles and enforce a depth limit
- Expand environment variables and support directory-only `Include` directives
- Warn on missing or unreadable include files
- Test include cycle handling, directory includes, and env var expansion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8002a06248328a3f6c09647a466ca