### PR TITLE
Adjust context menu coordinates for scrolled list

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -709,7 +709,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         pass
                     if btn not in (Gdk.BUTTON_SECONDARY, 3):
                         return
-                    row = self.connection_list.get_row_at_y(int(y))
+                    adjusted_y = y
+                    vadjustment = scrolled.get_vadjustment()
+                    if vadjustment is not None:
+                        try:
+                            adjusted_y += vadjustment.get_value()
+                        except Exception:
+                            pass
+                    row = self.connection_list.get_row_at_y(int(adjusted_y))
                     if not row:
                         return
                     self.connection_list.select_row(row)
@@ -813,7 +820,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     try:
                         rect = Gdk.Rectangle()
                         rect.x = int(x)
-                        rect.y = int(y)
+                        rect.y = int(adjusted_y)
                         rect.width = 1
                         rect.height = 1
                         pop.set_pointing_to(rect)


### PR DESCRIPTION
## Summary
- add the scrolled window's vertical adjustment to gesture coordinates before resolving the clicked row
- apply the same adjusted coordinate when positioning the popover so the menu points at the intended row

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8708372a08328a45de7d5e44fcb4e