### PR TITLE
Disable SSH compression by default

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -180,7 +180,7 @@ class Config(GObject.Object):
             'ssh': {
                 'connection_timeout': 30,
                 'keepalive_interval': 60,
-                'compression': True,
+                'compression': False,
                 'auto_add_host_keys': True,
                 'verbosity': 0,
                 'debug_enabled': False,
@@ -585,7 +585,7 @@ class Config(GObject.Object):
             'connection_attempts': self.get_setting('ssh.connection_attempts', 1),
             'keepalive_interval': self.get_setting('ssh.keepalive_interval', 60),
             'keepalive_count_max': self.get_setting('ssh.keepalive_count_max', 3),
-            'compression': self.get_setting('ssh.compression', True),
+            'compression': self.get_setting('ssh.compression', False),
             'auto_add_host_keys': self.get_setting('ssh.auto_add_host_keys', True),
             'verbosity': self.get_setting('ssh.verbosity', 0),
             'debug_enabled': self.get_setting('ssh.debug_enabled', False),

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -239,7 +239,7 @@ class Connection:
             connection_attempts = int(ssh_cfg.get('connection_attempts', 1)) if apply_adv else None
             strict_host = str(ssh_cfg.get('strict_host_key_checking', '')) if apply_adv else ''
             batch_mode = bool(ssh_cfg.get('batch_mode', False)) if apply_adv else False
-            compression = bool(ssh_cfg.get('compression', True)) if apply_adv else False
+            compression = bool(ssh_cfg.get('compression', False)) if apply_adv else False
             verbosity = int(ssh_cfg.get('verbosity', 0))
             debug_enabled = bool(ssh_cfg.get('debug_enabled', False))
             auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -868,7 +868,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             # Compression
             self.compression_row = Adw.SwitchRow()
             self.compression_row.set_title("Enable Compression (-C)")
-            self.compression_row.set_active(bool(self.config.get_setting('ssh.compression', True)))
+            self.compression_row.set_active(bool(self.config.get_setting('ssh.compression', False)))
             advanced_group.add(self.compression_row)
 
             # SSH verbosity (-v levels)
@@ -1289,8 +1289,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 self.config.set_setting('ssh.batch_mode', bool(defaults.get('batch_mode', True)))
                 self.batch_mode_row.set_active(bool(defaults.get('batch_mode', True)))
             if hasattr(self, 'compression_row'):
-                self.config.set_setting('ssh.compression', bool(defaults.get('compression', True)))
-                self.compression_row.set_active(bool(defaults.get('compression', True)))
+                self.config.set_setting('ssh.compression', bool(defaults.get('compression', False)))
+                self.compression_row.set_active(bool(defaults.get('compression', False)))
             if hasattr(self, 'verbosity_row'):
                 self.config.set_setting('ssh.verbosity', defaults.get('verbosity'))
                 self.verbosity_row.set_value(int(defaults.get('verbosity', 0)))

--- a/sshpilot/ssh_utils.py
+++ b/sshpilot/ssh_utils.py
@@ -50,7 +50,7 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
     strict_host = str(ssh_cfg.get('strict_host_key_checking', '')) if apply_adv else ''
     auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))
     batch_mode = bool(ssh_cfg.get('batch_mode', False)) if apply_adv else False
-    compression = bool(ssh_cfg.get('compression', True)) if apply_adv else False
+    compression = bool(ssh_cfg.get('compression', False)) if apply_adv else False
 
     # Determine auth method from connection and whether a password is available
     password_auth_selected = False

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -589,7 +589,7 @@ class TerminalWidget(Gtk.Box):
                 strict_host = str(ssh_cfg.get('strict_host_key_checking', '')) if apply_adv else ''
                 auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))
                 batch_mode = bool(ssh_cfg.get('batch_mode', False)) if apply_adv else False
-                compression = bool(ssh_cfg.get('compression', True)) if apply_adv else False
+                compression = bool(ssh_cfg.get('compression', False)) if apply_adv else False
 
                 # Determine auth method from connection and retrieve any saved password
                 try:


### PR DESCRIPTION
## Summary
- default SSH configuration no longer enables compression unless explicitly toggled
- ensure terminal, connection manager, and helper utilities respect the new default and update preferences UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d437acb9bc83288f672a5e961b27ac