### PR TITLE
Fix proxy command substitution for file manager

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -29,6 +29,7 @@ import shutil
 import stat
 import threading
 import time
+import re
 from datetime import datetime
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -832,6 +833,7 @@ class AsyncSFTPManager(GObject.GObject):
         self._connection = connection
         self._connection_manager = connection_manager
         self._ssh_config = dict(ssh_config) if ssh_config else None
+        self._proxy_sock: Optional[Any] = None
     
     def _format_size(self, size_bytes):
         """Format file size for display"""
@@ -861,6 +863,13 @@ class AsyncSFTPManager(GObject.GObject):
             if self._client is not None:
                 self._client.close()
                 self._client = None
+            if self._proxy_sock is not None:
+                try:
+                    self._proxy_sock.close()
+                except Exception as exc:  # pragma: no cover - defensive cleanup
+                    logger.debug("Error closing proxy socket: %s", exc)
+                finally:
+                    self._proxy_sock = None
         self._executor.shutdown(wait=False)
 
     # -- helpers --------------------------------------------------------
@@ -1064,6 +1073,147 @@ class AsyncSFTPManager(GObject.GObject):
                 allow_agent = False
                 look_for_keys = False
 
+        effective_cfg: Dict[str, Any] = {}
+        proxy_command: str = ""
+        proxy_jump: List[str] = []
+
+        target_alias: Optional[str] = None
+        config_override: Optional[str] = None
+
+        if connection is not None:
+            try:
+                proxy_command = str(getattr(connection, "proxy_command", "") or "")
+            except Exception:
+                proxy_command = ""
+            try:
+                raw_jump = getattr(connection, "proxy_jump", []) or []
+            except Exception:
+                raw_jump = []
+            if isinstance(raw_jump, str):
+                proxy_jump = [token.strip() for token in raw_jump.split(",") if token.strip()]
+            elif isinstance(raw_jump, (list, tuple, set)):
+                proxy_jump = [str(token).strip() for token in raw_jump if str(token).strip()]
+
+            source_path = str(getattr(connection, "source", "") or "")
+            if source_path:
+                expanded_source = os.path.abspath(
+                    os.path.expanduser(os.path.expandvars(source_path))
+                )
+                if os.path.exists(expanded_source):
+                    config_override = expanded_source
+
+            if not config_override and getattr(connection, "isolated_config", False):
+                root_candidate = str(getattr(connection, "config_root", "") or "")
+                if root_candidate:
+                    expanded_root = os.path.abspath(
+                        os.path.expanduser(os.path.expandvars(root_candidate))
+                    )
+                    if os.path.exists(expanded_root):
+                        config_override = expanded_root
+
+            target_alias = (
+                getattr(connection, "nickname", "")
+                or getattr(connection, "hostname", "")
+                or getattr(connection, "host", "")
+                or None
+            )
+
+        if not target_alias:
+            target_alias = self._host
+
+        alias_for_config: Optional[str] = None
+        if target_alias:
+            try:
+                from .ssh_config_utils import get_effective_ssh_config
+
+                effective_cfg = get_effective_ssh_config(
+                    target_alias, config_file=config_override
+                )
+                alias_for_config = target_alias
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "Failed to resolve effective SSH config for %s: %s",
+                    target_alias,
+                    exc,
+                )
+                effective_cfg = {}
+
+        if not proxy_command:
+            proxy_command = str(effective_cfg.get("proxycommand", "") or "")
+
+        if not proxy_jump:
+            raw_cfg_jump = effective_cfg.get("proxyjump", [])
+            if isinstance(raw_cfg_jump, str):
+                proxy_jump = [token.strip() for token in re.split(r"[\s,]+", raw_cfg_jump) if token.strip()]
+            elif isinstance(raw_cfg_jump, (list, tuple, set)):
+                proxy_jump = [
+                    str(token).strip()
+                    for token in raw_cfg_jump
+                    if str(token).strip()
+                ]
+
+        alias_for_substitution = alias_for_config or target_alias or self._host
+
+        def _expand_proxy_tokens(raw_command: str) -> str:
+            if not raw_command:
+                return raw_command
+
+            substitution_host = str(self._host)
+            substitution_port = str(self._port)
+            substitution_user = str(self._username) if self._username else ""
+            substitution_alias = str(alias_for_substitution) if alias_for_substitution else substitution_host
+
+            token_pattern = re.compile(r"%(?:%|h|p|r|n)")
+
+            def _replace(match: re.Match[str]) -> str:
+                token = match.group(0)
+                if token == "%%":
+                    return "%"
+                if token == "%h":
+                    return substitution_host
+                if token == "%p":
+                    return substitution_port
+                if token == "%r":
+                    return substitution_user
+                if token == "%n":
+                    return substitution_alias
+                return token
+
+            return token_pattern.sub(_replace, raw_command)
+
+        proxy_sock: Optional[Any] = None
+        proxy_command = proxy_command.strip()
+        if proxy_command:
+            try:
+                from paramiko.proxy import ProxyCommand as ParamikoProxyCommand
+
+                expanded_command = _expand_proxy_tokens(proxy_command)
+                proxy_sock = ParamikoProxyCommand(expanded_command)
+                logger.debug(
+                    "File manager: using ProxyCommand '%s' (expanded from '%s')",
+                    expanded_command,
+                    proxy_command,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to set up ProxyCommand '%s': %s", proxy_command, exc)
+                proxy_sock = None
+        elif proxy_jump:
+            jump_spec = ",".join(proxy_jump)
+            jump_command = f"ssh -W %h:%p -J {jump_spec} %h"
+            try:
+                from paramiko.proxy import ProxyCommand as ParamikoProxyCommand
+
+                expanded_jump = _expand_proxy_tokens(jump_command)
+                proxy_sock = ParamikoProxyCommand(expanded_jump)
+                logger.debug(
+                    "File manager: using ProxyJump via '%s' (expanded from '%s')",
+                    expanded_jump,
+                    jump_command,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to set up ProxyJump '%s': %s", jump_command, exc)
+                proxy_sock = None
+
         connect_kwargs: Dict[str, Any] = {
             "hostname": self._host,
             "username": self._username,
@@ -1082,12 +1232,25 @@ class AsyncSFTPManager(GObject.GObject):
         if passphrase:
             connect_kwargs["passphrase"] = passphrase
 
-        client.connect(**connect_kwargs)
-        sftp = client.open_sftp()
+        if proxy_sock is not None:
+            connect_kwargs["sock"] = proxy_sock
+
+        try:
+            client.connect(**connect_kwargs)
+            sftp = client.open_sftp()
+        except Exception:
+            if proxy_sock is not None:
+                try:
+                    proxy_sock.close()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+            raise
+
         with self._lock:
             self._client = client
             self._sftp = sftp
             self._password = password
+            self._proxy_sock = proxy_sock
 
     # -- public operations ----------------------------------------------
 

--- a/tests/test_file_manager_auth.py
+++ b/tests/test_file_manager_auth.py
@@ -21,6 +21,8 @@ class DummyClient:
         self.connect_calls = []
         self.open_sftp_called = False
         self.loaded_system = False
+        self.closed = False
+        self.last_sftp = None
         DummyClient.instances.append(self)
 
     def set_missing_host_key_policy(self, policy):
@@ -37,17 +39,37 @@ class DummyClient:
 
     def open_sftp(self):
         self.open_sftp_called = True
-        return object()
+        sftp = types.SimpleNamespace(close=lambda: setattr(self, "_sftp_closed", True))
+        self.last_sftp = sftp
+        self._sftp_closed = False
+        return sftp
+
+    def close(self):
+        self.closed = True
+
+
+class DummyProxyCommand:
+    instances = []
+
+    def __init__(self, command: str) -> None:
+        self.command = command
+        self.closed = False
+        DummyProxyCommand.instances.append(self)
+
+    def close(self) -> None:
+        self.closed = True
 
 
 @pytest.fixture(autouse=True)
 def reset_dummy_client():
     DummyClient.instances.clear()
+    DummyProxyCommand.instances.clear()
     yield
     DummyClient.instances.clear()
+    DummyProxyCommand.instances.clear()
 
 
-def test_async_sftp_manager_uses_stored_password(monkeypatch):
+def _load_file_manager_module(monkeypatch):
     setup_gi(monkeypatch)
 
     repository = sys.modules["gi.repository"]
@@ -57,6 +79,7 @@ def test_async_sftp_manager_uses_stored_password(monkeypatch):
     setattr(flags, "RUN_LAST", getattr(flags, "RUN_LAST", 1))
     gobject_module.SignalFlags = flags
     setattr(repository, "GObject", gobject_module)
+
     pango = types.SimpleNamespace(
         EllipsizeMode=types.SimpleNamespace(END=0, MIDDLE=1),
         WrapMode=types.SimpleNamespace(WORD_CHAR=0),
@@ -67,18 +90,24 @@ def test_async_sftp_manager_uses_stored_password(monkeypatch):
     monkeypatch.setitem(sys.modules, "gi.repository.PangoFT2", pangoft2)
     setattr(repository, "PangoFT2", pangoft2)
 
+    proxy_module = types.SimpleNamespace(ProxyCommand=DummyProxyCommand)
     paramiko_stub = types.SimpleNamespace(
         SSHClient=lambda: DummyClient(),
         AutoAddPolicy=lambda: DummyPolicy("auto"),
         RejectPolicy=lambda: DummyPolicy("reject"),
         WarningPolicy=lambda: DummyPolicy("warn"),
         MissingHostKeyPolicy=object,
+        proxy=proxy_module,
     )
     monkeypatch.setitem(sys.modules, "paramiko", paramiko_stub)
+    monkeypatch.setitem(sys.modules, "paramiko.proxy", proxy_module)
 
-    # Ensure we reload the module so it picks up our stubs
     sys.modules.pop("sshpilot.file_manager_window", None)
-    module = importlib.import_module("sshpilot.file_manager_window")
+    return importlib.import_module("sshpilot.file_manager_window")
+
+
+def test_async_sftp_manager_uses_stored_password(monkeypatch):
+    module = _load_file_manager_module(monkeypatch)
 
     # Pretend the known hosts file exists
     known_hosts_path = "/tmp/known_hosts"
@@ -134,3 +163,99 @@ def test_async_sftp_manager_uses_stored_password(monkeypatch):
     assert client.set_missing_host_key_policy_calls
     assert client.set_missing_host_key_policy_calls[-1].name == "auto"
     assert sftp_manager._password == "stored-secret"
+
+
+def test_async_sftp_manager_uses_proxy_command(monkeypatch):
+    module = _load_file_manager_module(monkeypatch)
+
+    connection = types.SimpleNamespace(
+        hostname="example.com",
+        host="example.com",
+        username="alice",
+        auth_method=0,
+        key_select_mode=0,
+        proxy_command="ssh -W %h:%p bastion",
+    )
+
+    manager = module.AsyncSFTPManager(
+        "example.com",
+        "alice",
+        port=22,
+        connection=connection,
+        connection_manager=None,
+        ssh_config={"auto_add_host_keys": True},
+    )
+
+    manager._connect_impl()
+
+    assert DummyClient.instances, "Expected AsyncSFTPManager to create a client"
+    client = DummyClient.instances[-1]
+    assert client.connect_calls, "Expected a connection attempt"
+    kwargs = client.connect_calls[-1]
+    assert "sock" in kwargs, "ProxyCommand should provide a socket to connect()"
+    proxy_instance = kwargs["sock"]
+    assert isinstance(proxy_instance, DummyProxyCommand)
+    assert proxy_instance.command == "ssh -W example.com:22 bastion"
+    assert not proxy_instance.closed
+
+
+def test_async_sftp_manager_expands_proxy_tokens(monkeypatch):
+    module = _load_file_manager_module(monkeypatch)
+
+    connection = types.SimpleNamespace(
+        hostname="example.com",
+        host="example.com",
+        username="alice",
+        nickname="prod",
+        auth_method=0,
+        key_select_mode=0,
+        proxy_command="ssh -W %h:%p %r@%n-%%bastion",
+    )
+
+    manager = module.AsyncSFTPManager(
+        "example.com",
+        "alice",
+        port=2200,
+        connection=connection,
+        connection_manager=None,
+        ssh_config={"auto_add_host_keys": True},
+    )
+
+    manager._connect_impl()
+
+    client = DummyClient.instances[-1]
+    kwargs = client.connect_calls[-1]
+    proxy_instance = kwargs["sock"]
+    assert proxy_instance.command == "ssh -W example.com:2200 alice@prod-%bastion"
+
+
+def test_async_sftp_manager_builds_proxy_jump_command(monkeypatch):
+    module = _load_file_manager_module(monkeypatch)
+
+    connection = types.SimpleNamespace(
+        hostname="example.com",
+        host="example.com",
+        username="alice",
+        auth_method=0,
+        key_select_mode=0,
+        proxy_jump=["Router"],
+    )
+
+    manager = module.AsyncSFTPManager(
+        "example.com",
+        "alice",
+        port=2222,
+        connection=connection,
+        connection_manager=None,
+        ssh_config={"auto_add_host_keys": True},
+    )
+
+    manager._connect_impl()
+
+    client = DummyClient.instances[-1]
+    kwargs = client.connect_calls[-1]
+    proxy_instance = kwargs["sock"]
+    assert proxy_instance.command == "ssh -W example.com:2222 -J Router example.com"
+
+    manager.close()
+    assert proxy_instance.closed, "ProxyCommand should be closed when manager closes"


### PR DESCRIPTION
## Summary
- expand ProxyCommand and ProxyJump strings with the target host, port, and username before launching Paramiko proxies
- retain the resolved alias for `%n` substitutions and surface expanded command strings in debug logs
- extend AsyncSFTPManager tests to cover placeholder substitution and ProxyJump handling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3ecdd287c8328a5c5bdf30522c318