### PR TITLE
Add configurable keyboard shortcut overrides

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -14,7 +14,7 @@ from .platform_utils import get_config_dir, is_flatpak
 logger = logging.getLogger(__name__)
 
 # Increment this whenever the configuration format changes
-CONFIG_VERSION = 2
+CONFIG_VERSION = 3
 
 class Config(GObject.Object):
     """Configuration manager for sshPilot"""
@@ -96,14 +96,54 @@ class Config(GObject.Object):
         try:
             if config_data is None:
                 config_data = self.config_data
-            
+
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
             with open(self.config_file, 'w') as f:
                 json.dump(config_data, f, indent=2)
-            
+
             logger.debug("Configuration saved to JSON file")
         except Exception as e:
             logger.error(f"Failed to save JSON config: {e}")
+
+    # --- Shortcut helpers -------------------------------------------------
+
+    def get_shortcut_overrides(self) -> Dict[str, Any]:
+        """Return the stored shortcut overrides mapping."""
+        try:
+            overrides = self.get_setting('shortcuts', {})
+            if isinstance(overrides, dict):
+                return overrides
+        except Exception:
+            pass
+        return {}
+
+    def get_shortcut_override(self, action_name: str):
+        """Return the stored shortcut override for an action.
+
+        Returns ``None`` when no override is stored, an empty list when the
+        shortcut is disabled, or the list of accelerator strings otherwise.
+        """
+        overrides = self.get_shortcut_overrides()
+        value = overrides.get(action_name)
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return value
+        # Coerce malformed entries back to sane defaults
+        return None
+
+    def set_shortcut_override(self, action_name: str, accelerators: Optional[list[str]]):
+        """Persist a shortcut override.
+
+        ``None`` clears the override, an empty list disables the shortcut, and
+        any other list stores custom accelerators for the action.
+        """
+        overrides = self.get_shortcut_overrides().copy()
+        if accelerators is None:
+            overrides.pop(action_name, None)
+        else:
+            overrides[action_name] = accelerators
+        self.set_setting('shortcuts', overrides)
 
     def get_default_config(self) -> Dict[str, Any]:
         """Get default configuration values"""
@@ -130,6 +170,7 @@ class Config(GObject.Object):
                 'tile_color': None,  # None for default, or hex color for custom
             },
             'connections_meta': {},  # per-connection metadata
