### PR TITLE
Normalize boolean IdentitiesOnly values

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1200,9 +1200,13 @@ class ConnectionManager(GObject.Object):
             has_specific_key = bool(keyfile_path and not keyfile_path.lower().startswith('select key file'))
             try:
                 ident_only_raw = config.get('identitiesonly')
+                ident_only_normalized = ident_only_raw
+                if ident_only_raw and not isinstance(ident_only_raw, str):
+                    ident_only_normalized = str(ident_only_raw)
+
                 ident_only = ''
-                if isinstance(ident_only_raw, str):
-                    ident_only = ident_only_raw.strip().lower()
+                if isinstance(ident_only_normalized, str):
+                    ident_only = ident_only_normalized.strip().lower()
 
                 if ident_only in ('yes', 'true', '1', 'on'):
                     parsed['key_select_mode'] = 1

--- a/tests/test_split_host_block.py
+++ b/tests/test_split_host_block.py
@@ -95,3 +95,34 @@ def test_split_host_block_preserves_identitiesonly_directive(tmp_path):
 
     assert f"IdentityFile {key_path}" in dedicated_block
     assert "IdentitiesOnly yes" in dedicated_block
+
+
+def test_truthy_non_string_identitiesonly_parsing_and_format(tmp_path):
+    cm = ConnectionManager.__new__(ConnectionManager)
+
+    key_path = tmp_path / "id_test_key"
+    key_path.write_text("dummy")
+
+    base_config = {
+        "host": "hostA",
+        "user": "testuser",
+        "identityfile": str(key_path),
+    }
+
+    parsed_bool = ConnectionManager.parse_host_config(
+        cm,
+        {**base_config, "identitiesonly": True},
+    )
+    assert parsed_bool["key_select_mode"] == 1
+
+    formatted_bool = ConnectionManager.format_ssh_config_entry(cm, parsed_bool)
+    assert "IdentitiesOnly yes" in formatted_bool
+
+    parsed_str = ConnectionManager.parse_host_config(
+        cm,
+        {**base_config, "identitiesonly": "yes"},
+    )
+    assert parsed_str["key_select_mode"] == 1
+
+    formatted_str = ConnectionManager.format_ssh_config_entry(cm, parsed_str)
+    assert formatted_str.count("IdentitiesOnly yes") == 1


### PR DESCRIPTION
## Summary
- normalize truthy non-string IdentitiesOnly values while parsing host entries
- add regression coverage ensuring boolean IdentitiesOnly produces key-select mode 1 and persists to config output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d61ee0c48328be083986c364ae4b