### PR TITLE
Normalize SFTP paths before building URIs

### DIFF
--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -30,7 +30,8 @@ def open_remote_in_file_manager(
     """Open remote server in file manager using SFTP URI with asynchronous verification"""
 
     # Build sftp URI
-    p = path or "~"
+    raw_path = path or "~"
+    p = raw_path if raw_path.startswith("/") else f"/{raw_path}"
     port_part = f":{port}" if port else ""
     uri = f"sftp://{user}@{host}{port_part}{p}"
 
@@ -46,7 +47,7 @@ def open_remote_in_file_manager(
                 host=host,
                 username=user,
                 port=port or 22,
-                path=p,
+                path=raw_path,
                 parent=parent_window,
                 transient_for_parent=False,
                 connection=connection,


### PR DESCRIPTION
## Summary
- ensure remote SFTP URIs include a leading slash even for `~`-prefixed paths
- keep the in-app file manager using the unmodified path value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1dd51ed208328be74453786915b83