### PR TITLE
Add file pane shortcut handling

### DIFF
--- a/documentation/keyboard-shortcuts.md
+++ b/documentation/keyboard-shortcuts.md
@@ -83,6 +83,16 @@ SSH Pilot is designed for efficient keyboard navigation. This guide covers all a
 
 ---
 
+## 📁 File Manager
+
+| Action | Linux/Windows | macOS | Description |
+|--------|---------------|-------|-------------|
+| **Focus path entry** | `Ctrl+L` | `Cmd+L` | Focus the active pane's path entry and select its contents |
+| **Refresh directory** | `F5` or `Ctrl+R` | `F5` or `Cmd+R` | Reload the visible directory in the focused pane |
+| **Delete selection** | `Delete` or `Shift+Delete` | `Delete` or `Shift+Delete` | Delete the selected files or folders in the focused pane |
+
+---
+
 ## 🗂️ Connection Dialog Shortcuts
 
 When editing connection settings:


### PR DESCRIPTION
## Summary
- add local ShortcutController instances to file pane views so focus, refresh, and delete accelerators work while the pane is active
- implement helper callbacks to focus the path entry, refresh the directory, and delete selections when their shortcuts fire
- document the new file manager keyboard shortcuts in the reference guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce30da60748328ba7775ec7ff1218e