### PR TITLE
Enable multi-selection actions in connection list

### DIFF
--- a/documentation/manual-qa.md
+++ b/documentation/manual-qa.md
@@ -1,0 +1,20 @@
+# Manual QA Checklist
+
+## Multi-selection connection management
+
+### Delete multiple connections
+1. Launch sshPilot and ensure the sidebar lists several connections.
+2. Hold Ctrl (or Command on macOS) and click two connection rows to multi-select them.
+3. Click the trash icon in the connection toolbar.
+4. Confirm that a single confirmation dialog references removing the selected hosts, then approve the action.
+5. Verify that both connections disappear from the sidebar.
+
+### Move multiple connections into a group
+1. With at least two connections selected (via Ctrl/Command-click), open the context menu on one of the highlighted rows.
+2. Choose **Move to Group** and pick an existing group (or create a new one) in the dialog.
+3. Confirm that all selected connections now appear under the chosen group.
+
+### Ungroup multiple connections
+1. Multi-select two grouped connections.
+2. Open the context menu on one of the highlighted rows and choose **Ungroup**.
+3. Confirm that both connections return to the Ungrouped section.


### PR DESCRIPTION
## Summary
- allow the connection list sidebar to use multi-selection and update toolbar/context menu state handling accordingly
- update delete and move actions to operate on every selected connection and guard against mixing group rows
- add manual QA notes for multi-selection delete and move workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce9ba465c83288e48923a53a6f111