### PR TITLE
Fix stale isolated config state handling

### DIFF
--- a/sshpilot/ssh_config_utils.py
+++ b/sshpilot/ssh_config_utils.py
@@ -77,14 +77,14 @@ def get_effective_ssh_config(
     The output is parsed into a dictionary with lowercased keys. Options that
     appear multiple times (e.g. ``IdentityFile``) are stored as lists.
     """
-    cmd = ['ssh', '-G']
+    cmd = ['ssh']
     if config_file:
         expanded = os.path.abspath(os.path.expanduser(os.path.expandvars(config_file)))
         if os.path.isfile(expanded):
             cmd.extend(['-F', expanded])
         else:
             logger.warning("Requested SSH config override %s does not exist", expanded)
-    cmd.append(host)
+    cmd.extend(['-G', host])
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -646,14 +646,21 @@ class QuickConnectDialog(Adw.MessageDialog):
                     elif option_key.startswith('-') and len(option_key) > 2:
                         option_key, attached_value = option_key[:2], option_key[2:]
 
-                    if option_key in SSH_OPTIONS_EXPECTING_ARGUMENT:
-                        if attached_value:
-                            i += 1
-                        elif i + 1 < len(args) and not args[i + 1].startswith('-'):
+                    expects_argument = option_key in SSH_OPTIONS_EXPECTING_ARGUMENT
+                    if attached_value:
+                        connection_data["unparsed_args"].append(arg)
+                        i += 1
+                        continue
+
+                    if expects_argument:
+                        if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                            connection_data["unparsed_args"].extend([arg, args[i + 1]])
                             i += 2
                         else:
+                            connection_data["unparsed_args"].append(arg)
                             i += 1
                     else:
+                        connection_data["unparsed_args"].append(arg)
                         i += 1
                     continue
 


### PR DESCRIPTION
## Summary
- reset cached isolated config details when refreshed connection data omits isolated_mode
- preserve existing config overrides while still honoring isolated config roots
- keep unknown SSH options (like -J) with quick connect commands and ensure ssh -G uses -F before -G

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d39e32a2a08328bebe305804ab375c