### PR TITLE
Handle IPv6 hosts for SCP transfers

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -4476,7 +4476,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
     ):
         argv = ['scp', '-v']
         host_value = _get_connection_host(connection) or _get_connection_alias(connection)
-        target = f"{connection.username}@{host_value}" if getattr(connection, 'username', '') else host_value
+        scp_host = host_value
+        if scp_host and ':' in scp_host and not (scp_host.startswith('[') and scp_host.endswith(']')):
+            scp_host = f"[{scp_host}]"
+        target = f"{connection.username}@{scp_host}" if getattr(connection, 'username', '') else scp_host
         transfer_sources, transfer_destination = assemble_scp_transfer_args(
             target,
             sources,

--- a/tests/test_scp_transfers.py
+++ b/tests/test_scp_transfers.py
@@ -17,6 +17,17 @@ def test_assemble_scp_transfer_args_upload():
     assert destination == 'alice@example.com:/var/tmp'
 
 
+def test_assemble_scp_transfer_args_upload_ipv6():
+    sources, destination = assemble_scp_transfer_args(
+        'alice@[2001:db8::1]',
+        ['file1.txt'],
+        '/var/tmp',
+        'upload',
+    )
+    assert sources == ['file1.txt']
+    assert destination == 'alice@[2001:db8::1]:/var/tmp'
+
+
 def test_assemble_scp_transfer_args_download_normalizes_host():
     sources, destination = assemble_scp_transfer_args(
         'alice@example.com',
@@ -26,6 +37,19 @@ def test_assemble_scp_transfer_args_download_normalizes_host():
     )
     assert sources[0] == 'alice@example.com:~/logs/app.log'
     assert sources[1] == 'example.com:/opt/data.tar'
+    assert destination == '/tmp/out'
+
+
+def test_assemble_scp_transfer_args_download_ipv6():
+    sources, destination = assemble_scp_transfer_args(
+        'alice@[2001:db8::1]',
+        ['~/logs/app.log', '[2001:db8::1]:/opt/data.tar', 'bob@[2001:db8::2]:/srv/backup'],
+        '/tmp/out',
+        'download',
+    )
+    assert sources[0] == 'alice@[2001:db8::1]:~/logs/app.log'
+    assert sources[1] == '[2001:db8::1]:/opt/data.tar'
+    assert sources[2] == 'bob@[2001:db8::2]:/srv/backup'
     assert destination == '/tmp/out'
 
 


### PR DESCRIPTION
## Summary
- wrap IPv6 connection hosts in brackets when building scp targets to avoid ambiguity
- normalize scp sources to accept bracketed IPv6 hosts and expand coverage for IPv6 uploads/downloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31f284bd48328baa147b6487dbb82