### PR TITLE
Limit ssh -G override to isolated config root

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -103,6 +103,8 @@ class Connection:
         self.key_passphrase = data.get('key_passphrase', '')
         # Source file of this configuration block
         self.source = data.get('source', '')
+        self.config_root = data.get('config_root', '')
+        self.isolated_config = bool(data.get('isolated_mode', False))
         # Provide friendly accessor for UI components that wish to display
         # the originating config file for this connection.
         
@@ -230,7 +232,13 @@ class Connection:
                 or self.hostname
             )
             if target_alias:
-                effective_cfg = get_effective_ssh_config(target_alias)
+                config_override = self.config_root if self.isolated_config else None
+                if config_override:
+                    effective_cfg = get_effective_ssh_config(
+                        target_alias, config_file=config_override
+                    )
+                else:
+                    effective_cfg = get_effective_ssh_config(target_alias)
 
             # Determine final parameters, falling back to resolved config when needed
             existing_hostname = self.hostname or ''
@@ -720,6 +728,10 @@ class Connection:
         self.password = data.get('password', '')
         self.key_passphrase = data.get('key_passphrase', '')
         self.source = data.get('source', getattr(self, 'source', ''))
+        self.config_root = data.get('config_root', getattr(self, 'config_root', ''))
+        self.isolated_config = bool(
+            data.get('isolated_mode', getattr(self, 'isolated_config', False))
+        )
         self.local_command = data.get('local_command', '')
         self.remote_command = data.get('remote_command', '')
         self.proxy_command = data.get('proxy_command', '')
@@ -902,7 +914,13 @@ class ConnectionManager(GObject.Object):
                                 existing.update_data(connection_data)
                                 self.connections.append(existing)
                             else:
-                                self.connections.append(Connection(connection_data))
+                                new_conn = Connection(connection_data)
+                                if getattr(self, 'isolated_mode', False):
+                                    new_conn.isolated_config = True
+                                    new_conn.config_root = self.ssh_config_path
+                                    new_conn.data['isolated_mode'] = True
+                                    new_conn.data['config_root'] = self.ssh_config_path
+                                self.connections.append(new_conn)
                 try:
                     with open(cfg_file, 'r') as f:
                         lines = f.readlines()
@@ -942,7 +960,13 @@ class ConnectionManager(GObject.Object):
                                             existing.update_data(connection_data)
                                             self.connections.append(existing)
                                         else:
-                                            self.connections.append(Connection(connection_data))
+                                            new_conn = Connection(connection_data)
+                                            if getattr(self, 'isolated_mode', False):
+                                                new_conn.isolated_config = True
+                                                new_conn.config_root = self.ssh_config_path
+                                                new_conn.data['isolated_mode'] = True
+                                                new_conn.data['config_root'] = self.ssh_config_path
+                                            self.connections.append(new_conn)
                         current_hosts = []
                         current_config = {}
                         block_lines = [raw_line.rstrip('\n')]
@@ -980,7 +1004,13 @@ class ConnectionManager(GObject.Object):
                                             existing.update_data(connection_data)
                                             self.connections.append(existing)
                                         else:
-                                            self.connections.append(Connection(connection_data))
+                                            new_conn = Connection(connection_data)
+                                            if getattr(self, 'isolated_mode', False):
+                                                new_conn.isolated_config = True
+                                                new_conn.config_root = self.ssh_config_path
+                                                new_conn.data['isolated_mode'] = True
+                                                new_conn.data['config_root'] = self.ssh_config_path
+                                            self.connections.append(new_conn)
                         current_hosts = tokens
                         current_config = {}
                         i += 1
@@ -1016,7 +1046,13 @@ class ConnectionManager(GObject.Object):
                                     existing.update_data(connection_data)
                                     self.connections.append(existing)
                                 else:
-                                    self.connections.append(Connection(connection_data))
+                                    new_conn = Connection(connection_data)
+                                    if getattr(self, 'isolated_mode', False):
+                                        new_conn.isolated_config = True
+                                        new_conn.config_root = self.ssh_config_path
+                                        new_conn.data['isolated_mode'] = True
+                                        new_conn.data['config_root'] = self.ssh_config_path
+                                    self.connections.append(new_conn)
             logger.info(f"Loaded {len(self.connections)} connections from SSH config")
         except Exception as e:
             logger.error(f"Failed to load SSH config: {e}", exc_info=True)
