### PR TITLE
Initialize jump client list when ProxyCommand is used

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1392,6 +1392,7 @@ class AsyncSFTPManager(GObject.GObject):
 
 
         proxy_sock: Optional[Any] = None
+        jump_clients: List[paramiko.SSHClient] = []
         proxy_command = proxy_command.strip()
         if proxy_command:
             try:


### PR DESCRIPTION
## Summary
- pre-initialize the jump client collection in the SFTP manager
- avoid UnboundLocalError when both ProxyCommand and ProxyJump are provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41be554588328aa1c32a549a439dc