### PR TITLE
Hide embedded file manager header in tabs

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -3737,6 +3737,7 @@ class FileManagerWindow(Adw.Window):
         
         # Create header bar with window controls
         header_bar = Adw.HeaderBar()
+        self._header_bar = header_bar
         title_parts = []
         if nickname and nickname.strip():
             title_parts.append(str(nickname).strip())
@@ -3944,6 +3945,10 @@ class FileManagerWindow(Adw.Window):
         if content is None:
             raise RuntimeError("File manager UI is not initialised")
 
+        enable_embedding_mode = getattr(self, 'enable_embedding_mode', None)
+        if callable(enable_embedding_mode):
+            enable_embedding_mode()
+
         try:
             current_child = self.get_content()
         except Exception:
@@ -3960,6 +3965,38 @@ class FileManagerWindow(Adw.Window):
                     pass
 
         return content
+
+    def enable_embedding_mode(self) -> None:
+        """Adjust the window chrome for embedded usage."""
+
+        if getattr(self, '_embedded_mode', False):
+            return
+
+        self._embedded_mode = True
+
+        try:
+            self.set_decorated(False)
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        header_bar = getattr(self, '_header_bar', None)
+        if header_bar is not None:
+            try:
+                header_bar.set_show_start_title_buttons(False)
+                header_bar.set_show_end_title_buttons(False)
+                header_bar.set_visible(False)
+            except Exception:  # pragma: no cover - defensive UI cleanup
+                try:
+                    header_bar.hide()
+                except Exception:
+                    pass
+
+        toolbar_view = getattr(self, '_toolbar_view', None)
+        if toolbar_view is not None:
+            try:
+                toolbar_view.add_css_class('embedded')
+            except Exception:  # pragma: no cover - optional styling
+                pass
 
     # -- signal handlers ------------------------------------------------
 

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -801,6 +801,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 )
 
                 file_manager_group.add(self.open_file_manager_externally_row)
+                self._update_external_file_manager_row()
                 advanced_page.add(file_manager_group)
 
             advanced_group = Adw.PreferencesGroup()
@@ -1327,6 +1328,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.config.set_setting('file_manager.open_externally', default_open_external)
             if getattr(self, 'open_file_manager_externally_row', None) is not None:
                 self.open_file_manager_externally_row.set_active(default_open_external)
+            self._update_external_file_manager_row()
         except Exception as e:
             logger.error(f"Failed to apply default advanced SSH settings: {e}")
 
@@ -1610,11 +1612,46 @@ class PreferencesWindow(Adw.PreferencesWindow):
         b = int(hex_color[4:6], 16) / 255.0
         return (r, g, b, 1.0)
 
+    def _is_internal_file_manager_enabled(self) -> bool:
+        """Return ``True`` when the application uses the built-in file manager."""
+
+        try:
+            if not has_internal_file_manager():
+                return False
+        except Exception as exc:  # pragma: no cover - defensive capability detection
+            logger.debug("Internal file manager check failed: %s", exc)
+            return False
+
+        try:
+            from .sftp_utils import should_use_in_app_file_manager  # pylint: disable=import-outside-toplevel
+
+            return bool(should_use_in_app_file_manager())
+        except Exception as exc:  # pragma: no cover - defensive capability detection
+            logger.debug("Failed to determine internal file manager usage: %s", exc)
+            try:
+                return bool(self.config.get_setting('file_manager.force_internal', False))
+            except Exception:
+                return False
+
+    def _update_external_file_manager_row(self) -> None:
+        """Sync the external window preference with the current availability."""
+
+        row = getattr(self, 'open_file_manager_externally_row', None)
+        if row is None:
+            return
+
+        use_internal = self._is_internal_file_manager_enabled()
+        row.set_sensitive(use_internal)
+
+        if not use_internal and row.get_active():
+            row.set_active(False)
+
     def on_force_internal_file_manager_changed(self, switch, *args):
         """Persist the preference for forcing the in-app file manager."""
         try:
             active = bool(switch.get_active())
             self.config.set_setting('file_manager.force_internal', active)
+            self._update_external_file_manager_row()
         except Exception as exc:
             logger.error("Failed to update file manager preference: %s", exc)
 

--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -32,7 +32,7 @@ def open_remote_in_file_manager(
     # Build sftp URI
     port_part = f":{port}" if port else ""
     
-    if _should_use_in_app_file_manager():
+    if should_use_in_app_file_manager():
         # For in-app file manager, use the specified path
         p = path or "~"
         uri = f"sftp://{user}@{host}{port_part}{p}"
@@ -45,7 +45,7 @@ def open_remote_in_file_manager(
 
     logger.info(f"Opening SFTP URI: {uri}")
 
-    if _should_use_in_app_file_manager():
+    if should_use_in_app_file_manager():
         logger.info("Using in-app file manager window for remote browsing")
 
         try:
@@ -113,6 +113,12 @@ def open_remote_in_file_manager(
     _verify_ssh_connection_async(user, host, port, _on_verify_complete)
 
     return True, None
+
+
+def should_use_in_app_file_manager() -> bool:
+    """Return ``True`` when the libadwaita based file manager should be used."""
+
+    return _should_use_in_app_file_manager()
 
 
 def _should_use_in_app_file_manager() -> bool:


### PR DESCRIPTION
## Summary
- hide the built-in file manager's headerbar and window chrome when embedded in a tab view
- expose a helper to detect when the in-app file manager is active and gate the "open externally" toggle accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4f6c6368c8328b029eee1c85956e2