### PR TITLE
Clear selection after closing connection list context menu

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -743,6 +743,17 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     listbox.set_selection_mode(Gtk.SelectionMode.NONE)
                     pop.set_child(listbox)
                     
+                    def _clear_selection_on_close(*_args):
+                        try:
+                            if hasattr(self, "connection_list") and self.connection_list:
+                                self.connection_list.unselect_all()
+                        except Exception as err:
+                            logger.debug(
+                                f"Failed to clear connection list selection after context menu closed: {err}"
+                            )
+
+                    pop.connect("closed", _clear_selection_on_close)
+
                     # Add menu items based on row type
                     if hasattr(row, 'group_id'):
                         # Group row context menu


### PR DESCRIPTION
## Summary
- clear the connection list selection when the context menu popover closes to avoid stale highlights

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d4c72d608328a5c7068deeaceb0c