### PR TITLE
Preserve quick connect commands

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -162,32 +162,39 @@ class WelcomePage(Gtk.Overlay):
     def _parse_ssh_command(self, command_text):
         """Parse SSH command text and extract connection parameters"""
         try:
+            raw_command = command_text.strip()
+
             # Handle simple user@host format (backward compatibility)
-            if not command_text.startswith('ssh') and '@' in command_text and ' ' not in command_text:
-                username, host = command_text.split('@', 1)
+            if not raw_command.startswith('ssh') and '@' in raw_command and ' ' not in raw_command:
+                username, host = raw_command.split('@', 1)
                 return {
                     "nickname": host,
                     "host": host,
                     "username": username,
                     "port": 22,
                     "auth_method": 0,  # Default to key-based auth
-                    "key_select_mode": 0  # Try all keys
+                    "key_select_mode": 0,  # Try all keys
+                    "quick_connect_command": "",
+                    "unparsed_args": [],
                 }
-            
+
+            quick_connect_command = raw_command if raw_command.startswith('ssh') else ""
+            working_text = raw_command
+
             # Parse full SSH command
             # Remove 'ssh' prefix if present
-            if command_text.startswith('ssh '):
-                command_text = command_text[4:]
-            elif command_text.startswith('ssh'):
-                command_text = command_text[3:]
-            
+            if working_text.startswith('ssh '):
+                working_text = working_text[4:]
+            elif working_text.startswith('ssh'):
+                working_text = working_text[3:]
+
             # Use shlex to properly parse the command with quoted arguments
             try:
-                args = shlex.split(command_text)
+                args = shlex.split(working_text)
             except ValueError:
                 # If shlex fails, fall back to simple split
-                args = command_text.split()
-            
+                args = working_text.split()
+
             # Initialize connection data with defaults
             connection_data = {
                 "nickname": "",
@@ -201,9 +208,11 @@ class WelcomePage(Gtk.Overlay):
                 "x11_forwarding": False,
                 "local_port_forwards": [],
                 "remote_port_forwards": [],
-                "dynamic_forwards": []
+                "dynamic_forwards": [],
+                "quick_connect_command": quick_connect_command,
+                "unparsed_args": [],
             }
-            
+
             i = 0
             while i < len(args):
                 arg = args[i]
@@ -305,20 +314,27 @@ class WelcomePage(Gtk.Overlay):
                     continue
                 elif not arg.startswith('-'):
                     # This should be the host specification (user@host)
-                    if '@' in arg:
-                        username, host = arg.split('@', 1)
-                        connection_data["username"] = username
-                        connection_data["host"] = host
-                        connection_data["nickname"] = host
+                    if not connection_data["host"]:
+                        if '@' in arg:
+                            username, host = arg.split('@', 1)
+                            connection_data["username"] = username
+                            connection_data["host"] = host
+                            connection_data["nickname"] = host
+                        else:
+                            # Just hostname, no username
+                            connection_data["host"] = arg
+                            connection_data["nickname"] = arg
                     else:
-                        # Just hostname, no username
-                        connection_data["host"] = arg
-                        connection_data["nickname"] = arg
+                        connection_data["unparsed_args"].append(arg)
                     i += 1
                 else:
-                    # Unknown option, skip it
-                    i += 1
-            
+                    connection_data["unparsed_args"].append(arg)
+                    if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                        connection_data["unparsed_args"].append(args[i + 1])
+                        i += 2
+                    else:
+                        i += 1
+
             # Validate that we have at least a host
             if not connection_data["host"]:
                 return None
@@ -327,8 +343,8 @@ class WelcomePage(Gtk.Overlay):
                 connection_data["key_select_mode"] = 2
 
             return connection_data
-            
-        except Exception as e:
+
+        except Exception:
             # If parsing fails, try simple fallback
             if '@' in command_text:
                 try:
@@ -339,9 +355,11 @@ class WelcomePage(Gtk.Overlay):
                         "username": username,
                         "port": 22,
                         "auth_method": 0,
-                        "key_select_mode": 0
+                        "key_select_mode": 0,
+                        "quick_connect_command": "",
+                        "unparsed_args": [],
                     }
-                except:
+                except Exception:
                     pass
             return None
 
@@ -415,31 +433,38 @@ class QuickConnectDialog(Adw.MessageDialog):
     def _parse_ssh_command(self, command_text):
         """Parse SSH command text and extract connection parameters"""
         try:
+            raw_command = command_text.strip()
+
             # Handle simple user@host format (backward compatibility)
-            if not command_text.startswith('ssh') and '@' in command_text and ' ' not in command_text:
-                username, host = command_text.split('@', 1)
+            if not raw_command.startswith('ssh') and '@' in raw_command and ' ' not in raw_command:
+                username, host = raw_command.split('@', 1)
                 return {
                     "nickname": host,
                     "host": host,
                     "username": username,
                     "port": 22,
                     "auth_method": 0,  # Default to key-based auth
-                    "key_select_mode": 0  # Try all keys
+                    "key_select_mode": 0,  # Try all keys
+                    "quick_connect_command": "",
+                    "unparsed_args": [],
                 }
+
+            quick_connect_command = raw_command if raw_command.startswith('ssh') else ""
+            working_text = raw_command
 
             # Parse full SSH command
             # Remove 'ssh' prefix if present
-            if command_text.startswith('ssh '):
-                command_text = command_text[4:]
-            elif command_text.startswith('ssh'):
-                command_text = command_text[3:]
+            if working_text.startswith('ssh '):
+                working_text = working_text[4:]
+            elif working_text.startswith('ssh'):
+                working_text = working_text[3:]
 
             # Use shlex to properly parse the command with quoted arguments
             try:
