### PR TITLE
Fix context menu selection for GTK4 views

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -645,12 +645,14 @@ class FilePane(Gtk.Box):
 
     def _update_selection_for_menu(self, widget: Gtk.Widget, x: float, y: float) -> None:
         position = Gtk.INVALID_LIST_POSITION
+        int_x, int_y = int(x), int(y)
+
         if widget is self._list_view:
-            row = self._list_view.get_row_at_y(int(y))
-            if row is not None:
-                position = row.get_position()
+            item = self._list_view.get_item_at_pos(int_x, int_y)
+            if item is not None:
+                position = item.get_position()
         elif widget is self._grid_view:
-            item = self._grid_view.get_item_at_pos(int(x), int(y))
+            item = self._grid_view.get_item_at_pos(int_x, int_y)
             if item is not None:
                 position = item.get_position()
 


### PR DESCRIPTION
## Summary
- resolve context menu selection using the GTK4 ListView/GridView item lookup APIs
- translate gesture coordinates into model indices before opening the popover menu

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda1c1f0fc83289463788e2aa8647f