@@ -1080,7 +1116,12 @@ class ConnectionManager(GObject.Object):
                 parsed['aliases'] = []
             if source:
                 parsed['source'] = source
-            
+
+            if getattr(self, 'isolated_mode', False):
+                parsed['isolated_mode'] = True
+                if getattr(self, 'ssh_config_path', ''):
+                    parsed['config_root'] = self.ssh_config_path
+
 
             # Map ForwardX11 yes/no → x11_forwarding boolean
             try:

--- a/sshpilot/ssh_config_utils.py
+++ b/sshpilot/ssh_config_utils.py
@@ -3,7 +3,7 @@ import glob
 import shlex
 import logging
 import subprocess
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 
 logger = logging.getLogger(__name__)
@@ -68,16 +68,25 @@ def resolve_ssh_config_files(main_path: str, *, max_depth: int = 32) -> List[str
     return resolved
 
 
-def get_effective_ssh_config(host: str) -> Dict[str, Union[str, List[str]]]:
+def get_effective_ssh_config(
+    host: str, config_file: Optional[str] = None
+) -> Dict[str, Union[str, List[str]]]:
     """Return effective SSH options for *host* using ``ssh -G``.
 
     The output is parsed into a dictionary with lowercased keys. Options that
     appear multiple times (e.g. ``IdentityFile``) are stored as lists.
     """
+    cmd = ['ssh', '-G']
+    if config_file:
+        expanded = os.path.abspath(os.path.expanduser(os.path.expandvars(config_file)))
+        if os.path.isfile(expanded):
+            cmd.extend(['-F', expanded])
+        else:
+            logger.warning("Requested SSH config override %s does not exist", expanded)
+    cmd.append(host)
+
     try:
-        result = subprocess.run(
-            ['ssh', '-G', host], capture_output=True, text=True, check=True
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     except Exception:
         return {}
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -997,6 +997,12 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 new_data.pop('source', None)
 
             new_connection = Connection(new_data)
+            if self.connection_manager.isolated_mode:
+                new_connection.isolated_config = True
+                new_connection.config_root = self.connection_manager.ssh_config_path
+                new_connection.data['isolated_mode'] = True
+                if self.connection_manager.ssh_config_path:
+                    new_connection.data['config_root'] = self.connection_manager.ssh_config_path
             try:
                 new_connection.auth_method = int(new_data.get('auth_method', 0) or 0)
             except Exception:
@@ -6410,6 +6416,12 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             else:
                 # Create new connection
                 connection = Connection(connection_data)
+                if self.connection_manager.isolated_mode:
+                    connection.isolated_config = True
+                    connection.config_root = self.connection_manager.ssh_config_path
+                    connection.data['isolated_mode'] = True
+                    if self.connection_manager.ssh_config_path:
+                        connection.data['config_root'] = self.connection_manager.ssh_config_path
                 # Ensure the in-memory object has the chosen auth_method immediately
                 try:
                     connection.auth_method = int(connection_data.get('auth_method', 0))

--- a/tests/test_ssh_config_tokenization.py
+++ b/tests/test_ssh_config_tokenization.py
@@ -102,7 +102,7 @@ def test_connect_without_hostname_uses_alias(monkeypatch):
     parsed = ConnectionManager.parse_host_config(cm, config)
     monkeypatch.setattr(
         "sshpilot.connection_manager.get_effective_ssh_config",
-        lambda alias: {"hostname": ""},
+        lambda alias, config_file=None: {"hostname": ""},
     )
     parsed["hostname"] = ""
     connection = Connection(parsed)
@@ -152,7 +152,10 @@ def test_connect_with_blank_hostname_uses_alias(monkeypatch):
         "hostname": "",
         "username": "mahdi",
     }
-    monkeypatch.setattr("sshpilot.connection_manager.get_effective_ssh_config", lambda alias: {})
+    monkeypatch.setattr(
+        "sshpilot.connection_manager.get_effective_ssh_config",
+        lambda alias, config_file=None: {},
+    )
     connection = Connection(data)
     loop = asyncio.new_event_loop()
     try:


### PR DESCRIPTION
## Summary
- teach `get_effective_ssh_config` to accept an optional override file and only pass it from connections that are marked as isolated
- propagate isolated-config metadata when parsing, duplicating, or creating connections so they resolve using the isolated config root
- update tests to stub the new helper signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d39a248b688328b3b39c3b2e0578f8