### PR TITLE
Handle IdentitiesOnly no with dedicated key

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1206,6 +1206,8 @@ class ConnectionManager(GObject.Object):
 
                 if ident_only in ('yes', 'true', '1', 'on'):
                     parsed['key_select_mode'] = 1
+                elif ident_only in ('no', 'false', '0', 'off'):
+                    parsed['key_select_mode'] = 2 if has_specific_key else 0
                 elif ident_only_raw is None or (isinstance(ident_only_raw, str) and not ident_only_raw.strip()):
                     parsed['key_select_mode'] = 2 if has_specific_key else 0
                 else:

--- a/tests/test_split_host_block.py
+++ b/tests/test_split_host_block.py
@@ -95,3 +95,52 @@ def test_split_host_block_preserves_identitiesonly_directive(tmp_path):
 
     assert f"IdentityFile {key_path}" in dedicated_block
     assert "IdentitiesOnly yes" in dedicated_block
+
+
+def test_split_host_block_respects_identitiesonly_no(tmp_path):
+    cm = ConnectionManager.__new__(ConnectionManager)
+
+    key_path = tmp_path / "id_test_key"
+    key_path.write_text("dummy")
+
+    config_path = tmp_path / "ssh_config"
+    config_path.write_text(
+        "\n".join(
+            [
+                "Host shared hostA hostB",
+                "    User testuser",
+                f"    IdentityFile {key_path}",
+                "    IdentitiesOnly no",
+                "",
+            ]
+        )
+    )
+
+    cm.ssh_config_path = str(config_path)
+
+    parsed = ConnectionManager.parse_host_config(
+        cm,
+        {
+            "host": "hostA",
+            "user": "testuser",
+            "identityfile": str(key_path),
+            "identitiesonly": "no",
+        },
+    )
+
+    assert parsed["key_select_mode"] == 2
+
+    parsed["source"] = str(config_path)
+
+    assert cm._split_host_block("hostA", parsed, str(config_path))
+
+    contents = config_path.read_text()
+
+    assert "Host shared hostB" in contents
+    assert "Host hostA" in contents
+
+    host_blocks = [block for block in contents.strip().split("\n\n") if block.strip()]
+    dedicated_block = next(block for block in host_blocks if block.startswith("Host hostA"))
+
+    assert f"IdentityFile {key_path}" in dedicated_block
+    assert "IdentitiesOnly yes" not in dedicated_block


### PR DESCRIPTION
## Summary
- treat IdentitiesOnly values like "no"/"false"/"0" as a dedicated key selection when an IdentityFile is provided
- keep emitting IdentitiesOnly yes only for the explicit "use specific key" mode
- add a regression test covering IdentitiesOnly no when splitting a shared host block

## Testing
- pytest tests/test_split_host_block.py

------
https://chatgpt.com/codex/tasks/task_e_68d1d75be910832894424fa8c58b3ba5