### PR TITLE
Default HostName to host alias when missing

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -937,11 +937,14 @@ class ConnectionManager(GObject.Object):
 
             hostname_value = config.get('hostname')
             parsed_host = _unwrap(hostname_value) if hostname_value else ''
+            if not parsed_host:
+                parsed_host = host
 
             # Extract relevant configuration
             parsed = {
                 'nickname': host,
                 'hostname': parsed_host,
+                'host': host,
 
                 'port': int(_unwrap(config.get('port', 22))),
                 'username': _unwrap(config.get('user', getpass.getuser())),

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -37,7 +37,7 @@ from sshpilot.connection_manager import ConnectionManager
 
 
 def test_host_token_used_when_hostname_missing(tmp_path):
-    """Entries without HostName should use Host token for nickname and leave hostname empty."""
+    """Entries without HostName should fall back to the Host token for the hostname."""
     asyncio.set_event_loop(asyncio.new_event_loop())
 
     manager = ConnectionManager.__new__(ConnectionManager)
@@ -52,7 +52,7 @@ def test_host_token_used_when_hostname_missing(tmp_path):
     assert len(manager.connections) == 1
     conn = manager.connections[0]
     assert conn.nickname == 'example.com'
-    assert conn.hostname == ''
+    assert conn.hostname == 'example.com'
 
 
 def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
@@ -73,7 +73,7 @@ def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
 
     assert sorted(c.nickname for c in manager.connections) == ['alias1', 'alias2', 'primary']
     for c in manager.connections:
-        assert c.hostname == ''
+        assert c.hostname == c.nickname
         assert not hasattr(c, 'aliases')
 
     primary = next(c for c in manager.connections if c.nickname == 'primary')


### PR DESCRIPTION
## Summary
- default parsed hostnames to the host token when HostName is omitted so connections have a valid target
- record the host token alongside parsed data and extend tests to cover alias fallback and ssh command generation
- update existing host-without-hostname expectations to reflect the alias fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d003172d108328a1848e4144b03ded