### PR TITLE
Fix context menu anchor position for connection list

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -711,9 +711,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     if btn not in (Gdk.BUTTON_SECONDARY, 3):
                         return
                     try:
-                        adjusted_y = float(y)
+                        original_y = float(y)
                     except (TypeError, ValueError):
-                        adjusted_y = 0.0
+                        original_y = 0.0
+                    adjusted_y = original_y
                     vadjustment = None
                     vadjust_value = 0.0
                     try:
@@ -726,7 +727,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         except Exception:
                             vadjust_value = 0.0
                         else:
-                            adjusted_y += vadjust_value
+                            adjusted_y = original_y + vadjust_value
                     row = self.connection_list.get_row_at_y(int(adjusted_y))
 
                     if not row:
@@ -832,7 +833,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     try:
                         rect = Gdk.Rectangle()
                         rect.x = int(x)
-                        rect.y = int(adjusted_y)
+                        rect.y = int(original_y)
 
                         rect.width = 1
                         rect.height = 1


### PR DESCRIPTION
## Summary
- keep the scroll-adjusted y coordinate only for row lookup in the connection list
- anchor the context menu popover using the original click position so the viewport does not jump on right-click

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d60a26808328bfe3704f2acfa740