-                args = shlex.split(command_text)
+                args = shlex.split(working_text)
             except ValueError:
                 # If shlex fails, fall back to simple split
-                args = command_text.split()
+                args = working_text.split()
 
             # Initialize connection data with defaults
             connection_data = {
@@ -454,7 +479,9 @@ class QuickConnectDialog(Adw.MessageDialog):
                 "x11_forwarding": False,
                 "local_port_forwards": [],
                 "remote_port_forwards": [],
-                "dynamic_forwards": []
+                "dynamic_forwards": [],
+                "quick_connect_command": quick_connect_command,
+                "unparsed_args": [],
             }
 
             i = 0
@@ -558,19 +585,26 @@ class QuickConnectDialog(Adw.MessageDialog):
                     continue
                 elif not arg.startswith('-'):
                     # This should be the host specification (user@host)
-                    if '@' in arg:
-                        username, host = arg.split('@', 1)
-                        connection_data["username"] = username
-                        connection_data["host"] = host
-                        connection_data["nickname"] = host
+                    if not connection_data["host"]:
+                        if '@' in arg:
+                            username, host = arg.split('@', 1)
+                            connection_data["username"] = username
+                            connection_data["host"] = host
+                            connection_data["nickname"] = host
+                        else:
+                            # Just hostname, no username
+                            connection_data["host"] = arg
+                            connection_data["nickname"] = arg
                     else:
-                        # Just hostname, no username
-                        connection_data["host"] = arg
-                        connection_data["nickname"] = arg
+                        connection_data["unparsed_args"].append(arg)
                     i += 1
                 else:
-                    # Unknown option, skip it
-                    i += 1
+                    connection_data["unparsed_args"].append(arg)
+                    if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                        connection_data["unparsed_args"].append(args[i + 1])
+                        i += 2
+                    else:
+                        i += 1
 
             # Validate that we have at least a host
             if not connection_data["host"]:
@@ -580,8 +614,8 @@ class QuickConnectDialog(Adw.MessageDialog):
                 connection_data["key_select_mode"] = 2
 
             return connection_data
-            
-        except Exception as e:
+
+        except Exception:
             # If parsing fails, try simple fallback
             if '@' in command_text:
                 try:
@@ -592,8 +626,10 @@ class QuickConnectDialog(Adw.MessageDialog):
                         "username": username,
                         "port": 22,
                         "auth_method": 0,
-                        "key_select_mode": 0
+                        "key_select_mode": 0,
+                        "quick_connect_command": "",
+                        "unparsed_args": [],
                     }
-                except:
+                except Exception:
                     pass
             return None

--- a/tests/test_quick_connect.py
+++ b/tests/test_quick_connect.py
@@ -1,0 +1,80 @@
+"""Regression tests for quick connect commands."""
+
+import asyncio
+import shlex
+import sys
+import types
+
+
+def _ensure_gi_stubs():
+    if 'gi' not in sys.modules:
+        gi = types.ModuleType('gi')
+        gi.require_version = lambda *args, **kwargs: None
+        repository = types.ModuleType('gi.repository')
+        gi.repository = repository
+        sys.modules['gi'] = gi
+        sys.modules['gi.repository'] = repository
+    else:
+        gi = sys.modules['gi']
+        repository = getattr(gi, 'repository', None)
+        if repository is None:
+            repository = types.ModuleType('gi.repository')
+            gi.repository = repository
+            sys.modules['gi.repository'] = repository
+
+    for name, attr_map in (
+        ('Gtk', {'Overlay': type('Overlay', (object,), {})}),
+        ('Adw', {'MessageDialog': type('MessageDialog', (object,), {})}),
+        ('Gdk', {}),
+    ):
+        module_name = f'gi.repository.{name}'
+        module = sys.modules.get(module_name)
+        if module is None:
+            module = types.ModuleType(module_name)
+            sys.modules[module_name] = module
+        setattr(sys.modules['gi.repository'], name, module)
+        for attr, value in attr_map.items():
+            if not hasattr(module, attr):
+                setattr(module, attr, value)
+
+
+_ensure_gi_stubs()
+
+from sshpilot.connection_manager import Connection
+from sshpilot.welcome_page import QuickConnectDialog
+
+
+def _parse_quick_command(command: str):
+    dialog = QuickConnectDialog.__new__(QuickConnectDialog)
+    return QuickConnectDialog._parse_ssh_command(dialog, command)
+
+
+def test_quick_connect_preserves_original_command():
+    command = "ssh -J bastion -o Foo=bar user@host"
+
+    parsed = _parse_quick_command(command)
+
+    assert parsed["quick_connect_command"] == command
+    assert parsed["host"] == "host"
+    assert parsed["username"] == "user"
+    assert parsed["unparsed_args"] == ['-J', 'bastion']
+
+    new_loop = asyncio.new_event_loop()
+    previous_loop = None
+    try:
+        try:
+            previous_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            previous_loop = None
+        asyncio.set_event_loop(new_loop)
+
+        connection = Connection(parsed)
+        assert connection.quick_connect_command == command
+
+        connected = new_loop.run_until_complete(connection.connect())
+    finally:
+        asyncio.set_event_loop(previous_loop)
+        new_loop.close()
+
+    assert connected is True
+    assert connection.ssh_cmd == shlex.split(command)


### PR DESCRIPTION
## Summary
- retain the raw quick-connect command and any unparsed arguments when parsing SSH text input
- short-circuit connection preparation and terminal setup when a quick-connect command is present so argv stays untouched
- add regression coverage to ensure quick-connect commands are preserved verbatim

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d331099b808328a2a266b0e57110c4