### PR TITLE
Allow dedicated SSH keys without IdentitiesOnly

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -957,7 +957,9 @@ class ConnectionDialog(Adw.Window):
             self.key_passphrase_row.set_visible(is_key_based)
         if hasattr(self, 'key_select_row'):
             self.key_select_row.set_visible(is_key_based)
-            
+        if hasattr(self, 'key_only_row'):
+            self.key_only_row.set_visible(is_key_based and self.key_select_row.get_selected() == 1)
+
         # Password field is always available since key-based auth can also require a password
         if hasattr(self, 'password_row'):
             self.password_row.set_visible(True)
@@ -989,6 +991,9 @@ class ConnectionDialog(Adw.Window):
                 self.certificate_row.set_sensitive(use_specific)
             if hasattr(self, 'cert_dropdown'):
                 self.cert_dropdown.set_sensitive(use_specific)
+            if hasattr(self, 'key_only_row'):
+                self.key_only_row.set_visible(use_specific)
+                self.key_only_row.set_sensitive(use_specific)
         except Exception:
             pass
         
@@ -1086,6 +1091,7 @@ class ConnectionDialog(Adw.Window):
             port = getattr(self, 'port_row', None)
             auth_method = getattr(self, 'auth_method_row', None)
             key_select_mode = getattr(self, 'key_select_row', None)
+            key_only_row = getattr(self, 'key_only_row', None)
             
             # Get values from UI or use defaults
             nickname_val = nickname.get_text().strip() if nickname else "my-server"
@@ -1095,7 +1101,14 @@ class ConnectionDialog(Adw.Window):
             
             # Get authentication settings
             auth_method_val = auth_method.get_selected() if auth_method else 0
-            key_select_mode_val = key_select_mode.get_selected() if key_select_mode else 0
+            selection_val = key_select_mode.get_selected() if key_select_mode else 0
+            key_select_mode_val = 0
+            if selection_val == 1:
+                try:
+                    only_active = key_only_row.get_active() if key_only_row else True
+                except Exception:
+                    only_active = True
+                key_select_mode_val = 1 if only_active else 2
             
             # Get keyfile and certificate if available
             keyfile_val = ""
@@ -1148,9 +1161,10 @@ class ConnectionDialog(Adw.Window):
             password_val = self.password_row.get_text().strip() if hasattr(self, 'password_row') else ''
 
             if auth_method_val == 0:  # Key-based auth (password optional)
-                if key_select_mode_val == 1 and keyfile_val:  # Specific key
+                if key_select_mode_val in (1, 2) and keyfile_val:  # Specific key
                     config_lines.append(f"    IdentityFile {keyfile_val}")
-                    config_lines.append("    IdentitiesOnly yes")
+                    if key_select_mode_val == 1:
+                        config_lines.append("    IdentitiesOnly yes")
 
                     # Add certificate if specified (validate to skip placeholder text)
                     if certificate_val and certificate_val.lower() not in ['select certificate file (optional)', '']:
@@ -1341,18 +1355,24 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                                 mode = int(self.connection.data.get('key_select_mode', 0)) if hasattr(self.connection, 'data') else 0
                             except Exception:
                                 mode = 0
-                    if has_specific_key and mode != 1:
-                        mode = 1
+                    if has_specific_key and mode not in (1, 2):
+                        mode = 2
                         try:
-                            self.connection.key_select_mode = 1
+                            self.connection.key_select_mode = 2
                         except Exception:
                             pass
                         try:
                             if hasattr(self.connection, 'data'):
-                                self.connection.data['key_select_mode'] = 1
+                                self.connection.data['key_select_mode'] = 2
                         except Exception:
                             pass
-                    self.key_select_row.set_selected(0 if mode != 1 else 1)
+                    selection = 1 if mode in (1, 2) else 0
+                    self.key_select_row.set_selected(selection)
+                    if hasattr(self, 'key_only_row'):
+                        try:
+                            self.key_only_row.set_active(mode == 1)
+                        except Exception:
+                            pass
                     self.on_key_select_changed(self.key_select_row, None)
             except Exception:
                 pass
