### PR TITLE
Enable internal file manager to use saved SSH credentials

### DIFF
--- a/sshpilot/file_manager_integration.py
+++ b/sshpilot/file_manager_integration.py
@@ -69,23 +69,25 @@ def open_internal_file_manager(
     port: Optional[int] = None,
     parent_window: Any = None,
     nickname: Optional[str] = None,
+    connection: Any = None,
+    connection_manager: Any = None,
+    ssh_config: Optional[dict] = None,
 ):
     """Instantiate and present the built-in file manager window."""
 
-    from .file_manager_window import FileManagerWindow
+    from .file_manager_window import launch_file_manager_window
 
-    window = FileManagerWindow(
-        user=user,
+    window = launch_file_manager_window(
         host=host,
-        port=port,
+        username=user,
+        port=port or 22,
+        path="~",
         parent=parent_window,
         nickname=nickname,
+        connection=connection,
+        connection_manager=connection_manager,
+        ssh_config=ssh_config,
     )
-
-    try:
-        window.present()
-    except Exception:  # pragma: no cover - testing stubs may not implement present
-        pass
 
     return window
 
@@ -98,6 +100,9 @@ def launch_remote_file_manager(
     nickname: Optional[str] = None,
     parent_window: Any = None,
     error_callback: Optional[Any] = None,
+    connection: Any = None,
+    connection_manager: Any = None,
+    ssh_config: Optional[dict] = None,
 ) -> Tuple[bool, Optional[str], Optional[Any]]:
     """Launch the appropriate file manager for the supplied connection."""
 
@@ -119,6 +124,9 @@ def launch_remote_file_manager(
                 port=port,
                 parent_window=parent_window,
                 nickname=nickname,
+                connection=connection,
+                connection_manager=connection_manager,
+                ssh_config=ssh_config,
             )
             return True, None, window
         except Exception as exc:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -5165,6 +5165,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             logger.error(f"Failed to open file manager for {nickname}: {message}")
             self._show_manage_files_error(str(nickname), message)
 
+        ssh_config = None
+        if hasattr(self, 'config') and self.config is not None:
+            try:
+                ssh_config = self.config.get_ssh_config()
+            except Exception as exc:
+                logger.debug("Failed to read SSH configuration for file manager: %s", exc)
+                ssh_config = None
+
         success, error_msg, window = launch_remote_file_manager(
             user=str(username or ''),
             host=str(host_value or ''),
@@ -5172,6 +5180,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             nickname=str(nickname),
             parent_window=self,
             error_callback=error_callback,
+            connection=connection,
+            connection_manager=self.connection_manager,
+            ssh_config=ssh_config,
         )
 
         if success:

--- a/tests/test_file_manager_auth.py
+++ b/tests/test_file_manager_auth.py
@@ -1,0 +1,136 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+from tests.test_sftp_utils_in_app_manager import setup_gi
+
+
+class DummyPolicy:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class DummyClient:
+    instances = []
+
+    def __init__(self) -> None:
+        self.set_missing_host_key_policy_calls = []
+        self.loaded_host_keys = []
+        self.connect_calls = []
+        self.open_sftp_called = False
+        self.loaded_system = False
+        DummyClient.instances.append(self)
+
+    def set_missing_host_key_policy(self, policy):
+        self.set_missing_host_key_policy_calls.append(policy)
+
+    def load_system_host_keys(self):
+        self.loaded_system = True
+
+    def load_host_keys(self, path):
+        self.loaded_host_keys.append(path)
+
+    def connect(self, **kwargs):
+        self.connect_calls.append(kwargs)
+
+    def open_sftp(self):
+        self.open_sftp_called = True
+        return object()
+
+
+@pytest.fixture(autouse=True)
+def reset_dummy_client():
+    DummyClient.instances.clear()
+    yield
+    DummyClient.instances.clear()
+
+
+def test_async_sftp_manager_uses_stored_password(monkeypatch):
+    setup_gi(monkeypatch)
+
+    repository = sys.modules["gi.repository"]
+    gobject_module = sys.modules["gi.repository.GObject"]
+    flags = getattr(gobject_module, "SignalFlags", types.SimpleNamespace())
+    setattr(flags, "RUN_FIRST", getattr(flags, "RUN_FIRST", 0))
+    setattr(flags, "RUN_LAST", getattr(flags, "RUN_LAST", 1))
+    gobject_module.SignalFlags = flags
+    setattr(repository, "GObject", gobject_module)
+    pango = types.SimpleNamespace(
+        EllipsizeMode=types.SimpleNamespace(END=0, MIDDLE=1),
+        WrapMode=types.SimpleNamespace(WORD_CHAR=0),
+    )
+    monkeypatch.setitem(sys.modules, "gi.repository.Pango", pango)
+    setattr(repository, "Pango", pango)
+    pangoft2 = types.ModuleType("PangoFT2")
+    monkeypatch.setitem(sys.modules, "gi.repository.PangoFT2", pangoft2)
+    setattr(repository, "PangoFT2", pangoft2)
+
+    paramiko_stub = types.SimpleNamespace(
+        SSHClient=lambda: DummyClient(),
+        AutoAddPolicy=lambda: DummyPolicy("auto"),
+        RejectPolicy=lambda: DummyPolicy("reject"),
+        WarningPolicy=lambda: DummyPolicy("warn"),
+        MissingHostKeyPolicy=object,
+    )
+    monkeypatch.setitem(sys.modules, "paramiko", paramiko_stub)
+
+    # Ensure we reload the module so it picks up our stubs
+    sys.modules.pop("sshpilot.file_manager_window", None)
+    module = importlib.import_module("sshpilot.file_manager_window")
+
+    # Pretend the known hosts file exists
+    known_hosts_path = "/tmp/known_hosts"
+    monkeypatch.setattr(
+        module.os.path,
+        "exists",
+        lambda path: True if path == known_hosts_path else False,
+    )
+
+    connection = types.SimpleNamespace(
+        hostname="example.com",
+        host="example.com",
+        username="alice",
+        auth_method=1,
+        key_select_mode=0,
+        password="",
+        pubkey_auth_no=True,
+    )
+
+    class DummyManager:
+        def __init__(self, path):
+            self.password_calls = []
+            self.known_hosts_path = path
+
+        def get_password(self, host, username):
+            self.password_calls.append((host, username))
+            return "stored-secret"
+
+    manager = DummyManager(known_hosts_path)
+
+    sftp_manager = module.AsyncSFTPManager(
+        "example.com",
+        "alice",
+        port=2222,
+        connection=connection,
+        connection_manager=manager,
+        ssh_config={"auto_add_host_keys": True},
+    )
+
+    sftp_manager._connect_impl()
+
+    assert manager.password_calls == [("example.com", "alice")]
+    assert DummyClient.instances, "Expected AsyncSFTPManager to create a client"
+    client = DummyClient.instances[-1]
+    assert client.loaded_host_keys == [known_hosts_path]
+    assert client.open_sftp_called
+    assert client.connect_calls, "Expected a connection attempt"
+    connect_kwargs = client.connect_calls[-1]
+    assert connect_kwargs["password"] == "stored-secret"
+    assert connect_kwargs["port"] == 2222
+    assert connect_kwargs["allow_agent"] is False
+    assert connect_kwargs["look_for_keys"] is False
+    assert client.set_missing_host_key_policy_calls
+    assert client.set_missing_host_key_policy_calls[-1].name == "auto"
+    assert sftp_manager._password == "stored-secret"

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -179,6 +179,11 @@ def test_launch_remote_file_manager_uses_internal(monkeypatch):
     assert window is sentinel
     assert captured["kwargs"]["user"] == "bob"
     assert captured["kwargs"]["host"] == "example.net"
+    assert captured["kwargs"]["nickname"] == "Internal"
+    assert "connection" in captured["kwargs"]
+    assert captured["kwargs"]["connection"] is None
+    assert captured["kwargs"].get("connection_manager") is None
+    assert captured["kwargs"].get("ssh_config") is None
 
 
 def test_launch_remote_file_manager_no_backend(monkeypatch):


### PR DESCRIPTION
## Summary
- pass the selected connection and connection manager through the manage files launch path so the internal manager can reuse stored context
- extend the internal file manager window and AsyncSFTPManager to honour saved passwords, key preferences, and known-host settings when building Paramiko clients
- add regression coverage to ensure the fallback file manager works for password-protected hosts and keep the existing integration tests in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce85939c548328a1356c830dc0eef5