### PR TITLE
Ensure IdentityFile hosts default to dedicated key mode

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -1250,18 +1250,20 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 self.pubkey_auth_row.set_active(False)
             
             # Get keyfile path from either keyfile or private_key attribute
+            has_specific_key = False
             keyfile = getattr(self.connection, 'keyfile', None) or getattr(self.connection, 'private_key', None)
             if keyfile:
                 # Normalize the keyfile path and ensure it's a string
                 keyfile_path = str(keyfile).strip()
-                
+
                 # Update the connection's keyfile attribute if it comes from private_key
                 if not getattr(self.connection, 'keyfile', None) and hasattr(self.connection, 'private_key'):
                     self.connection.keyfile = keyfile_path
-                
+
                 # Only update the UI if we have a valid path
                 if keyfile_path and keyfile_path.lower() not in ['select key file or leave empty for auto-detection', '']:
                     logger.debug(f"Setting keyfile path in UI: {keyfile_path}")
+                    has_specific_key = True
                     self.keyfile_row.set_subtitle(keyfile_path)
                     # Sync the dropdown to match the loaded keyfile
                     self._sync_key_dropdown_with_current_keyfile()
@@ -1339,6 +1341,17 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                                 mode = int(self.connection.data.get('key_select_mode', 0)) if hasattr(self.connection, 'data') else 0
                             except Exception:
                                 mode = 0
+                    if has_specific_key and mode != 1:
+                        mode = 1
+                        try:
+                            self.connection.key_select_mode = 1
+                        except Exception:
+                            pass
+                        try:
+                            if hasattr(self.connection, 'data'):
+                                self.connection.data['key_select_mode'] = 1
+                        except Exception:
+                            pass
                     self.key_select_row.set_selected(0 if mode != 1 else 1)
                     self.on_key_select_changed(self.key_select_row, None)
             except Exception:

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1191,11 +1191,21 @@ class ConnectionManager(GObject.Object):
             except Exception:
                 pass
 
-            # Key selection mode: if IdentitiesOnly is set truthy, select specific key
+            # Key selection mode defaults: prefer "specific key" when IdentityFile is explicit
             try:
-                ident_only = str(config.get('identitiesonly', '')).strip().lower()
+                ident_only_raw = config.get('identitiesonly')
+                ident_only = ''
+                if isinstance(ident_only_raw, str):
+                    ident_only = ident_only_raw.strip().lower()
                 if ident_only in ('yes', 'true', '1', 'on'):
                     parsed['key_select_mode'] = 1
+                elif ident_only_raw is None or (isinstance(ident_only_raw, str) and not ident_only_raw.strip()):
+                    keyfile_value = parsed.get('keyfile', '')
+                    keyfile_path = keyfile_value.strip() if isinstance(keyfile_value, str) else ''
+                    if keyfile_path and not keyfile_path.lower().startswith('select key file'):
+                        parsed['key_select_mode'] = 1
+                    else:
+                        parsed['key_select_mode'] = 0
                 else:
                     parsed['key_select_mode'] = 0
             except Exception:

--- a/tests/test_split_host_block.py
+++ b/tests/test_split_host_block.py
@@ -1,0 +1,50 @@
+from sshpilot.connection_manager import ConnectionManager
+
+
+def test_split_host_block_preserves_specific_identityfile(tmp_path):
+    cm = ConnectionManager.__new__(ConnectionManager)
+
+    key_path = tmp_path / "id_test_key"
+    key_path.write_text("dummy")
+
+    config_path = tmp_path / "ssh_config"
+    config_path.write_text(
+        "\n".join(
+            [
+                "Host shared hostA hostB",
+                "    User testuser",
+                f"    IdentityFile {key_path}",
+                "",
+            ]
+        )
+    )
+
+    cm.ssh_config_path = str(config_path)
+
+    parsed = ConnectionManager.parse_host_config(
+        cm,
+        {
+            "host": "hostA",
+            "user": "testuser",
+            "identityfile": str(key_path),
+        },
+    )
+
+    assert parsed["key_select_mode"] == 1
+
+    parsed["source"] = str(config_path)
+
+    assert cm._split_host_block("hostA", parsed, str(config_path))
+
+    contents = config_path.read_text()
+
+    assert "Host shared hostB" in contents
+    assert "Host hostA" in contents
+    assert "IdentityFile" in contents
+    assert "IdentitiesOnly yes" in contents
+
+    host_blocks = [block for block in contents.strip().split("\n\n") if block.strip()]
+    dedicated_block = next(block for block in host_blocks if block.startswith("Host hostA"))
+
+    assert f"IdentityFile {key_path}" in dedicated_block
+    assert "IdentitiesOnly yes" in dedicated_block


### PR DESCRIPTION
## Summary
- default hosts with explicit IdentityFile paths to the dedicated key selection mode when IdentitiesOnly is absent
- keep the key selection dropdown in sync when an existing connection already specifies a concrete key
- add a regression test covering host block splits to ensure IdentitiesOnly is written alongside IdentityFile

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bf3cc4b08328b10651fb588f94ef