### PR TITLE
Improve typeahead prefix handling

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1678,14 +1678,23 @@ class FilePane(Gtk.Box):
             selected_index = selected
 
         start_index = selected_index
+        match: Optional[int] = None
+        prefix: Optional[str] = None
+
         if repeat_cycle:
-            start_index += 1
-            prefix = self._typeahead_buffer
+            candidate = self._typeahead_buffer + char
+            match = self._find_prefix_match(candidate, start_index)
+            if match is not None:
+                self._typeahead_buffer = candidate
+            else:
+                start_index += 1
+                prefix = self._typeahead_buffer
         else:
             self._typeahead_buffer += char
             prefix = self._typeahead_buffer
 
-        match = self._find_prefix_match(prefix, start_index)
+        if match is None and prefix is not None:
+            match = self._find_prefix_match(prefix, start_index)
 
         if match is None and not repeat_cycle:
             self._typeahead_buffer = char


### PR DESCRIPTION
## Summary
- update the typeahead handler to prefer extended prefixes before cycling repeated keys and persist successful buffers
- extend the test stubs used for FilePane unit tests to cover additional GDK and GObject requirements
- add a regression test that verifies repeated-letter prefixes continue matching longer entry names

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce2cd25db48328a94f4c80118faa28