### PR TITLE
Add native connect mode for SSH sessions

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -184,6 +184,7 @@ class Config(GObject.Object):
                 'auto_add_host_keys': True,
                 'verbosity': 0,
                 'debug_enabled': False,
+                'native_connect': False,
                 'use_isolated_config': is_flatpak(),
             },
             'file_manager': {
@@ -588,6 +589,7 @@ class Config(GObject.Object):
             'auto_add_host_keys': self.get_setting('ssh.auto_add_host_keys', True),
             'verbosity': self.get_setting('ssh.verbosity', 0),
             'debug_enabled': self.get_setting('ssh.debug_enabled', False),
+            'native_connect': self.get_setting('ssh.native_connect', False),
         }
 
     def get_security_config(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add an experimental native connect mode that prepares a minimal `ssh Host` command and respects overrides from the application
- integrate the native connect flag across terminal launchers, external terminal handling, and preference resets while keeping configuration state synchronized
- surface the feature via a new Advanced preference toggle and a `--native-connect` CLI switch backed by stored defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4248969ac83288abd4f1bd9fa49a4