### PR TITLE
Handle multiple labels on SSH Host lines

### DIFF
--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -55,8 +55,8 @@ def test_host_token_used_when_hostname_missing(tmp_path):
     assert conn.host == 'example.com'
 
 
-def test_alias_list_without_hostname(tmp_path):
-    """Alias groups without HostName should not gain HostName when formatted."""
+def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
+    """Multiple labels without HostName produce separate entries without aliases."""
     asyncio.set_event_loop(asyncio.new_event_loop())
 
     manager = ConnectionManager.__new__(ConnectionManager)
@@ -71,13 +71,41 @@ def test_alias_list_without_hostname(tmp_path):
 
     manager.load_ssh_config()
 
-    assert len(manager.connections) == 1
-    conn = manager.connections[0]
-    assert conn.nickname == 'primary'
-    assert conn.aliases == ['alias1', 'alias2']
-    assert conn.host == 'primary'
+    assert sorted(c.nickname for c in manager.connections) == ['alias1', 'alias2', 'primary']
+    for c in manager.connections:
+        assert c.host == c.nickname
+        assert c.aliases == []
 
-    entry = manager.format_ssh_config_entry(conn.data)
+    primary = next(c for c in manager.connections if c.nickname == 'primary')
+    entry = manager.format_ssh_config_entry(primary.data)
     assert 'HostName' not in entry
-    assert entry.splitlines()[0] == 'Host primary alias1 alias2'
+    assert entry.splitlines()[0] == 'Host primary'
+    assert 'alias1' not in entry and 'alias2' not in entry
+
+
+def test_alias_labels_with_hostname(tmp_path):
+    """Alias groups with HostName create entries for each label."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+    manager = ConnectionManager.__new__(ConnectionManager)
+    manager.connections = []
+
+    cfg = """Host app1 app2
+    HostName 192.168.1.50
+    User testuser
+"""
+    config_path = tmp_path / 'config'
+    config_path.write_text(cfg)
+    manager.ssh_config_path = str(config_path)
+
+    manager.load_ssh_config()
+
+    assert sorted(c.nickname for c in manager.connections) == ['app1', 'app2']
+    for c in manager.connections:
+        assert c.host == '192.168.1.50'
+        assert c.username == 'testuser'
+        if c.nickname == 'app1':
+            assert c.aliases == ['app2']
+        else:
+            assert c.aliases == ['app1']
 

--- a/tests/test_wildcard_rules.py
+++ b/tests/test_wildcard_rules.py
@@ -69,6 +69,6 @@ def test_wildcard_and_negated_hosts_are_stored_as_rules(tmp_path):
     assert len(cm.rules) == 2
     first, second = cm.rules
     assert first['host'] == '*.example.com'
-    assert first.get('aliases') == ['alias?']
+    assert 'aliases' not in first
     assert second['host'] == '!blocked'
 


### PR DESCRIPTION
## Summary
- expand SSH config parsing so each label on a Host line becomes its own connection entry
- treat Host line tokens as aliases only when a HostName directive is present
- add tests covering Host blocks without HostName and wildcard rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81de944dc83289ac2dce1be348aae