### PR TITLE
Allow blank host entries

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -118,8 +118,10 @@ class SSHConnectionValidator:
             return ValidationResult(True, _("Unknown or uncommon top-level domain"), "warning")
         return ValidationResult(True, _("Valid hostname"))
 
-    def validate_hostname(self, hostname: str) -> 'ValidationResult':
+    def validate_hostname(self, hostname: str, allow_empty: bool = False) -> 'ValidationResult':
         if not hostname or not hostname.strip():
+            if allow_empty:
+                return ValidationResult(True, "")
             return ValidationResult(False, _("Hostname is required"), "error")
         hostname = hostname.strip()
         ip_result = self._validate_ip_address(hostname)
@@ -1531,7 +1533,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             raw = (text or '').strip()
             if raw.startswith('[') and raw.endswith(']') and len(raw) > 2:
                 raw = raw[1:-1]
-            result = self.validator.validate_hostname(raw)
+            result = self.validator.validate_hostname(raw, allow_empty=True)
         elif field_name == 'port':
             result = self.validator.validate_port(text, context)
         elif field_name == 'username':
@@ -3198,10 +3200,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             self.show_error(_("Please enter a nickname for this connection"))
             return
             
-        if not self.host_row.get_text().strip():
-            self.show_error(_("Please enter a hostname or IP address"))
-            return
-        
         # Initialize forwarding_rules list if needed
         if not hasattr(self, 'forwarding_rules') or self.forwarding_rules is None:
             self.forwarding_rules = []

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -932,10 +932,13 @@ class ConnectionManager(GObject.Object):
 
             host = host_token
 
+            hostname_value = config.get('hostname')
+            parsed_host = _unwrap(hostname_value) if hostname_value else ''
+
             # Extract relevant configuration
             parsed = {
                 'nickname': host,
-                'host': _unwrap(config.get('hostname', host)),
+                'host': parsed_host,
 
                 'port': int(_unwrap(config.get('port', 22))),
                 'username': _unwrap(config.get('user', getpass.getuser())),

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -37,7 +37,7 @@ from sshpilot.connection_manager import ConnectionManager
 
 
 def test_host_token_used_when_hostname_missing(tmp_path):
-    """Entries without HostName should use Host token for both nickname and hostname."""
+    """Entries without HostName should use Host token for nickname and leave host empty."""
     asyncio.set_event_loop(asyncio.new_event_loop())
 
     manager = ConnectionManager.__new__(ConnectionManager)
@@ -52,7 +52,7 @@ def test_host_token_used_when_hostname_missing(tmp_path):
     assert len(manager.connections) == 1
     conn = manager.connections[0]
     assert conn.nickname == 'example.com'
-    assert conn.host == 'example.com'
+    assert conn.host == ''
 
 
 def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
@@ -73,7 +73,7 @@ def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
 
     assert sorted(c.nickname for c in manager.connections) == ['alias1', 'alias2', 'primary']
     for c in manager.connections:
-        assert c.host == c.nickname
+        assert c.host == ''
         assert not hasattr(c, 'aliases')
 
     primary = next(c for c in manager.connections if c.nickname == 'primary')


### PR DESCRIPTION
## Summary
- allow the connection dialog host field to be left blank while still validating any entered hostname
- ensure SSH config parsing only sets the host when a HostName directive is present
- update host-without-hostname tests to expect empty host fields when HostName is omitted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc120bed188328a33be3fff8fd9d9b