### PR TITLE
Adjust host display subtitle when hostname is present

### DIFF
--- a/sshpilot/connection_display.py
+++ b/sshpilot/connection_display.py
@@ -51,8 +51,6 @@ def format_connection_host_display(connection: Any, include_port: bool = False) 
         display = f"{display}:{port}"
 
     if hostname:
-        if alias and alias != hostname:
-            return f"{display} ({alias})"
         return display
 
     if alias and not used_nickname:

--- a/tests/test_connection_display.py
+++ b/tests/test_connection_display.py
@@ -32,7 +32,7 @@ def test_format_display_with_hostname_and_alias():
 
     display = format_connection_host_display(connection)
 
-    assert display == "user@example.com (prod)"
+    assert display == "user@example.com"
 
 
 def test_format_display_keeps_alias_suffix_when_no_nickname():


### PR DESCRIPTION
## Summary
- simplify connection subtitle formatting to only show the resolved hostname when available
- leave nickname- and alias-based formatting unchanged when no hostname is configured
- update unit test expectations to match the new formatting rule

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d91997b08328a3181793b736b5fc