### PR TITLE
Preserve alias host when hostname is blank

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -79,7 +79,8 @@ class Connection:
         if 'aliases' in data:
             self.aliases = data.get('aliases', [])
         self.hostname = data.get('hostname', data.get('host', ''))
-        self.host = self.hostname  # Backward compatibility for legacy references
+        host_value = data.get('host')
+        self.host = host_value if host_value else self.hostname
         self.username = data.get('username', '')
         self.port = data.get('port', 22)
         # previously: self.keyfile = data.get('keyfile', '')
@@ -200,14 +201,19 @@ class Connection:
                 effective_cfg = get_effective_ssh_config(target_alias)
 
             # Determine final parameters, falling back to resolved config when needed
-            resolved_host = str(effective_cfg.get('hostname', self.hostname))
+            resolved_host_cfg = effective_cfg.get('hostname')
+            if resolved_host_cfg:
+                resolved_host = str(resolved_host_cfg)
+            else:
+                resolved_host = self.hostname or self.host
             resolved_user = self.username or str(effective_cfg.get('user', ''))
             try:
                 resolved_port = int(effective_cfg.get('port', self.port))
             except Exception:
                 resolved_port = self.port
-            self.hostname = resolved_host
-            self.host = self.hostname
+            previous_host = self.host
+            self.hostname = resolved_host or self.hostname
+            self.host = resolved_host or previous_host
             self.port = resolved_port
             if resolved_user:
                 self.username = resolved_user
@@ -623,7 +629,8 @@ class Connection:
         if 'aliases' in data:
             self.aliases = data.get('aliases', getattr(self, 'aliases', []))
         self.hostname = data.get('hostname', data.get('host', ''))
-        self.host = self.hostname
+        host_value = data.get('host')
+        self.host = host_value if host_value else self.hostname
         self.username = data.get('username', '')
         self.port = data.get('port', 22)
         self.keyfile = data.get('keyfile') or data.get('private_key', '') or ''

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -108,6 +108,39 @@ def test_connect_without_hostname_uses_alias(monkeypatch):
     assert connection.ssh_cmd[-1] == "mahdi@localhost"
 
 
+def test_connection_host_preserves_alias_when_hostname_blank():
+    data = {
+        "host": "alias",
+        "hostname": "",
+        "username": "user",
+    }
+    connection = Connection(data)
+    assert connection.host == "alias"
+    assert connection.hostname == ""
+
+
+def test_connect_with_blank_hostname_uses_alias(monkeypatch):
+    data = {
+        "host": "myalias",
+        "hostname": "",
+        "username": "mahdi",
+    }
+    monkeypatch.setattr("sshpilot.connection_manager.get_effective_ssh_config", lambda alias: {})
+    connection = Connection(data)
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        connected = loop.run_until_complete(connection.connect())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+    assert connected
+    assert connection.ssh_cmd[-1] == "mahdi@myalias"
+    assert connection.host == "myalias"
+    assert connection.hostname == "myalias"
+
+
 def test_format_host_requotes():
     cm = make_cm()
     data = {


### PR DESCRIPTION
## Summary
- ensure `Connection.host` keeps the configured alias when the hostname field is blank
- fall back to the alias when resolving the host during `connect` and property refreshes
- add regression coverage confirming alias retention and connect behaviour when `hostname` is empty

## Testing
- pytest *(fails: GLib.get_user_config_dir is missing from the GI stub used by file manager tests)*
- pytest tests/test_ssh_config_tokenization.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d008f4a47c8328b938dd9ae663f624