### PR TITLE
Drop SSH alias handling

### DIFF
--- a/sshpilot/search_utils.py
+++ b/sshpilot/search_utils.py
@@ -7,8 +7,7 @@ def connection_matches(connection: Any, query: str) -> bool:
     """Return True if connection matches the search query.
 
     The search checks the connection's nickname, host alias (``hname``),
-    any additional aliases, and host/IP address in a case-insensitive
-    manner.
+    and host/IP address in a case-insensitive manner.
     """
     if not query:
         return True
@@ -18,8 +17,6 @@ def connection_matches(connection: Any, query: str) -> bool:
         getattr(connection, "host", ""),
         getattr(connection, "hname", ""),
     ]
-    aliases = getattr(connection, "aliases", []) or []
-    fields.extend(aliases)
     return any(text in (field or "").lower() for field in fields)
 
 

--- a/tests/test_advanced_host_aliases.py
+++ b/tests/test_advanced_host_aliases.py
@@ -96,7 +96,7 @@ def test_host_aliases_added_via_advanced_tab():
     entry = cm.format_ssh_config_entry(connection.data)
 
     lines = entry.splitlines()
-    assert lines[0] == 'Host primary foo bar'
+    assert lines[0] == 'Host primary'
     assert 'HostName' not in entry
     assert sum(1 for line in lines if line.startswith('Host ')) == 1
 

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -74,7 +74,7 @@ def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
     assert sorted(c.nickname for c in manager.connections) == ['alias1', 'alias2', 'primary']
     for c in manager.connections:
         assert c.host == c.nickname
-        assert c.aliases == []
+        assert not hasattr(c, 'aliases')
 
     primary = next(c for c in manager.connections if c.nickname == 'primary')
 
@@ -105,10 +105,7 @@ def test_alias_labels_with_hostname(tmp_path):
     for c in manager.connections:
         assert c.host == '192.168.1.50'
         assert c.username == 'testuser'
-        if c.nickname == 'app1':
-            assert c.aliases == ['app2']
-        else:
-            assert c.aliases == ['app1']
+        assert not hasattr(c, 'aliases')
 
 
 def test_alias_labels_with_hostname(tmp_path):
@@ -132,4 +129,5 @@ def test_alias_labels_with_hostname(tmp_path):
     for c in manager.connections:
         assert c.host == '192.168.1.50'
         assert c.username == 'testuser'
+        assert not hasattr(c, 'aliases')
 

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -27,8 +27,7 @@ def test_matches_alias():
     assert connection_matches(conn, "myalias")
 
 
-def test_matches_alias_list():
+def test_alias_list_is_ignored():
     conn = Connection({"nickname": "srv", "host": "host", "username": "user", "aliases": ["alias1", "alias2"]})
-    assert connection_matches(conn, "alias1")
-    assert connection_matches(conn, "alias2")
-    assert not connection_matches(conn, "alias3")
+    assert not connection_matches(conn, "alias1")
+    assert not connection_matches(conn, "alias2")

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -15,7 +15,7 @@ def test_parse_host_with_quotes():
     }
     parsed = ConnectionManager.parse_host_config(cm, config)
     assert parsed["nickname"] == "nick name"
-    assert parsed["aliases"] == ["alias1", "alias two"]
+    assert "aliases" not in parsed
 
 
 def test_format_host_requotes():
@@ -27,4 +27,4 @@ def test_format_host_requotes():
         "username": "user",
     }
     entry = ConnectionManager.format_ssh_config_entry(cm, data)
-    assert entry.splitlines()[0] == 'Host "nick name" alias1 "alias two"'
+    assert entry.splitlines()[0] == 'Host "nick name"'


### PR DESCRIPTION
## Summary
- remove alias tracking from Connection objects and stop parsing alias tokens from SSH config
- update config loading to process each host token independently and only emit primary hostnames
- adjust search utilities and tests to reflect the absence of alias-based matching

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c831adf3c883289f4d91e48f23cc97