### PR TITLE
Adjust SCP key handling and cover key modes

### DIFF
--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -37,8 +37,11 @@ def open_remote_in_file_manager(
         p = path or "~"
         uri = f"sftp://{user}@{host}{port_part}{p}"
     else:
-        # For external file managers, don't set any path - let them mount to root
-        uri = f"sftp://{user}@{host}{port_part}/"
+        # For external file managers, default to root but honor explicit paths
+        requested_path = path or "/"
+        if requested_path not in ("/", "") and not requested_path.startswith(("/", "~")):
+            requested_path = f"/{requested_path.lstrip('/')}"
+        uri = f"sftp://{user}@{host}{port_part}{requested_path}"
 
     logger.info(f"Opening SFTP URI: {uri}")
 

--- a/tests/test_window_scp_args.py
+++ b/tests/test_window_scp_args.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from sshpilot import window
+
+
+class _DummyConfig:
+    def __init__(self, *_, **__):
+        pass
+
+    def get_ssh_config(self):
+        return {}
+
+
+class _DummyConnectionManager:
+    def get_password(self, *_):
+        return None
+
+    def get_key_passphrase(self, *_):
+        return None
+
+
+def _build_args(monkeypatch, tmp_path, key_mode):
+    monkeypatch.setattr(window, 'Config', _DummyConfig)
+
+    key_path = tmp_path / 'id_test_key'
+    key_path.write_text('dummy')
+
+    connection = SimpleNamespace(
+        hostname='example.com',
+        username='alice',
+        keyfile=str(key_path),
+        key_select_mode=key_mode,
+        auth_method=2,
+        port=22,
+    )
+
+    dummy_window = SimpleNamespace(connection_manager=_DummyConnectionManager())
+
+    argv = window.MainWindow._build_scp_argv(
+        dummy_window,
+        connection,
+        ['local.txt'],
+        '/remote/path',
+        direction='upload',
+    )
+
+    return argv, str(key_path)
+
+
+def test_build_scp_argv_mode_1_adds_identity_options(monkeypatch, tmp_path):
+    argv, key_path = _build_args(monkeypatch, tmp_path, key_mode=1)
+
+    assert '-i' in argv
+    assert argv[argv.index('-i') + 1] == key_path
+    assert 'IdentitiesOnly=yes' in argv
+
+
+def test_build_scp_argv_mode_2_skips_identities_only(monkeypatch, tmp_path):
+    argv, key_path = _build_args(monkeypatch, tmp_path, key_mode=2)
+
+    assert '-i' in argv
+    assert argv[argv.index('-i') + 1] == key_path
+    assert 'IdentitiesOnly=yes' not in argv


### PR DESCRIPTION
## Summary
- ensure scp invocations include the selected key file for both key selection modes while only forcing IdentitiesOnly for mode 1
- add unit coverage for _build_scp_argv to validate the key mode behaviours
- preserve requested paths when opening SFTP URIs in external file managers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d23411c414832884d8414d7644a552