### PR TITLE
Add SCP download flow with direction-aware transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - Option to use the built-in terminal or your favorite one
 - Broadcast commands to all open tabs
 - Full support for Local, Remote and Dynamic port forwarding 
-- SCP support for quicly uploading a file to remote server
+- SCP support for quickly uploading or downloading files to/from remote servers
 - Keypair generation and copying to remote servers (ssh-copy-id)
 - Support for running remote and local commands upon login
 - Secure storage for credentials via libsecret on Linux; no secret (password or passphrase) is copied to clipboard or saved to plain text

--- a/sshpilot/scp_utils.py
+++ b/sshpilot/scp_utils.py
@@ -1,0 +1,68 @@
+"""Utilities for assembling scp command arguments."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+import re
+
+_REMOTE_SPEC_RE = re.compile(r"^[^@]+@[^:]+:.+$")
+
+
+def _extract_host(target: str) -> str:
+    if '@' in target:
+        return target.split('@', 1)[1]
+    return target
+
+
+def _normalize_remote_sources(target: str, sources: Iterable[str]) -> List[str]:
+    host = _extract_host(target)
+    normalized: List[str] = []
+    for item in sources:
+        path = (item or '').strip()
+        if not path:
+            continue
+        if path.startswith(f"{target}:"):
+            normalized.append(path)
+            continue
+        if host and path.startswith(f"{host}:"):
+            normalized.append(path)
+            continue
+        if _REMOTE_SPEC_RE.match(path):
+            normalized.append(path)
+            continue
+        normalized.append(f"{target}:{path}")
+    return normalized
+
+
+def assemble_scp_transfer_args(
+    target: str,
+    sources: Iterable[str],
+    destination: str,
+    direction: str,
+) -> Tuple[List[str], str]:
+    """Return normalized scp sources and destination arguments for a transfer.
+
+    Parameters
+    ----------
+    target:
+        The ``user@host`` string for the connection (user may be omitted).
+    sources:
+        Iterable of source paths supplied by the caller.
+    destination:
+        Destination path (remote directory for uploads or local path for downloads).
+    direction:
+        Either ``"upload"`` or ``"download"``.
+    """
+    direction_value = (direction or '').lower()
+    if direction_value not in {'upload', 'download'}:
+        raise ValueError(f"Unsupported scp direction: {direction}")
+
+    if direction_value == 'upload':
+        cleaned_sources = [s for s in sources if s]
+        return cleaned_sources, f"{target}:{destination}"
+
+    remote_sources = _normalize_remote_sources(target, sources)
+    return remote_sources, destination
+
+
+__all__ = ['assemble_scp_transfer_args']

--- a/tests/test_scp_transfers.py
+++ b/tests/test_scp_transfers.py
@@ -1,0 +1,106 @@
+import subprocess
+
+import pytest
+
+from sshpilot.scp_utils import assemble_scp_transfer_args
+from sshpilot import ssh_password_exec
+
+
+def test_assemble_scp_transfer_args_upload():
+    sources, destination = assemble_scp_transfer_args(
+        'alice@example.com',
+        ['file1.txt', 'dir/archive.tar'],
+        '/var/tmp',
+        'upload',
+    )
+    assert sources == ['file1.txt', 'dir/archive.tar']
+    assert destination == 'alice@example.com:/var/tmp'
+
+
+def test_assemble_scp_transfer_args_download_normalizes_host():
+    sources, destination = assemble_scp_transfer_args(
+        'alice@example.com',
+        ['~/logs/app.log', 'example.com:/opt/data.tar'],
+        '/tmp/out',
+        'download',
+    )
+    assert sources[0] == 'alice@example.com:~/logs/app.log'
+    assert sources[1] == 'example.com:/opt/data.tar'
+    assert destination == '/tmp/out'
+
+
+@pytest.mark.parametrize('direction,expected_path', [
+    ('upload', 'alice@example.com:/remote/dir'),
+    ('download', '/local/dir'),
+])
+def test_run_scp_with_password_builds_command(monkeypatch, direction, expected_path):
+    recorded = {}
+
+    tmpdir = []
+
+    original_mkdtemp = ssh_password_exec.tempfile.mkdtemp
+
+    def fake_mkdtemp(prefix=None):
+        path = original_mkdtemp(prefix=prefix)
+        tmpdir.append(path)
+        return path
+
+    monkeypatch.setattr(ssh_password_exec.tempfile, 'mkdtemp', fake_mkdtemp)
+
+    original_exists = ssh_password_exec.os.path.exists
+    original_access = ssh_password_exec.os.access
+
+    def fake_exists(path):
+        if path == '/app/bin/sshpass':
+            return False
+        return original_exists(path)
+
+    def fake_access(path, mode):
+        if path == '/app/bin/sshpass':
+            return False
+        return original_access(path, mode)
+
+    monkeypatch.setattr(ssh_password_exec.os.path, 'exists', fake_exists)
+    monkeypatch.setattr(ssh_password_exec.os, 'access', fake_access)
+
+    def fake_which(binary):
+        if binary == 'sshpass':
+            return '/usr/bin/sshpass'
+        if binary == 'scp':
+            return '/usr/bin/scp'
+        return None
+
+    monkeypatch.setattr(ssh_password_exec.shutil, 'which', fake_which)
+
+    def fake_run(cmd, env, text, capture_output, check):
+        recorded['cmd'] = cmd
+        recorded['env'] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(ssh_password_exec.subprocess, 'run', fake_run)
+
+    result = ssh_password_exec.run_scp_with_password(
+        'example.com',
+        'alice',
+        'topsecret',
+        ['/local/file'] if direction == 'upload' else ['~/remote.dat'],
+        '/remote/dir' if direction == 'upload' else '/local/dir',
+        direction=direction,
+        port=2222,
+    )
+
+    assert isinstance(result, subprocess.CompletedProcess)
+    cmd = recorded['cmd']
+    assert cmd[0] == '/usr/bin/sshpass'
+    assert cmd[1] == '-f'
+    assert cmd[3] == '/usr/bin/scp'
+    assert cmd[4:7] == ['-v', '-P', '2222']
+    assert expected_path == cmd[-1]
+    if direction == 'download':
+        assert 'alice@example.com:~/remote.dat' in cmd
+    else:
+        assert 'alice@example.com:/remote/dir' == cmd[-1]
+
+    # Cleanup temp directories created during the test
+    for path in tmpdir:
+        ssh_password_exec.shutil.rmtree(path, ignore_errors=True)


### PR DESCRIPTION
## Summary
- replace the toolbar upload shortcut with an scp action chooser that supports uploads and new download prompts
- reuse the scp terminal workflow for both directions and build direction-aware command arguments
- extend password-based scp execution and add regression tests for the helper utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd30137fd88328a313eaaa55e304d2