### PR TITLE
Fix GDK pixbuf module env paths for mac bundle

### DIFF
--- a/hook-gtk_runtime.py
+++ b/hook-gtk_runtime.py
@@ -23,15 +23,24 @@ if sys.platform == "darwin":
     os.environ["GSETTINGS_SCHEMA_DIR"] = str(resources / "share" / "glib-2.0" / "schemas")
     os.environ["XDG_DATA_DIRS"] = str(resources / "share")
     
-    # Set up GDK-Pixbuf loaders
-    gdkpixbuf_module_dir = frameworks / "lib" / "gdk-pixbuf" / "loaders"
-    gdkpixbuf_module_file = resources / "lib" / "gdk-pixbuf" / "loaders.cache"
+    # Set up GDK-Pixbuf loaders (bundled under Resources/lib/gdk-pixbuf-2.0/2.10.0)
+    gdkpixbuf_root = resources / "lib" / "gdk-pixbuf-2.0" / "2.10.0"
+    if gdkpixbuf_root.exists():
+        print(f"DEBUG: Found GDK-Pixbuf root at {gdkpixbuf_root}")
+    else:
+        print(f"DEBUG: GDK-Pixbuf root not found at {gdkpixbuf_root}")
+    gdkpixbuf_module_dir = gdkpixbuf_root / "loaders"
+    gdkpixbuf_module_file = gdkpixbuf_root / "loaders.cache"
     if gdkpixbuf_module_dir.exists():
         os.environ["GDK_PIXBUF_MODULEDIR"] = str(gdkpixbuf_module_dir)
         print(f"DEBUG: Set GDK_PIXBUF_MODULEDIR = {gdkpixbuf_module_dir}")
+    else:
+        print(f"DEBUG: GDK_PIXBUF_MODULEDIR not set; missing {gdkpixbuf_module_dir}")
     if gdkpixbuf_module_file.exists():
         os.environ["GDK_PIXBUF_MODULE_FILE"] = str(gdkpixbuf_module_file)
         print(f"DEBUG: Set GDK_PIXBUF_MODULE_FILE = {gdkpixbuf_module_file}")
+    else:
+        print(f"DEBUG: GDK_PIXBUF_MODULE_FILE not set; missing {gdkpixbuf_module_file}")
     
     # Set up keyring environment for macOS (like the working bundle)
     os.environ["KEYRING_BACKEND"] = "keyring.backends.macOS.Keyring"


### PR DESCRIPTION
## Summary
- derive the GDK-Pixbuf runtime paths from the bundled Resources/lib/gdk-pixbuf-2.0/2.10.0 directory
- set the GDK_PIXBUF_MODULEDIR and GDK_PIXBUF_MODULE_FILE environment variables only when the expected loader assets are present, with additional debug logging

## Testing
- pytest *(fails: tests/test_file_manager_auth.py::test_async_sftp_manager_uses_stored_password - assert True is False)*

------
https://chatgpt.com/codex/tasks/task_e_68cec7a731ac83288c9214c023c687d7