### PR TITLE
Refactor file manager integration

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -4,7 +4,6 @@ import logging
 from gi.repository import Gio, Gtk, Adw, GLib
 from gettext import gettext as _
 
-from .sftp_utils import open_remote_in_file_manager
 from .preferences import (
     should_hide_external_terminal_options,
     should_hide_file_manager_options,
@@ -99,30 +98,13 @@ class WindowActions:
         if hasattr(self, '_context_menu_connection') and self._context_menu_connection:
             connection = self._context_menu_connection
             try:
-                # Define error callback for async operation
-                def error_callback(error_msg):
-                    logger.error(f"Failed to open file manager for {connection.nickname}: {error_msg}")
-                    # Show error dialog to user
-                    self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
-
-                host_value = getattr(connection, 'hostname', getattr(connection, 'host', getattr(connection, 'nickname', '')))
-                success, error_msg = open_remote_in_file_manager(
-                    user=connection.username,
-                    host=host_value,
-                    port=connection.port if connection.port != 22 else None,
-                    error_callback=error_callback,
-                    parent_window=self
+                self._open_sftp_file_manager_for_connection(
+                    connection,
+                    restrict_to_file_manager=True,
+                    show_error=True,
                 )
-                if success:
-                    logger.info(f"Started file manager process for {connection.nickname}")
-                else:
-                    logger.error(f"Failed to start file manager process for {connection.nickname}: {error_msg}")
-                    # Show error dialog to user
-                    self._show_manage_files_error(connection.nickname, error_msg or "Failed to start file manager process")
             except Exception as e:
-                logger.error(f"Error opening file manager: {e}")
-                # Show error dialog to user
-                self._show_manage_files_error(connection.nickname, str(e))
+                logger.error(f"Error opening SFTP file manager: {e}")
 
     def on_edit_connection_action(self, action, param=None):
         """Handle edit connection action from context menu"""

--- a/tests/test_macos_terminal.py
+++ b/tests/test_macos_terminal.py
@@ -53,7 +53,9 @@ stub_modules = {
     "sshpilot.sshcopyid_window": types.SimpleNamespace(SshCopyIdWindow=object),
     "sshpilot.groups": types.SimpleNamespace(GroupManager=object),
     "sshpilot.sidebar": types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
-    "sshpilot.sftp_utils": types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+    "sshpilot.file_manager": types.SimpleNamespace(
+        launch_sftp_file_manager_for_connection=lambda *a, **k: types.SimpleNamespace(present=lambda: None)
+    ),
     "sshpilot.welcome_page": types.SimpleNamespace(WelcomePage=object),
     "sshpilot.actions": types.SimpleNamespace(WindowActions=object, register_window_actions=lambda *a, **k: None),
     "sshpilot.shutdown": types.SimpleNamespace(),

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -37,11 +37,19 @@ def reload_module(name):
 
 def prepare_actions(monkeypatch):
     setup_gi(monkeypatch)
-    sftp_stub = types.ModuleType("sshpilot.sftp_utils")
-    def open_remote_in_file_manager(*args, **kwargs):
-        return True, None
-    sftp_stub.open_remote_in_file_manager = open_remote_in_file_manager
-    monkeypatch.setitem(sys.modules, "sshpilot.sftp_utils", sftp_stub)
+    file_manager_stub = types.ModuleType("sshpilot.file_manager")
+
+    class DummyFileManager:
+        def present(self):
+            pass
+
+    def launch_sftp_file_manager_for_connection(*args, **kwargs):
+        return DummyFileManager()
+
+    file_manager_stub.launch_sftp_file_manager_for_connection = (
+        launch_sftp_file_manager_for_connection
+    )
+    monkeypatch.setitem(sys.modules, "sshpilot.file_manager", file_manager_stub)
     return reload_module("sshpilot.actions")
 
 
@@ -75,6 +83,8 @@ def create_window():
              pass
         def on_toggle_sidebar_action(self, *args):
              pass
+        def _open_sftp_file_manager_for_connection(self, *args, **kwargs):
+            self.file_manager_opened = True
     return DummyWindow()
 
 

--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -38,7 +38,9 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
         'sshpilot.sshcopyid_window': types.SimpleNamespace(SshCopyIdWindow=object),
         'sshpilot.groups': types.SimpleNamespace(GroupManager=lambda config: None),
         'sshpilot.sidebar': types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
-        'sshpilot.sftp_utils': types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+        'sshpilot.file_manager': types.SimpleNamespace(
+            launch_sftp_file_manager_for_connection=lambda *a, **k: types.SimpleNamespace(present=lambda: None)
+        ),
         'sshpilot.welcome_page': types.SimpleNamespace(WelcomePage=object),
         'sshpilot.actions': types.SimpleNamespace(WindowActions=object, register_window_actions=lambda window: None),
         'sshpilot.shutdown': types.SimpleNamespace(cleanup_and_quit=lambda w: None),


### PR DESCRIPTION
## Summary
- add a connection-aware helper for launching the SFTP file manager and support a restricted remote-only mode
- reuse the helper from the SCP toolbar button and manage-files actions while tracking open manager windows
- update unit tests to stub the new launcher helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd44bba9c08328ac1eaf564f81b789