### PR TITLE
Prefer in-app file manager when GVFS unavailable

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -3573,14 +3573,16 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     logger.error(f"Failed to open file manager for {connection.nickname}: {error_msg}")
                     # Show error dialog to user
                     self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
-                
+
                 host_value = _get_connection_host(connection)
+                metadata = self._build_file_manager_metadata(connection)
                 success, error_msg = open_remote_in_file_manager(
                     user=connection.username,
                     host=host_value,
                     port=connection.port if connection.port != 22 else None,
                     error_callback=error_callback,
-                    parent_window=self
+                    parent_window=self,
+                    connection_metadata=metadata,
                 )
                 if success:
                     logger.info(f"Started file manager process for {connection.nickname}")
@@ -5174,14 +5176,16 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     logger.error(f"Failed to open file manager for {connection.nickname}: {error_msg}")
                     # Show error dialog to user
                     self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
-                
+
                 host_value = _get_connection_host(connection)
+                metadata = self._build_file_manager_metadata(connection)
                 success, error_msg = open_remote_in_file_manager(
                     user=connection.username,
                     host=host_value,
                     port=connection.port if connection.port != 22 else None,
                     error_callback=error_callback,
-                    parent_window=self
+                    parent_window=self,
+                    connection_metadata=metadata,
                 )
                 if success:
                     logger.info(f"Started file manager process for {connection.nickname}")


### PR DESCRIPTION
## Summary
- allow the in-app SFTP file manager to accept pre-selected connection metadata and provide a launcher helper
- prefer the in-app manager from `open_remote_in_file_manager` whenever GVFS is unavailable or unsupported, falling back to the old mounting flow only as needed
- plumb stored connection details into manage-files actions so automatic authentication works when launching the internal manager

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5774da508328bf498e3fdf636b53