### PR TITLE
Include libadwaita assets in macOS bundle

### DIFF
--- a/sshpilot.spec
+++ b/sshpilot.spec
@@ -64,6 +64,7 @@ datas += [
     (os.path.join(hb_share, "glib-2.0", "schemas"), "Resources/share/glib-2.0/schemas"),
     (os.path.join(hb_share, "icons", "Adwaita"),    "Resources/share/icons/Adwaita"),
     (os.path.join(hb_share, "gtk-4.0"),               "Resources/share/gtk-4.0"),
+    (os.path.join(hb_share, "libadwaita-1"),          "Resources/share/libadwaita-1"),
     ("sshpilot", "sshpilot"),
     ("sshpilot/resources/sshpilot.gresource", "Resources/sshpilot"),
     ("sshpilot/io.github.mfat.sshpilot.svg", "share/icons"),


### PR DESCRIPTION
## Summary
- copy Homebrew's libadwaita share directory into the bundled app resources so CSS and gresources are available at runtime

## Testing
- ./pyinstaller.sh *(fails: Homebrew python@3.13 not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc168b811c8328abe75e2d85e4fd40