### PR TITLE
Handle missing HostName by keeping empty hostname

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -78,8 +78,9 @@ class Connection:
         self.nickname = data.get('nickname', data.get('hostname', data.get('host', 'Unknown')))
         if 'aliases' in data:
             self.aliases = data.get('aliases', [])
-        self.hostname = data.get('hostname', data.get('host', ''))
-        self.host = self.hostname  # Backward compatibility for legacy references
+        resolved_hostname = data.get('hostname') or data.get('host', '')
+        self.hostname = resolved_hostname
+        self.host = resolved_hostname  # Backward compatibility for legacy references
         self.username = data.get('username', '')
         self.port = data.get('port', 22)
         # previously: self.keyfile = data.get('keyfile', '')
@@ -622,8 +623,9 @@ class Connection:
         self.nickname = data.get('nickname', data.get('hostname', data.get('host', 'Unknown')))
         if 'aliases' in data:
             self.aliases = data.get('aliases', getattr(self, 'aliases', []))
-        self.hostname = data.get('hostname', data.get('host', ''))
-        self.host = self.hostname
+        resolved_hostname = data.get('hostname') or data.get('host', '')
+        self.hostname = resolved_hostname
+        self.host = resolved_hostname
         self.username = data.get('username', '')
         self.port = data.get('port', 22)
         self.keyfile = data.get('keyfile') or data.get('private_key', '') or ''
@@ -937,8 +939,6 @@ class ConnectionManager(GObject.Object):
 
             hostname_value = config.get('hostname')
             parsed_host = _unwrap(hostname_value) if hostname_value else ''
-            if not parsed_host:
-                parsed_host = host
 
             # Extract relevant configuration
             parsed = {
@@ -1332,7 +1332,7 @@ class ConnectionManager(GObject.Object):
                 return f'"{token}"'
             return token
 
-        host = data.get('hostname', data.get('host', ''))
+        host = data.get('hostname') or data.get('host', '')
         nickname = data.get('nickname') or host
         primary_token = _quote_token(nickname)
         lines = [f"Host {primary_token}"]

--- a/tests/test_host_without_hostname.py
+++ b/tests/test_host_without_hostname.py
@@ -52,6 +52,8 @@ def test_host_token_used_when_hostname_missing(tmp_path):
     assert len(manager.connections) == 1
     conn = manager.connections[0]
     assert conn.nickname == 'example.com'
+    assert conn.data['hostname'] == ''
+    assert conn.data['host'] == 'example.com'
     assert conn.hostname == 'example.com'
 
 
@@ -73,6 +75,7 @@ def test_multiple_labels_without_hostname_have_no_aliases(tmp_path):
 
     assert sorted(c.nickname for c in manager.connections) == ['alias1', 'alias2', 'primary']
     for c in manager.connections:
+        assert c.data['hostname'] == ''
         assert c.hostname == c.nickname
         assert not hasattr(c, 'aliases')
 
@@ -103,6 +106,7 @@ def test_alias_labels_with_hostname(tmp_path):
 
     assert sorted(c.nickname for c in manager.connections) == ['app1', 'app2']
     for c in manager.connections:
+        assert c.data['hostname'] == '192.168.1.50'
         assert c.hostname == '192.168.1.50'
         assert c.username == 'testuser'
         assert c.aliases == []

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -76,14 +76,14 @@ def test_parse_host_with_quotes():
     assert parsed["aliases"] == []
 
 
-def test_parse_host_without_hostname_defaults_to_alias():
+def test_parse_host_without_hostname_stores_empty_hostname():
     cm = make_cm()
     config = {
         "host": "localhost",
         "user": "mahdi",
     }
     parsed = ConnectionManager.parse_host_config(cm, config)
-    assert parsed["hostname"] == "localhost"
+    assert parsed["hostname"] == ""
     assert parsed["host"] == "localhost"
 
 


### PR DESCRIPTION
## Summary
- ensure ConnectionManager.parse_host_config preserves an empty hostname when HostName is not set while keeping the alias in the host field
- update connection property hydration and formatting helpers to fall back to the alias when the hostname string is empty
- adjust tests covering hosts without HostName directives to expect the empty hostname and confirm the alias is used for connections

## Testing
- pytest *(fails: GLib stub in tests lacks get_user_config_dir, causing file manager module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d008fe7b6083289b8ea7ad0351d104