### PR TITLE
Enable wrapping for SSH config editor text view

### DIFF
--- a/sshpilot/ssh_config_editor.py
+++ b/sshpilot/ssh_config_editor.py
@@ -43,6 +43,7 @@ class SSHConfigEditorWindow(Adw.Window):
         # Text view for editing
         self.textview = Gtk.TextView()
         self.textview.set_monospace(True)
+        self.textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         buffer = self.textview.get_buffer()
 
         try:


### PR DESCRIPTION
## Summary
- enable character wrapping on the SSH config editor text view so long lines stay visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2dc822790832887c74586c490da10