### PR TITLE
Add preference to force built-in file manager usage

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -186,6 +186,9 @@ class Config(GObject.Object):
                 'debug_enabled': False,
                 'use_isolated_config': is_flatpak(),
             },
+            'file_manager': {
+                'force_internal': False,
+            },
             'security': {
                 'store_passwords': True,
                 'ssh_agent_forwarding': True,
@@ -671,6 +674,14 @@ class Config(GObject.Object):
         shortcuts = config.get('shortcuts')
         if not isinstance(shortcuts, dict):
             config['shortcuts'] = {}
+            updated = True
+
+        file_manager_cfg = config.get('file_manager')
+        if not isinstance(file_manager_cfg, dict):
+            config['file_manager'] = {'force_internal': False}
+            updated = True
+        elif 'force_internal' not in file_manager_cfg:
+            file_manager_cfg['force_internal'] = False
             updated = True
 
         return config, updated

--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -103,6 +103,13 @@ def _should_use_in_app_file_manager() -> bool:
 
     if os.environ.get("SSHPILOT_FORCE_IN_APP_FILE_MANAGER") == "1":
         return True
+    try:
+        app = Adw.Application.get_default()
+        config = getattr(app, 'config', None) if app else None
+        if config and bool(config.get_setting('file_manager.force_internal', False)):
+            return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Failed to read file manager preference: %s", exc)
     if is_flatpak():
         return True
     if os.environ.get("SSHPILOT_DISABLE_GVFS") == "1":


### PR DESCRIPTION
## Summary
- add an advanced preference switch to always use the in-app file manager when available
- persist the preference in the configuration defaults and ensure it is included for upgrades
- respect the new preference when choosing between GVFS and the built-in file manager

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd77f680048328bdb95ecd673ba3f5