### PR TITLE
Support custom SSH ports in key-based connections

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from typing import Optional
 
 try:
     import gi
@@ -493,18 +494,27 @@ def get_scp_ssh_options() -> list:
         "-o", "IdentitiesOnly=yes",
     ]
 
-def connect_ssh_with_key(host: str, username: str, key_path: str, command: str = None) -> subprocess.CompletedProcess:
+def connect_ssh_with_key(
+    host: str,
+    username: str,
+    key_path: str,
+    command: str = None,
+    port: Optional[int] = None,
+) -> subprocess.CompletedProcess:
     """Connect via SSH with proper key handling"""
     # Ensure key is loaded in ssh-agent
     if not ensure_key_in_agent(key_path):
         raise Exception(f"Failed to load key {key_path} into SSH agent")
-    
+
     # Get SSH environment with askpass
     env = get_ssh_env_with_askpass("force")
-    
+
     # Build SSH command
     ssh_cmd = ["ssh", "-o", "PreferredAuthentications=publickey", "-o", "PasswordAuthentication=no"]
-    
+
+    if port is not None:
+        ssh_cmd.extend(["-p", str(port)])
+
     if command:
         ssh_cmd.extend([f"{username}@{host}", command])
     else:

--- a/sshpilot/file_manager.py
+++ b/sshpilot/file_manager.py
@@ -34,7 +34,7 @@ except ImportError:
             return os.environ.copy()
         def ensure_key_in_agent(key_path):
             return True
-        def connect_ssh_with_key(host, username, key_path, command=None):
+        def connect_ssh_with_key(host, username, key_path, command=None, port=None):
             raise NotImplementedError("askpass_utils module not available")
         def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False):
             return []
@@ -354,7 +354,13 @@ class SftpFileManager(Adw.ApplicationWindow):
                     return
                 
                 # Test connection using your SSH utilities
-                result = connect_ssh_with_key(host, username, key_file, "echo 'connection_test'")
+                result = connect_ssh_with_key(
+                    host,
+                    username,
+                    key_file,
+                    "echo 'connection_test'",
+                    port=port,
+                )
                 
                 if result.returncode == 0 and "connection_test" in result.stdout:
                     self.connection_info = {
@@ -485,7 +491,8 @@ class SftpFileManager(Adw.ApplicationWindow):
                         self.connection_info['host'],
                         self.connection_info['username'],
                         self.connection_info['key_file'],
-                        f'ls -la --time-style="+%Y-%m-%d %H:%M" "{self.current_remote_path}"'
+                        f'ls -la --time-style="+%Y-%m-%d %H:%M" "{self.current_remote_path}"',
+                        port=self.connection_info['port'],
                     )
                 else:  # password
                     result = run_ssh_with_password(
@@ -599,7 +606,8 @@ class SftpFileManager(Adw.ApplicationWindow):
                         self.connection_info['host'],
                         self.connection_info['username'],
                         self.connection_info['key_file'],
-                        f'test -d "{new_path}" && echo "OK"'
+                        f'test -d "{new_path}" && echo "OK"',
+                        port=self.connection_info['port'],
                     )
                 else:  # password
                     result = run_ssh_with_password(
@@ -641,7 +649,8 @@ class SftpFileManager(Adw.ApplicationWindow):
                         self.connection_info['host'],
                         self.connection_info['username'],
                         self.connection_info['key_file'],
-                        f'test -d "{path}" && echo "OK"'
+                        f'test -d "{path}" && echo "OK"',
+                        port=self.connection_info['port'],
                     )
                 else:  # password
                     result = run_ssh_with_password(


### PR DESCRIPTION
## Summary
- add optional `port` support to `connect_ssh_with_key` so non-standard SSH ports can be used
- update file manager key-auth paths to forward the configured port for listings and navigation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd568571dc8328a04f58b1f888a769