@@ -2119,6 +2139,13 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         self.key_select_row.set_selected(0)
         self.key_select_row.connect("notify::selected", self.on_key_select_changed)
         auth_group.add(self.key_select_row)
+
+        self.key_only_row = Adw.SwitchRow()
+        self.key_only_row.set_title(_("Only use the specified key"))
+        self.key_only_row.set_subtitle(_("This will append \"IdentitiesOnly yes\" to the configuration."))
+        self.key_only_row.set_active(True)
+        self.key_only_row.set_visible(False)
+        auth_group.add(self.key_only_row)
         
         # Keyfile dropdown with detected keys and an inline Browse item
         self.keyfile_row = Adw.ActionRow(title=_("SSH Key"), subtitle=_("Select key file or leave empty for auto-detection"))
@@ -3350,6 +3377,17 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 logger.error(f"Error getting extra SSH config from advanced tab: {e}")
                 extra_ssh_config = ''
 
+        key_select_mode_val = 0
+        try:
+            if hasattr(self, 'key_select_row'):
+                key_selection = self.key_select_row.get_selected()
+                if key_selection == 1:
+                    use_only = getattr(self, 'key_only_row', None)
+                    only_active = use_only.get_active() if use_only else True
+                    key_select_mode_val = 1 if only_active else 2
+        except Exception:
+            key_select_mode_val = 0
+
         # Gather connection data
         connection_data = {
             'nickname': self.nickname_row.get_text().strip(),
@@ -3359,7 +3397,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             'auth_method': self.auth_method_row.get_selected(),
             'keyfile': keyfile_value,
             'certificate': certificate_value,
-            'key_select_mode': (self.key_select_row.get_selected() if hasattr(self, 'key_select_row') else 0),
+            'key_select_mode': key_select_mode_val,
             'key_passphrase': self.key_passphrase_row.get_text(),
             'password': self.password_row.get_text(),
             'x11_forwarding': self.x11_row.get_active(),

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1006,7 +1006,7 @@ class AsyncSFTPManager(GObject.GObject):
         else:
             logger.debug("File manager: No connection object provided")
 
-        if connection is not None and key_mode == 1 and keyfile and os.path.isfile(keyfile):
+        if connection is not None and key_mode in (1, 2) and keyfile and os.path.isfile(keyfile):
                 key_filename = keyfile
                 look_for_keys = False
                 logger.debug("File manager: Using specific key file: %s", keyfile)

--- a/sshpilot/ssh_utils.py
+++ b/sshpilot/ssh_utils.py
@@ -124,14 +124,15 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
         except Exception:
             pass
         
-        # Only add specific key if key_select_mode == 1 (specific key)
-        if key_select_mode == 1 and hasattr(connection, 'keyfile') and connection.keyfile and \
+        # Only add specific key when a dedicated key mode is selected
+        if key_select_mode in (1, 2) and hasattr(connection, 'keyfile') and connection.keyfile and \
            os.path.isfile(connection.keyfile) and \
            not connection.keyfile.startswith('Select key file'):
-            
+
             if not for_ssh_copy_id:
                 options.extend(['-i', connection.keyfile])
-            options.extend(['-o', 'IdentitiesOnly=yes'])
+            if key_select_mode == 1:
+                options.extend(['-o', 'IdentitiesOnly=yes'])
             
             # Add certificate if specified
             if hasattr(connection, 'certificate') and connection.certificate and \

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -657,8 +657,8 @@ class TerminalWidget(Gtk.Box):
                 except Exception:
                     pass
 
-                # Only add specific key if key_select_mode == 1 (specific key)
-                if key_select_mode == 1 and hasattr(self.connection, 'keyfile') and self.connection.keyfile and \
+                # Only add specific key when a dedicated key mode is selected
+                if key_select_mode in (1, 2) and hasattr(self.connection, 'keyfile') and self.connection.keyfile and \
                    os.path.isfile(self.connection.keyfile) and \
                    not self.connection.keyfile.startswith('Select key file'):
 
@@ -677,7 +677,8 @@ class TerminalWidget(Gtk.Box):
                     if self.connection.keyfile not in ssh_cmd:
                         ssh_cmd.extend(['-i', self.connection.keyfile])
                     logger.debug(f"Using SSH key: {self.connection.keyfile}")
-                    ensure_option('IdentitiesOnly=yes')
+                    if key_select_mode == 1:
+                        ensure_option('IdentitiesOnly=yes')
 
                     # Add certificate if specified
                     if hasattr(self.connection, 'certificate') and self.connection.certificate and \

--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -83,6 +83,17 @@ class TerminalManager:
         def _set_terminal_colors():
 
             try:
+                if not getattr(connection, 'ssh_cmd', None):
+                    try:
+                        loop = asyncio.get_event_loop()
+                        if loop.is_running():
+                            fut = asyncio.run_coroutine_threadsafe(connection.connect(), loop)
+                            fut.result()
+                        else:
+                            loop.run_until_complete(connection.connect())
+                    except Exception as prep_err:
+                        logger.error(f"Failed to prepare SSH command: {prep_err}")
+
                 terminal.apply_theme()
                 terminal.vte.queue_draw()
                 if not terminal._connect_ssh():

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -207,7 +207,7 @@ class WelcomePage(Gtk.Overlay):
             i = 0
             while i < len(args):
                 arg = args[i]
-                
+
                 # Handle options with values
                 if arg == '-p' and i + 1 < len(args):
                     try:
@@ -218,25 +218,54 @@ class WelcomePage(Gtk.Overlay):
                         pass
                 elif arg == '-i' and i + 1 < len(args):
                     connection_data["keyfile"] = args[i + 1]
-                    connection_data["key_select_mode"] = 1  # Use specific key
+                    connection_data["key_select_mode"] = 2  # Use specific key without forcing IdentitiesOnly by default
                     i += 2
                     continue
                 elif arg == '-o' and i + 1 < len(args):
                     # Handle SSH options like -o "UserKnownHostsFile=/dev/null"
                     option = args[i + 1]
-                    if '=' in option:
-                        key, value = option.split('=', 1)
-                        if key == 'User':
+                    parsed = option.split('=', 1)
+                    if len(parsed) == 2:
+                        key, value = parsed
+                        key_lower = key.lower()
+                        value = value.strip()
+                        if key_lower == 'user':
                             connection_data["username"] = value
-                        elif key == 'Port':
+                        elif key_lower == 'port':
                             try:
                                 connection_data["port"] = int(value)
                             except ValueError:
                                 pass
-                        elif key == 'IdentityFile':
+                        elif key_lower == 'identityfile':
                             connection_data["keyfile"] = value
-                            connection_data["key_select_mode"] = 1
+                            connection_data["key_select_mode"] = 2
+                        elif key_lower == 'identitiesonly':
+                            if value.lower() in ('yes', 'true', '1', 'on'):
+                                connection_data["key_select_mode"] = 1
+                            elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
+                                connection_data["key_select_mode"] = 2
                     i += 2
+                    continue
+                elif arg.startswith('-o') and '=' in arg[2:]:
+                    key, value = arg[2:].split('=', 1)
+                    key_lower = key.lower()
+                    value = value.strip()
+                    if key_lower == 'identityfile':
+                        connection_data["keyfile"] = value
+                        connection_data["key_select_mode"] = 2
+                    elif key_lower == 'identitiesonly':
+                        if value.lower() in ('yes', 'true', '1', 'on'):
+                            connection_data["key_select_mode"] = 1
+                        elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
+                            connection_data["key_select_mode"] = 2
+                    elif key_lower == 'user':
+                        connection_data["username"] = value
+                    elif key_lower == 'port':
+                        try:
+                            connection_data["port"] = int(value)
+                        except ValueError:
+                            pass
+                    i += 1
                     continue
                 elif arg == '-X':
                     connection_data["x11_forwarding"] = True
@@ -271,7 +300,7 @@ class WelcomePage(Gtk.Overlay):
                 elif arg.startswith('-i'):
                     # Handle -i/path/to/key format (no space)
                     connection_data["keyfile"] = arg[2:]
-                    connection_data["key_select_mode"] = 1
+                    connection_data["key_select_mode"] = 2
                     i += 1
                     continue
                 elif not arg.startswith('-'):
@@ -293,7 +322,10 @@ class WelcomePage(Gtk.Overlay):
             # Validate that we have at least a host
             if not connection_data["host"]:
                 return None
-            
+
+            if connection_data.get("keyfile") and connection_data.get("key_select_mode", 0) == 0:
+                connection_data["key_select_mode"] = 2
+
             return connection_data
             
         except Exception as e:
@@ -428,7 +460,7 @@ class QuickConnectDialog(Adw.MessageDialog):
             i = 0
             while i < len(args):
                 arg = args[i]
-                
+
                 # Handle options with values
                 if arg == '-p' and i + 1 < len(args):
                     try:
@@ -439,25 +471,54 @@ class QuickConnectDialog(Adw.MessageDialog):
                         pass
                 elif arg == '-i' and i + 1 < len(args):
                     connection_data["keyfile"] = args[i + 1]
-                    connection_data["key_select_mode"] = 1  # Use specific key
+                    connection_data["key_select_mode"] = 2  # Use specific key without forcing IdentitiesOnly by default
                     i += 2
                     continue
                 elif arg == '-o' and i + 1 < len(args):
                     # Handle SSH options like -o "UserKnownHostsFile=/dev/null"
                     option = args[i + 1]
-                    if '=' in option:
-                        key, value = option.split('=', 1)
-                        if key == 'User':
+                    parsed = option.split('=', 1)
+                    if len(parsed) == 2:
+                        key, value = parsed
+                        key_lower = key.lower()
+                        value = value.strip()
+                        if key_lower == 'user':
                             connection_data["username"] = value
-                        elif key == 'Port':
+                        elif key_lower == 'port':
                             try:
                                 connection_data["port"] = int(value)
                             except ValueError:
                                 pass
-                        elif key == 'IdentityFile':
+                        elif key_lower == 'identityfile':
                             connection_data["keyfile"] = value
-                            connection_data["key_select_mode"] = 1
+                            connection_data["key_select_mode"] = 2
+                        elif key_lower == 'identitiesonly':
+                            if value.lower() in ('yes', 'true', '1', 'on'):
+                                connection_data["key_select_mode"] = 1
+                            elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
+                                connection_data["key_select_mode"] = 2
                     i += 2
+                    continue
+                elif arg.startswith('-o') and '=' in arg[2:]:
+                    key, value = arg[2:].split('=', 1)
+                    key_lower = key.lower()
+                    value = value.strip()
+                    if key_lower == 'identityfile':
+                        connection_data["keyfile"] = value
+                        connection_data["key_select_mode"] = 2
+                    elif key_lower == 'identitiesonly':
+                        if value.lower() in ('yes', 'true', '1', 'on'):
+                            connection_data["key_select_mode"] = 1
+                        elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
+                            connection_data["key_select_mode"] = 2
+                    elif key_lower == 'user':
+                        connection_data["username"] = value
+                    elif key_lower == 'port':
+                        try:
+                            connection_data["port"] = int(value)
+                        except ValueError:
+                            pass
+                    i += 1
                     continue
                 elif arg == '-X':
                     connection_data["x11_forwarding"] = True
@@ -492,7 +553,7 @@ class QuickConnectDialog(Adw.MessageDialog):
                 elif arg.startswith('-i'):
                     # Handle -i/path/to/key format (no space)
                     connection_data["keyfile"] = arg[2:]
-                    connection_data["key_select_mode"] = 1
+                    connection_data["key_select_mode"] = 2
                     i += 1
                     continue
                 elif not arg.startswith('-'):
@@ -514,7 +575,10 @@ class QuickConnectDialog(Adw.MessageDialog):
             # Validate that we have at least a host
             if not connection_data["host"]:
                 return None
-            
+
+            if connection_data.get("keyfile") and connection_data.get("key_select_mode", 0) == 0:
+                connection_data["key_select_mode"] = 2
+
             return connection_data
             
         except Exception as e:

--- a/tests/test_certificate_support.py
+++ b/tests/test_certificate_support.py
@@ -84,7 +84,7 @@ def test_certificate_support(tmp_path):
         'keyfile': key_path,
         'certificate': cert_path,
         'auth_method': 0,
-        'key_select_mode': 1,
+        'key_select_mode': 2,
     }
 
     conn = Connection(data)

