### PR TITLE
Fix hostname override for alias-only hosts

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -694,14 +694,16 @@ class Connection:
         if 'aliases' in data:
             self.aliases = data.get('aliases', getattr(self, 'aliases', []))
 
-        resolved_host = hostname_value if hostname_value else host_value
+        if hostname_value in (None, ''):
+            resolved_host = host_value or getattr(self, 'host', '')
+        else:
+            resolved_host = hostname_value
         self.host = resolved_host
 
         if hostname_value is None:
             self.hostname = resolved_host
         elif hostname_value == '':
-            source_value = data.get('source', getattr(self, 'source', ''))
-            self.hostname = resolved_host if source_value else ''
+            self.hostname = ''
         else:
             self.hostname = hostname_value
 


### PR DESCRIPTION
## Summary
- stop `_update_properties_from_data` from copying alias hostnames into the `hostname` field when the saved hostname is intentionally empty
- retain the connection's alias in `self.host` so the UI and connection logic still have a fallback value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bbbd6aa48328923c8020c1d19a29