### PR TITLE
Remove shortcut editor action from window menu

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -275,14 +275,6 @@ class WindowActions:
         except Exception as e:
             logger.error(f"Failed to open known hosts editor: {e}")
 
-    def on_edit_shortcuts_action(self, action, param=None):
-        """Open the shortcut editor window."""
-        try:
-            if hasattr(self, 'show_shortcut_editor'):
-                self.show_shortcut_editor()
-        except Exception as e:
-            logger.error(f"Failed to open shortcut editor: {e}")
-
     def on_create_group_action(self, action, param=None):
         """Handle create group action"""
         try:
@@ -737,12 +729,6 @@ def register_window_actions(window):
         window.edit_known_hosts_action = Gio.SimpleAction.new('edit-known-hosts', None)
         window.edit_known_hosts_action.connect('activate', window.on_edit_known_hosts_action)
         window.add_action(window.edit_known_hosts_action)
-
-    # Action for editing shortcuts
-    if hasattr(window, 'on_edit_shortcuts_action'):
-        window.edit_shortcuts_action = Gio.SimpleAction.new('edit-shortcuts', None)
-        window.edit_shortcuts_action.connect('activate', window.on_edit_shortcuts_action)
-        window.add_action(window.edit_shortcuts_action)
 
     # Group management actions
     window.create_group_action = Gio.SimpleAction.new('create-group', None)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1922,7 +1922,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         # Help submenu with platform-aware keyboard shortcuts overlay
         help_menu = Gio.Menu()
         help_menu.append('Keyboard Shortcuts', 'app.shortcuts')
-        help_menu.append('Shortcut Editor', 'win.edit-shortcuts')
         help_menu.append('Documentation', 'app.help')
         menu.append_submenu('Help', help_menu)
 
@@ -2793,16 +2792,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             editor.present()
         except Exception as e:
             logger.error(f"Failed to open known hosts editor: {e}")
-
-    def show_shortcut_editor(self):
-        """Launch the shortcut editor window"""
-        logger.info("Show shortcut editor window")
-        try:
-            from .shortcut_editor import ShortcutEditorWindow
-            editor = ShortcutEditorWindow(self)
-            editor.present()
-        except Exception as e:
-            logger.error(f"Failed to open shortcut editor: {e}")
 
     def show_preferences(self):
         """Show preferences dialog"""


### PR DESCRIPTION
## Summary
- remove the Shortcut Editor entry from the window menu now that it moves under preferences
- delete the unused shortcut editor action registration and helper method

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25dd17ec88328a46ba9555bf7bed3