--- a/tests/test_split_host_block.py
+++ b/tests/test_split_host_block.py
@@ -1,7 +1,7 @@
 from sshpilot.connection_manager import ConnectionManager
 
 
-def test_split_host_block_preserves_specific_identityfile(tmp_path):
+def test_split_host_block_preserves_identityfile_without_identitiesonly(tmp_path):
     cm = ConnectionManager.__new__(ConnectionManager)
 
     key_path = tmp_path / "id_test_key"
@@ -30,6 +30,55 @@ def test_split_host_block_preserves_specific_identityfile(tmp_path):
         },
     )
 
+    assert parsed["key_select_mode"] == 2
+
+    parsed["source"] = str(config_path)
+
+    assert cm._split_host_block("hostA", parsed, str(config_path))
+
+    contents = config_path.read_text()
+
+    assert "Host shared hostB" in contents
+    assert "Host hostA" in contents
+
+    host_blocks = [block for block in contents.strip().split("\n\n") if block.strip()]
+    dedicated_block = next(block for block in host_blocks if block.startswith("Host hostA"))
+
+    assert f"IdentityFile {key_path}" in dedicated_block
+    assert "IdentitiesOnly yes" not in dedicated_block
+
+
+def test_split_host_block_preserves_identitiesonly_directive(tmp_path):
+    cm = ConnectionManager.__new__(ConnectionManager)
+
+    key_path = tmp_path / "id_test_key"
+    key_path.write_text("dummy")
+
+    config_path = tmp_path / "ssh_config"
+    config_path.write_text(
+        "\n".join(
+            [
+                "Host shared hostA hostB",
+                "    User testuser",
+                f"    IdentityFile {key_path}",
+                "    IdentitiesOnly yes",
+                "",
+            ]
+        )
+    )
+
+    cm.ssh_config_path = str(config_path)
+
+    parsed = ConnectionManager.parse_host_config(
+        cm,
+        {
+            "host": "hostA",
+            "user": "testuser",
+            "identityfile": str(key_path),
+            "identitiesonly": "yes",
+        },
+    )
+
     assert parsed["key_select_mode"] == 1
 
     parsed["source"] = str(config_path)
@@ -40,8 +89,6 @@ def test_split_host_block_preserves_specific_identityfile(tmp_path):
 
     assert "Host shared hostB" in contents
     assert "Host hostA" in contents
-    assert "IdentityFile" in contents
-    assert "IdentitiesOnly yes" in contents
 
     host_blocks = [block for block in contents.strip().split("\n\n") if block.strip()]
     dedicated_block = next(block for block in host_blocks if block.startswith("Host hostA"))


### PR DESCRIPTION
## Summary
- differentiate key-select mode when IdentityFile is present without IdentitiesOnly
- add an IdentitiesOnly toggle to the connection dialog and propagate the three-state key selection mode through command builders
- update terminal preparation and tests to cover dedicated key handling without IdentitiesOnly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1ced240f88328802b7678183aeb5d