### PR TITLE
Add connection duplication flow

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -58,6 +58,20 @@ class WindowActions:
         except Exception as e:
             logger.error(f"Failed to open new connection tab: {e}")
 
+    def on_duplicate_connection_action(self, action, param=None):
+        """Duplicate the currently selected connection."""
+        try:
+            connection = getattr(self, '_context_menu_connection', None)
+            if connection is None:
+                row = self.connection_list.get_selected_row()
+                connection = getattr(row, 'connection', None) if row else None
+            if connection is None:
+                return
+            if hasattr(self, 'duplicate_connection'):
+                self.duplicate_connection(connection)
+        except Exception as e:
+            logger.error(f"Failed to duplicate connection: {e}")
+
     def on_open_new_connection_tab_action(self, action, param=None):
         """Open a new tab for the selected connection via global shortcut (Ctrl/⌘+Alt+N)."""
         try:
@@ -679,6 +693,11 @@ def register_window_actions(window):
         window.manage_files_action = Gio.SimpleAction.new('manage-files', None)
         window.manage_files_action.connect('activate', window.on_manage_files_action)
         window.add_action(window.manage_files_action)
+
+    if hasattr(window, 'on_duplicate_connection_action'):
+        window.duplicate_connection_action = Gio.SimpleAction.new('duplicate-connection', None)
+        window.duplicate_connection_action.connect('activate', window.on_duplicate_connection_action)
+        window.add_action(window.duplicate_connection_action)
 
     # Action for editing connections via context menu
     window.edit_connection_action = Gio.SimpleAction.new('edit-connection', None)


### PR DESCRIPTION
## Summary
- add a window action handler for duplicating the selected connection and register the associated simple action
- implement connection duplication helpers in MainWindow to clone, normalize, persist, and select the new entry
- expose the duplicate command in the connection context menu before the manage files action

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2fef14a4832895a406f50c9c2456