### PR TITLE
Enforce nickname whitespace validation

### DIFF
--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -11,6 +11,13 @@ try:  # Skip test if Gtk/Adw bindings aren't available
 except Exception:  # pragma: no cover - environment without GI bindings
     pytest.skip("GTK or Adw not available", allow_module_level=True)
 
+if (
+    not hasattr(Gtk, 'ApplicationWindow')
+    or not hasattr(Adw, 'ApplicationWindow')
+    or not getattr(Gtk.ApplicationWindow, '__module__', '').startswith('gi.repository')
+):
+    pytest.skip("GTK/Adw ApplicationWindow unavailable", allow_module_level=True)
+
 
 
 def test_application_quit_with_confirmation_dialog_does_not_crash():

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -1,4 +1,61 @@
+import sys
+import types
+
+
+class _DummyGITypeMeta(type):
+    def __getattr__(cls, name):
+        value = _DummyGITypeMeta(name, (object,), {})
+        setattr(cls, name, value)
+        return value
+
+    def __call__(cls, *args, **kwargs):
+        return object()
+
+
+class _DummyGIModule(types.ModuleType):
+    def __getattr__(self, name):
+        value = _DummyGITypeMeta(name, (object,), {})
+        setattr(self, name, value)
+        return value
+
+
+def _ensure_gi_stub():
+    gi = sys.modules.get("gi")
+    if gi is None:
+        gi = types.ModuleType("gi")
+        gi.require_version = lambda *args, **kwargs: None
+        sys.modules["gi"] = gi
+    repository = getattr(gi, "repository", None)
+    if not isinstance(repository, _DummyGIModule):
+        repository = _DummyGIModule("gi.repository")
+        gi.repository = repository
+        sys.modules["gi.repository"] = repository
+    for name in ["Gtk", "Adw", "Gio", "GLib", "GObject", "Gdk", "Pango", "PangoFT2"]:
+        submodule = _DummyGIModule(f"gi.repository.{name}")
+        setattr(repository, name, submodule)
+        sys.modules[f"gi.repository.{name}"] = submodule
+    repository.GObject.SignalFlags = types.SimpleNamespace(RUN_FIRST=None)
+    repository.GLib.idle_add = lambda *a, **k: None
+
+
+_ORIGINAL_GI_MODULES = {
+    name: sys.modules.get(name)
+    for name in ["gi", "gi.repository"] + [f"gi.repository.{n}" for n in ["Gtk", "Adw", "Gio", "GLib", "GObject", "Gdk", "Pango", "PangoFT2"]]
+}
+
+_ensure_gi_stub()
+
+from sshpilot.connection_dialog import SSHConnectionValidator
 from sshpilot.connection_manager import ConnectionManager
+
+for name, module in _ORIGINAL_GI_MODULES.items():
+    if module is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = module
+
+if "gi" in sys.modules and "gi.repository" in sys.modules:
+    setattr(sys.modules["gi"], "repository", sys.modules["gi.repository"])
 
 
 def make_cm():
@@ -27,3 +84,10 @@ def test_format_host_requotes():
     }
     entry = ConnectionManager.format_ssh_config_entry(cm, data)
     assert entry.splitlines()[0] == 'Host "nick name"'
+
+
+def test_connection_name_rejects_whitespace():
+    validator = SSHConnectionValidator()
+    result = validator.validate_connection_name("nick name")
+    assert not result.is_valid
+    assert "whitespace" in result.message.lower()


### PR DESCRIPTION
## Summary
- disallow whitespace in connection names and add a GTK fallback stub for headless environments
- broaden GI stubs for tests and confine temporary replacements in the tokenization suite
- add whitespace validation coverage and guard the quit test when GTK widgets are unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1167757083289e51491100330b5b