### PR TITLE
Refine hostname handling for alias-only SSH entries

### DIFF
--- a/sshpilot/connection_display.py
+++ b/sshpilot/connection_display.py
@@ -1,0 +1,57 @@
+"""Helpers for presenting connection host and alias information."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_connection_host(connection: Any) -> str:
+    """Return the configured hostname for a connection when available."""
+    host = getattr(connection, "hostname", None)
+    if host:
+        return str(host)
+    return ""
+
+
+def get_connection_alias(connection: Any) -> str:
+    """Return the alias/nickname used to identify the connection in SSH config."""
+    alias = getattr(connection, "host", None)
+    if alias:
+        return str(alias)
+    nickname = getattr(connection, "nickname", "")
+    return str(nickname or "")
+
+
+def format_connection_host_display(connection: Any, include_port: bool = False) -> str:
+    """Create a user-facing string describing host/alias details for a connection."""
+    username = str(getattr(connection, "username", "") or "")
+    hostname = str(getattr(connection, "hostname", "") or "")
+    alias = get_connection_alias(connection)
+    base_target = hostname or alias
+
+    display = ""
+    if username and base_target:
+        display = f"{username}@{base_target}"
+    elif base_target:
+        display = base_target
+    else:
+        display = username
+
+    port = getattr(connection, "port", 22)
+    if include_port and port and port != 22 and display:
+        display = f"{display}:{port}"
+
+    if hostname:
+        if alias and alias != hostname:
+            return f"{display} ({alias})"
+        return display
+
+    if alias:
+        suffix_display = display or alias
+        if include_port and port and port != 22 and not display:
+            suffix_display = f"{alias}:{port}"
+        if username and not display:
+            suffix_display = f"{username}@{suffix_display}"
+        return f"{suffix_display} (alias)"
+
+    return display

--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -13,6 +13,11 @@ from gi.repository import Gtk, Gdk, GObject, GLib, Adw, Graphene
 from gettext import gettext as _
 
 from .connection_manager import Connection
+from .connection_display import (
+    get_connection_alias as _get_connection_alias,
+    get_connection_host as _get_connection_host,
+    format_connection_host_display as _format_connection_host_display,
+)
 from .groups import GroupManager
 
 logger = logging.getLogger(__name__)
@@ -451,8 +456,8 @@ class ConnectionRow(Gtk.ListBoxRow):
         if hide:
             self.host_label.set_text("••••••••••")
         else:
-            host_value = getattr(self.connection, 'hostname', getattr(self.connection, 'host', getattr(self.connection, 'nickname', '')))
-            self.host_label.set_text(f"{self.connection.username}@{host_value}")
+            display = _format_connection_host_display(self.connection)
+            self.host_label.set_text(display or '')
 
     def apply_hide_hosts(self, hide: bool):
         self._apply_host_label_text()
@@ -476,7 +481,7 @@ class ConnectionRow(Gtk.ListBoxRow):
 
             if has_active_terminal:
                 self.status_icon.set_from_icon_name("network-idle-symbolic")
-                host_value = getattr(self.connection, 'hostname', getattr(self.connection, 'host', getattr(self.connection, 'nickname', '')))
+                host_value = _get_connection_host(self.connection) or _get_connection_alias(self.connection)
                 self.status_icon.set_tooltip_text(
                     f"Connected to {host_value}"
                 )
@@ -495,9 +500,8 @@ class ConnectionRow(Gtk.ListBoxRow):
             self.nickname_label.set_markup(f"<b>{self.connection.nickname}</b>")
 
         if hasattr(self.connection, "username") and hasattr(self, "host_label"):
-            host_value = getattr(self.connection, 'hostname', getattr(self.connection, 'host', getattr(self.connection, 'nickname', '')))
-            port_text = f":{self.connection.port}" if getattr(self.connection, "port", 22) != 22 else ""
-            self.host_label.set_text(f"{self.connection.username}@{host_value}{port_text}")
+            display = _format_connection_host_display(self.connection, include_port=True)
+            self.host_label.set_text(display or '')
         self._update_forwarding_indicators()
         self.update_status()
 

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -116,7 +116,8 @@ def test_connect_without_hostname_uses_alias(monkeypatch):
 
     assert connected
     assert connection.ssh_cmd[-1].endswith("localhost")
-    assert connection.hostname == "localhost"
+    assert connection.hostname == ""
+    assert connection.host == "localhost"
 
 
 def test_connection_host_preserves_alias_when_hostname_blank():
@@ -128,7 +129,7 @@ def test_connection_host_preserves_alias_when_hostname_blank():
     connection = Connection(data)
     assert connection.data["host"] == "alias"
     assert connection.host == "alias"
-    assert connection.hostname == "alias"
+    assert connection.hostname == ""
 
 
 def test_connection_update_preserves_alias_when_hostname_blank():
@@ -141,7 +142,7 @@ def test_connection_update_preserves_alias_when_hostname_blank():
     # Update with new username but keep hostname blank
     connection.update_data({"username": "newuser", "hostname": ""})
     assert connection.host == "alias"
-    assert connection.hostname == "alias"
+    assert connection.hostname == ""
 
 
 
@@ -164,7 +165,7 @@ def test_connect_with_blank_hostname_uses_alias(monkeypatch):
     assert connected
     assert connection.ssh_cmd[-1] == "mahdi@myalias"
     assert connection.host == "myalias"
-    assert connection.hostname == "myalias"
+    assert connection.hostname == ""
 
 
 def test_update_connection_password_storage_uses_alias(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure Connection objects only populate `hostname` from explicit HostName values and preserve aliases separately
- update connection command building and UI helpers to keep alias display distinct from hostname details
- add dedicated helpers for host/alias formatting and adjust tests for alias-only connections

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1a1e071188328af3a55b726ee1e2c