### PR TITLE
Embed file manager in tab view by default

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -4,7 +4,6 @@ import logging
 from gi.repository import Gio, Gtk, Adw, GLib
 from gettext import gettext as _
 
-from .sftp_utils import open_remote_in_file_manager
 from .preferences import (
     should_hide_external_terminal_options,
     should_hide_file_manager_options,
@@ -99,32 +98,9 @@ class WindowActions:
         if hasattr(self, '_context_menu_connection') and self._context_menu_connection:
             connection = self._context_menu_connection
             try:
-                # Define error callback for async operation
-                def error_callback(error_msg):
-                    logger.error(f"Failed to open file manager for {connection.nickname}: {error_msg}")
-                    # Show error dialog to user
-                    self._show_manage_files_error(connection.nickname, error_msg or "Failed to open file manager")
-
-                host_value = getattr(connection, 'hostname', getattr(connection, 'host', getattr(connection, 'nickname', '')))
-                success, error_msg = open_remote_in_file_manager(
-                    user=connection.username,
-                    host=host_value,
-                    port=connection.port if connection.port != 22 else None,
-                    error_callback=error_callback,
-                    parent_window=self,
-                    connection=connection,
-                    connection_manager=getattr(self, 'connection_manager', None),
-                    ssh_config=getattr(self.config, 'get_ssh_config', lambda: {})()
-                )
-                if success:
-                    logger.info(f"Started file manager process for {connection.nickname}")
-                else:
-                    logger.error(f"Failed to start file manager process for {connection.nickname}: {error_msg}")
-                    # Show error dialog to user
-                    self._show_manage_files_error(connection.nickname, error_msg or "Failed to start file manager process")
+                self._open_manage_files_for_connection(connection)
             except Exception as e:
                 logger.error(f"Error opening file manager: {e}")
-                # Show error dialog to user
                 self._show_manage_files_error(connection.nickname, str(e))
 
     def on_edit_connection_action(self, action, param=None):

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -189,6 +189,7 @@ class Config(GObject.Object):
             },
             'file_manager': {
                 'force_internal': False,
+                'open_externally': False,
             },
             'security': {
                 'store_passwords': True,
@@ -680,11 +681,18 @@ class Config(GObject.Object):
 
         file_manager_cfg = config.get('file_manager')
         if not isinstance(file_manager_cfg, dict):
-            config['file_manager'] = {'force_internal': False}
+            config['file_manager'] = {
+                'force_internal': False,
+                'open_externally': False,
+            }
             updated = True
-        elif 'force_internal' not in file_manager_cfg:
-            file_manager_cfg['force_internal'] = False
-            updated = True
+        else:
+            if 'force_internal' not in file_manager_cfg:
+                file_manager_cfg['force_internal'] = False
+                updated = True
+            if 'open_externally' not in file_manager_cfg:
+                file_manager_cfg['open_externally'] = False
+                updated = True
 
         return config, updated
 

--- a/sshpilot/file_manager_integration.py
+++ b/sshpilot/file_manager_integration.py
@@ -10,6 +10,10 @@ from typing import Any, Optional, Tuple
 
 import gi
 
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk
+
 from .platform_utils import is_flatpak, is_macos
 from .sftp_utils import open_remote_in_file_manager
 
@@ -90,6 +94,112 @@ def open_internal_file_manager(
     )
 
     return window
+
+
+if isinstance(getattr(Gtk, 'Box', None), type):
+
+    class FileManagerTabEmbed(Gtk.Box):
+        """Container for hosting the built-in file manager inside a tab."""
+
+        def __init__(self, controller: Any, content: Gtk.Widget) -> None:
+            super().__init__(orientation=Gtk.Orientation.VERTICAL)
+            self.set_hexpand(True)
+            self.set_vexpand(True)
+            self._controller = controller
+
+            if content.get_parent() is not None:
+                content.unparent()
+
+            self.append(content)
+            self.connect('destroy', self._on_destroy)
+
+        def _on_destroy(self, *_args) -> None:
+            controller = getattr(self, '_controller', None)
+            if controller is None:
+                return
+
+            self._controller = None
+
+            manager = getattr(controller, '_manager', None)
+            if manager is not None and hasattr(manager, 'close'):
+                try:
+                    manager.close()
+                except Exception as exc:  # pragma: no cover - defensive cleanup
+                    logger.debug("Failed to close embedded file manager backend: %s", exc)
+
+            try:
+                controller.destroy()
+            except Exception as exc:  # pragma: no cover - defensive cleanup
+                logger.debug("Failed to destroy embedded file manager controller: %s", exc)
+
+else:  # pragma: no cover - fallback for test doubles
+
+    class FileManagerTabEmbed:  # type: ignore[misc]
+        """Lightweight fallback used when Gtk.Box is unavailable (test doubles)."""
+
+        def __init__(self, controller: Any, content: Any) -> None:
+            self._controller = controller
+            self._content = content
+            self._destroy_handlers: list[Any] = []
+
+        # Compatibility shims used by window code
+        def set_hexpand(self, *_args, **_kwargs):
+            return None
+
+        def set_vexpand(self, *_args, **_kwargs):
+            return None
+
+        def append(self, *_args, **_kwargs):
+            return None
+
+        def connect(self, signal: str, callback):
+            if signal == 'destroy':
+                self._destroy_handlers.append(callback)
+            return None
+
+        # Manual cleanup helper for tests to simulate GTK destroy
+        def destroy(self):
+            for handler in list(self._destroy_handlers):
+                try:
+                    handler(self)
+                except Exception:
+                    pass
+
+
+def create_internal_file_manager_tab(
+    *,
+    user: str,
+    host: str,
+    port: Optional[int] = None,
+    nickname: Optional[str] = None,
+    parent_window: Any = None,
+    connection: Any = None,
+    connection_manager: Any = None,
+    ssh_config: Optional[dict] = None,
+) -> Tuple[Gtk.Widget, Any]:
+    """Create an embedded file manager suitable for use inside a tab."""
+
+    app = Gtk.Application.get_default()
+    if app is None:
+        raise RuntimeError("An application instance is required to embed the file manager")
+
+    from .file_manager_window import FileManagerWindow
+
+    controller = FileManagerWindow(
+        application=app,
+        host=host,
+        username=user,
+        port=port or 22,
+        initial_path="~",
+        nickname=nickname,
+        connection=connection,
+        connection_manager=connection_manager,
+        ssh_config=ssh_config,
+    )
+
+    content = controller.detach_for_embedding(parent_window)
+    widget = FileManagerTabEmbed(controller, content)
+    return widget, controller
 
 
 def launch_remote_file_manager(


### PR DESCRIPTION
## Summary
- embed the built-in file manager in a new tab by default and keep external launch as a fallback
- add a preferences toggle and config setting to force the file manager to open in a separate window
- extend the internal file manager integration so it can be embedded safely and cleaned up on tab close

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4817662ac8328b4366568a729d950