+            'shortcuts': {},  # action -> list of custom accelerators
             'ssh': {
                 'connection_timeout': 30,
                 'keepalive_interval': 60,

--- a/sshpilot/shortcut_editor.py
+++ b/sshpilot/shortcut_editor.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import logging
+from gettext import gettext as _
+from typing import Dict, List, Optional
+
+from gi.repository import Adw, Gdk, Gtk
+
+logger = logging.getLogger(__name__)
+
+
+ACTION_LABELS: Dict[str, str] = {
+    'quit': _('Quit'),
+    'new-connection': _('New Connection'),
+    'open-new-connection-tab': _('Open New Connection Tab'),
+    'toggle-list': _('Focus Connection List'),
+    'search': _('Search Connections'),
+    'new-key': _('Copy Key to Server'),
+    'edit-ssh-config': _('SSH Config Editor'),
+    'local-terminal': _('Local Terminal'),
+    'preferences': _('Preferences'),
+    'tab-close': _('Close Tab'),
+    'broadcast-command': _('Broadcast Command'),
+    'help': _('Documentation'),
+    'shortcuts': _('Keyboard Shortcuts'),
+    'tab-next': _('Next Tab'),
+    'tab-prev': _('Previous Tab'),
+    'tab-overview': _('Tab Overview'),
+    'quick-connect': _('Quick Connect'),
+}
+
+
+def _get_action_label(name: str) -> str:
+    label = ACTION_LABELS.get(name)
+    if label:
+        return label
+    return name.replace('-', ' ').title()
+
+
+class _ShortcutCaptureDialog(Adw.Window):
+    """Modal dialog that captures a shortcut press."""
+
+    def __init__(self, parent: Adw.Window, on_selected):
+        super().__init__(transient_for=parent, modal=True)
+        self.set_title(_('Assign Shortcut'))
+        self.set_default_size(360, 160)
+        self._on_selected = on_selected
+        self._handled = False
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(24)
+        box.set_margin_bottom(24)
+        box.set_margin_start(24)
+        box.set_margin_end(24)
+
+        title = Gtk.Label(label=_('Press the new shortcut'))
+        title.add_css_class('title-3')
+        title.set_halign(Gtk.Align.CENTER)
+
+        subtitle = Gtk.Label(
+            label=_('Press Esc to cancel. Shortcuts must include a key (modifiers optional).')
+        )
+        subtitle.set_wrap(True)
+        subtitle.set_justify(Gtk.Justification.CENTER)
+
+        box.append(title)
+        box.append(subtitle)
+
+        self.set_content(box)
+
+        controller = Gtk.EventControllerKey()
+        controller.connect('key-pressed', self._on_key_pressed)
+        self.add_controller(controller)
+
+    def _on_key_pressed(self, _controller, keyval: int, keycode: int, state: Gdk.ModifierType) -> bool:
+        if self._handled:
+            return True
+
+        if keyval == Gdk.KEY_Escape:
+            self.close()
+            return True
+
+        # Mask modifiers to GTK's default accelerator mask
+        modifiers = state & Gtk.accelerator_get_default_mod_mask()
+
+        if not Gtk.accelerator_valid(keyval, modifiers):
+            return True
+
+        accelerator = Gtk.accelerator_name_with_keycode(None, keyval, keycode, modifiers)
+        if not accelerator:
+            accelerator = Gtk.accelerator_name(keyval, modifiers)
+
+        if accelerator:
+            self._handled = True
+            try:
+                self._on_selected(accelerator)
+            finally:
+                self.close()
+        return True
+
+
+class ShortcutEditorWindow(Adw.Window):
+    """Window that allows editing of application keyboard shortcuts."""
+
+    def __init__(self, parent_window):
+        super().__init__(transient_for=parent_window, modal=True)
+        self.set_title(_('Shortcut Editor'))
+        self.set_default_size(560, 520)
+
+        self._parent_window = parent_window
+        self._app = parent_window.get_application()
+        self._config = getattr(self._app, 'config', None)
+        self._rows: Dict[str, Adw.ActionRow] = {}
+        self._pending_overrides: Dict[str, List[str]] = {}
+        self._default_shortcuts: Dict[str, Optional[List[str]]] = {}
+
+        if self._config is not None:
+            try:
+                stored = self._config.get_shortcut_overrides()
+                if isinstance(stored, dict):
+                    self._pending_overrides = {
+                        name: value for name, value in stored.items() if isinstance(value, list)
+                    }
+            except Exception as exc:
+                logger.error('Failed to load shortcut overrides: %s', exc)
+
+        try:
+            defaults = self._app.get_registered_shortcut_defaults()
+            if isinstance(defaults, dict):
+                self._default_shortcuts = defaults
+        except Exception as exc:
+            logger.error('Failed to load default shortcuts: %s', exc)
+
+        self._action_names = self._collect_actions()
+
+        toolbar_view = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        header.set_title_widget(Adw.WindowTitle.new(_('Shortcut Editor'), _('Customize keyboard shortcuts')))
+        toolbar_view.add_top_bar(header)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(self._build_list_box())
+
+        toolbar_view.set_content(scrolled)
+        self.set_content(toolbar_view)
+
+        self.connect('close-request', self._on_close_request)
+
+    def _collect_actions(self) -> List[str]:
+        names: List[str] = []
+        try:
+            order = self._app.get_registered_action_order()
+        except Exception:
+            order = []
+
+        for name in order:
+            default = self._default_shortcuts.get(name)
+            override = self._pending_overrides.get(name)
+            if default is None and override is None:
+                continue
+            names.append(name)
+        return names
+
+    def _build_list_box(self) -> Gtk.Widget:
+        list_box = Gtk.ListBox()
+        list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        for name in self._action_names:
+            row = Adw.ActionRow()
+            row.set_title(_get_action_label(name))
+            row.set_subtitle(self._build_subtitle(name))
+            row.set_activatable(True)
+            row.connect('activated', self._on_row_activated, name)
+
+            buttons = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+
+            assign_button = Gtk.Button(label=_('Assign…'))
+            assign_button.add_css_class('suggested-action')
+            assign_button.connect('clicked', self._on_assign_clicked, name)
+            buttons.append(assign_button)
+
+            disable_button = Gtk.Button(label=_('Disable'))
+            disable_button.connect('clicked', self._on_disable_clicked, name)
+            buttons.append(disable_button)
+
+            reset_button = Gtk.Button(label=_('Reset'))
+            reset_button.connect('clicked', self._on_reset_clicked, name)
+            buttons.append(reset_button)
+
+            row.add_suffix(buttons)
+            row.set_activatable_widget(assign_button)
+
+            list_box.append(row)
+            self._rows[name] = row
+
+        return list_box
+
+    def _build_subtitle(self, action_name: str) -> str:
+        current = self._format_accelerators(self._get_effective_shortcuts(action_name))
+        default = self._format_accelerators(self._default_shortcuts.get(action_name))
+        subtitle_parts = [
+            _('Current: {shortcut}').format(shortcut=current),
+        ]
+        subtitle_parts.append(_('Default: {shortcut}').format(shortcut=default))
+        return '\n'.join(subtitle_parts)
+
+    def _format_accelerators(self, accelerators: Optional[List[str]]) -> str:
+        if accelerators is None:
+            return _('None')
+        if len(accelerators) == 0:
+            return _('Disabled')
+
+        labels: List[str] = []
+        for accel in accelerators:
+            keyval, modifiers = Gtk.accelerator_parse(accel)
+            if keyval == 0 and modifiers == 0:
+                labels.append(accel)
+            else:
+                labels.append(Gtk.accelerator_get_label(keyval, modifiers))
+        return ', '.join(labels) if labels else _('None')
+
+    def _get_effective_shortcuts(self, action_name: str) -> Optional[List[str]]:
+        if action_name in self._pending_overrides:
+            return self._pending_overrides[action_name]
+        return self._default_shortcuts.get(action_name)
+
+    def _on_row_activated(self, _row, action_name: str):
+        self._on_assign_clicked(None, action_name)
+
+    def _on_assign_clicked(self, _button, action_name: str):
+        dialog = _ShortcutCaptureDialog(self, lambda accel: self._attempt_set_override(action_name, [accel]))
+        dialog.present()
+
+    def _on_disable_clicked(self, _button, action_name: str):
+        self._attempt_set_override(action_name, [])
+
+    def _on_reset_clicked(self, _button, action_name: str):
+        self._attempt_set_override(action_name, None)
+
+    def _attempt_set_override(self, action_name: str, accelerators: Optional[List[str]]):
+        if accelerators and len(accelerators) > 1:
+            accelerators = accelerators[:1]
+
+        if accelerators and len(accelerators) == 1:
+            conflict = self._find_conflict(action_name, accelerators[0])
+            if conflict:
+                self._show_conflict_dialog(conflict)
+                return
+
+        default = self._default_shortcuts.get(action_name)
+        normalized: Optional[List[str]]
+        if accelerators is None:
+            normalized = None
+        else:
+            normalized = list(accelerators)
+            if default is not None and normalized == default:
+                normalized = None
+
+        if normalized is None:
+            self._pending_overrides.pop(action_name, None)
+        else:
+            self._pending_overrides[action_name] = normalized
+
+        if self._config is not None:
+            try:
+                self._config.set_shortcut_override(action_name, normalized)
+            except Exception as exc:
+                logger.error('Failed to persist shortcut override for %s: %s', action_name, exc)
+
+        self._update_row_display(action_name)
+        self._apply_shortcuts()
+
+    def _update_row_display(self, action_name: str):
+        row = self._rows.get(action_name)
+        if row is not None:
+            row.set_subtitle(self._build_subtitle(action_name))
+
+    def _find_conflict(self, action_name: str, accelerator: str) -> Optional[str]:
+        for other in self._action_names:
+            if other == action_name:
+                continue
+            current = self._get_effective_shortcuts(other)
+            if not current:
+                continue
+            if accelerator in current:
+                return other
+        return None
+
+    def _show_conflict_dialog(self, conflict_action: str):
+        dialog = Adw.MessageDialog(
+            transient_for=self,
+            modal=True,
+            heading=_('Shortcut Already In Use'),
+            body=_('The selected shortcut is already assigned to “{action}”.').format(
+                action=_get_action_label(conflict_action)
+            ),
+        )
+        dialog.add_response('ok', _('OK'))
+        dialog.connect('response', lambda d, _r: d.close())
+        dialog.present()
+
+    def _apply_shortcuts(self):
+        try:
+            self._app.apply_shortcut_overrides()
+        except Exception as exc:
+            logger.error('Failed to reapply shortcuts: %s', exc)
+
+    def _on_close_request(self, *_args):
+        self._apply_shortcuts()
+        return False
+
+
+__all__ = ['ShortcutEditorWindow']


### PR DESCRIPTION
## Summary
- add shortcut override storage helpers to the configuration and bump the config version
- teach the application to reuse stored overrides when registering actions and to expose shortcut metadata
- add a shortcut editor window that lets users assign or disable accelerators with conflict detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd260db2d08328829d7c9788c1f913