### PR TITLE
Remove connection alias field from dialog

### DIFF
--- a/tests/test_advanced_host_aliases.py
+++ b/tests/test_advanced_host_aliases.py
@@ -46,8 +46,8 @@ from sshpilot.connection_dialog import SSHConfigAdvancedTab
 from sshpilot.connection_manager import ConnectionManager
 
 
-def test_host_aliases_added_via_advanced_tab():
-    """Host entries in advanced tab populate alias list without stray directives."""
+def test_host_directives_ignored_in_advanced_tab():
+    """Host entries in advanced tab are ignored without touching connection aliases."""
 
     asyncio.set_event_loop(asyncio.new_event_loop())
 
@@ -61,17 +61,15 @@ def test_host_aliases_added_via_advanced_tab():
         def set_text(self, text):
             self._text = text
 
-    alias_row = DummyEntryRow()
-
     connection = types.SimpleNamespace(
         nickname='primary',
         host='primary',
         aliases=[],
-        data={'nickname': 'primary', 'host': 'primary', 'aliases': [], 'username': '', 'port': 22, 'extra_ssh_config': ''},
+        data={'nickname': 'primary', 'host': 'primary', 'username': '', 'port': 22, 'extra_ssh_config': ''},
         extra_ssh_config=''
     )
 
-    parent_dialog = types.SimpleNamespace(connection=connection, aliases_row=alias_row)
+    parent_dialog = types.SimpleNamespace(connection=connection)
 
     row_grid = types.SimpleNamespace()
     row_grid.key_dropdown = 'Host'
@@ -86,9 +84,8 @@ def test_host_aliases_added_via_advanced_tab():
 
     extra = tab.get_extra_ssh_config()
     assert extra == ''
-    assert alias_row.get_text() == 'foo bar'
-    assert connection.aliases == ['foo', 'bar']
-    assert connection.data['aliases'] == ['foo', 'bar']
+    assert connection.aliases == []
+    assert 'aliases' not in connection.data
     assert tab.config_entries == []
 
     connection.data['extra_ssh_config'] = extra
@@ -96,7 +93,7 @@ def test_host_aliases_added_via_advanced_tab():
     entry = cm.format_ssh_config_entry(connection.data)
 
     lines = entry.splitlines()
-    assert lines[0] == 'Host primary foo bar'
+    assert lines[0] == 'Host primary'
     assert 'HostName' not in entry
     assert sum(1 for line in lines if line.startswith('Host ')) == 1
 


### PR DESCRIPTION
## Summary
- remove the aliases entry row and related state updates from the connection dialog
- ensure the advanced tab ignores Host directives without attempting to merge aliases
- refresh the host alias test to reflect the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c831b643fc8328b9c8e1772a673f8a