### PR TITLE
Enable native controls on main header bar

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -677,6 +677,11 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         
         # Create header bar
         self.header_bar = Adw.HeaderBar()
+        try:
+            if hasattr(self.header_bar, 'set_use_native_controls'):
+                self.header_bar.set_use_native_controls(True)
+        except Exception:
+            logger.debug('Failed to enable native window controls on header bar', exc_info=True)
         self.header_bar.set_title_widget(Gtk.Label(label="sshPilot"))
         
         # Add window controls (minimize, maximize, close)


### PR DESCRIPTION
## Summary
- enable native window controls on the main header bar when supported to match platform expectations

## Testing
- pytest *(fails: tests/test_file_manager_auth.py::test_async_sftp_manager_uses_stored_password expects allow_agent False)*

------
https://chatgpt.com/codex/tasks/task_e_68cefca72c008328a3c46c1c22f0fcf4