### PR TITLE
Handle nickname fallback in host display

### DIFF
--- a/sshpilot/connection_display.py
+++ b/sshpilot/connection_display.py
@@ -26,8 +26,17 @@ def format_connection_host_display(connection: Any, include_port: bool = False) 
     """Create a user-facing string describing host/alias details for a connection."""
     username = str(getattr(connection, "username", "") or "")
     hostname = str(getattr(connection, "hostname", "") or "")
-    alias = get_connection_alias(connection)
-    base_target = hostname or alias
+    nickname = str(getattr(connection, "nickname", "") or "")
+    alias = str(getattr(connection, "host", "") or "")
+
+    used_nickname = False
+    if hostname:
+        base_target = hostname
+    elif nickname:
+        base_target = nickname
+        used_nickname = True
+    else:
+        base_target = alias or ""
 
     display = ""
     if username and base_target:
@@ -46,7 +55,7 @@ def format_connection_host_display(connection: Any, include_port: bool = False) 
             return f"{display} ({alias})"
         return display
 
-    if alias:
+    if alias and not used_nickname:
         suffix_display = display or alias
         if include_port and port and port != 22 and not display:
             suffix_display = f"{alias}:{port}"

--- a/tests/test_connection_display.py
+++ b/tests/test_connection_display.py
@@ -1,0 +1,43 @@
+"""Tests for connection display helpers."""
+
+from types import SimpleNamespace
+
+from sshpilot.connection_display import format_connection_host_display
+
+
+def make_connection(**kwargs):
+    """Helper to construct a simple connection-like object."""
+
+    defaults = {
+        "username": "user",
+        "hostname": "",
+        "host": "",
+        "nickname": "",
+        "port": 22,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_format_display_uses_nickname_without_alias_suffix():
+    connection = make_connection(nickname="Production", host="Production")
+
+    display = format_connection_host_display(connection)
+
+    assert display == "user@Production"
+
+
+def test_format_display_with_hostname_and_alias():
+    connection = make_connection(hostname="example.com", host="prod")
+
+    display = format_connection_host_display(connection)
+
+    assert display == "user@example.com (prod)"
+
+
+def test_format_display_keeps_alias_suffix_when_no_nickname():
+    connection = make_connection(host="prod", nickname="")
+
+    display = format_connection_host_display(connection)
+
+    assert display == "user@prod (alias)"


### PR DESCRIPTION
## Summary
- adjust the connection host formatter to prefer the nickname when no hostname is available and avoid adding the alias suffix in that case
- cover the formatter changes with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bbc4ec688328818739834d2189ed