### PR TITLE
Use new file manager helpers

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -4,7 +4,7 @@ import logging
 from gi.repository import Gio, Gtk, Adw, GLib
 from gettext import gettext as _
 
-from .sftp_utils import open_remote_in_file_manager
+from .file_manager import open_connection_in_file_manager
 from .preferences import (
     should_hide_external_terminal_options,
     should_hide_file_manager_options,
@@ -91,12 +91,10 @@ class WindowActions:
                     # Show error dialog to user
                     self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
 
-                success, error_msg = open_remote_in_file_manager(
-                    user=connection.username,
-                    host=connection.host,
-                    port=connection.port if connection.port != 22 else None,
+                success, error_msg = open_connection_in_file_manager(
+                    connection,
                     error_callback=error_callback,
-                    parent_window=self
+                    parent_window=self,
                 )
                 if success:
                     logger.info(f"Started file manager process for {connection.nickname}")

--- a/sshpilot/file_manager.py
+++ b/sshpilot/file_manager.py
@@ -1,0 +1,65 @@
+"""High-level APIs for launching remote file manager sessions."""
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple
+
+from .sftp_utils import open_remote_in_file_manager as _open_remote_in_file_manager
+
+
+def open_connection_in_file_manager(
+    connection,
+    *,
+    path: Optional[str] = None,
+    parent_window=None,
+    error_callback: Optional[Callable[[str], None]] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Open the provided connection in the system file manager.
+
+    The helper normalizes connection attributes before delegating to the
+    lower-level SFTP utilities so callers don't need to duplicate logic for
+    stripping default ports or extracting credentials from the connection
+    object.
+    """
+
+    username = getattr(connection, "username", None)
+    host = getattr(connection, "host", None)
+    port = getattr(connection, "port", None)
+
+    if port == 22:
+        port = None
+
+    return open_remote_location(
+        user=username,
+        host=host,
+        port=port,
+        path=path,
+        parent_window=parent_window,
+        error_callback=error_callback,
+    )
+
+
+def open_remote_location(
+    *,
+    user: str,
+    host: str,
+    port: Optional[int] = None,
+    path: Optional[str] = None,
+    parent_window=None,
+    error_callback: Optional[Callable[[str], None]] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Open a remote SFTP location in the system file manager."""
+
+    return _open_remote_in_file_manager(
+        user=user,
+        host=host,
+        port=port,
+        path=path,
+        error_callback=error_callback,
+        parent_window=parent_window,
+    )
+
+
+__all__ = [
+    "open_connection_in_file_manager",
+    "open_remote_location",
+]

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -50,7 +50,7 @@ from .sshcopyid_window import SshCopyIdWindow
 from .groups import GroupManager
 from .sidebar import GroupRow, ConnectionRow, build_sidebar
 
-from .sftp_utils import open_remote_in_file_manager
+from .file_manager import open_connection_in_file_manager
 from .welcome_page import WelcomePage
 from .actions import WindowActions, register_window_actions
 from . import shutdown
@@ -2831,12 +2831,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     # Show error dialog to user
                     self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
                 
-                success, error_msg = open_remote_in_file_manager(
-                    user=connection.username,
-                    host=connection.host,
-                    port=connection.port if connection.port != 22 else None,
+                success, error_msg = open_connection_in_file_manager(
+                    connection,
                     error_callback=error_callback,
-                    parent_window=self
+                    parent_window=self,
                 )
                 if success:
                     logger.info(f"Started file manager process for {connection.nickname}")
@@ -4457,12 +4455,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     # Show error dialog to user
                     self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
                 
-                success, error_msg = open_remote_in_file_manager(
-                    user=connection.username,
-                    host=connection.host,
-                    port=connection.port if connection.port != 22 else None,
+                success, error_msg = open_connection_in_file_manager(
+                    connection,
                     error_callback=error_callback,
-                    parent_window=self
+                    parent_window=self,
                 )
                 if success:
                     logger.info(f"Started file manager process for {connection.nickname}")

--- a/tests/test_macos_terminal.py
+++ b/tests/test_macos_terminal.py
@@ -53,7 +53,7 @@ stub_modules = {
     "sshpilot.sshcopyid_window": types.SimpleNamespace(SshCopyIdWindow=object),
     "sshpilot.groups": types.SimpleNamespace(GroupManager=object),
     "sshpilot.sidebar": types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
-    "sshpilot.sftp_utils": types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+    "sshpilot.file_manager": types.SimpleNamespace(open_connection_in_file_manager=lambda *a, **k: None),
     "sshpilot.welcome_page": types.SimpleNamespace(WelcomePage=object),
     "sshpilot.actions": types.SimpleNamespace(WindowActions=object, register_window_actions=lambda *a, **k: None),
     "sshpilot.shutdown": types.SimpleNamespace(),

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -37,11 +37,11 @@ def reload_module(name):
 
 def prepare_actions(monkeypatch):
     setup_gi(monkeypatch)
-    sftp_stub = types.ModuleType("sshpilot.sftp_utils")
-    def open_remote_in_file_manager(*args, **kwargs):
+    fm_stub = types.ModuleType("sshpilot.file_manager")
+    def open_connection_in_file_manager(*args, **kwargs):
         return True, None
-    sftp_stub.open_remote_in_file_manager = open_remote_in_file_manager
-    monkeypatch.setitem(sys.modules, "sshpilot.sftp_utils", sftp_stub)
+    fm_stub.open_connection_in_file_manager = open_connection_in_file_manager
+    monkeypatch.setitem(sys.modules, "sshpilot.file_manager", fm_stub)
     return reload_module("sshpilot.actions")
 
 

--- a/tests/test_quit_no_crash.py
+++ b/tests/test_quit_no_crash.py
@@ -31,7 +31,7 @@ def test_application_quit_with_confirmation_dialog_does_not_crash():
         'sshpilot.sshcopyid_window': types.SimpleNamespace(SshCopyIdWindow=object),
         'sshpilot.groups': types.SimpleNamespace(GroupManager=lambda config: None),
         'sshpilot.sidebar': types.SimpleNamespace(GroupRow=object, ConnectionRow=object, build_sidebar=lambda *a, **k: None),
-        'sshpilot.sftp_utils': types.SimpleNamespace(open_remote_in_file_manager=lambda *a, **k: None),
+        'sshpilot.file_manager': types.SimpleNamespace(open_connection_in_file_manager=lambda *a, **k: None),
         'sshpilot.welcome_page': types.SimpleNamespace(WelcomePage=object),
         'sshpilot.actions': types.SimpleNamespace(WindowActions=object, register_window_actions=lambda window: None),
         'sshpilot.shutdown': types.SimpleNamespace(cleanup_and_quit=lambda w: None),


### PR DESCRIPTION
## Summary
- add a new file_manager helper module to wrap launching SFTP file managers
- update MainWindow and associated actions to call the new helper API
- refresh tests to stub the new module when exercising the Manage Files UI

## Testing
- pytest tests/test_manage_files_ui.py tests/test_macos_terminal.py tests/test_quit_no_crash.py

------
https://chatgpt.com/codex/tasks/task_e_68cd501f48bc83288d1714ea5f0439c5