### PR TITLE
Add keyboard shortcut for file manager

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -574,6 +574,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_clear_progress_toast()`** — Clear the progress dialog safely.
 
+- **`_compute_effective_split_width()`** — Determine the appropriate width to use when sizing the split view.
+
 - **`_copy_remote_directory(sftp, source_path, destination_path)`** — Handles copy remote directory.
 
 - **`_copy_remote_file(sftp, source_path, destination_path)`** — Handles copy remote file.
@@ -594,11 +596,15 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_on_connection_error(_manager, message)`** — Handle connection error with toast.
 
+- **`_on_content_size_allocate(_widget, allocation)`** — Adjust split position based on the actual allocated width of the content.
+
 - **`_on_directory_loaded(_manager, path, entries)`** — Handles directory loaded.
 
 - **`_on_local_pane_toggle(toggle_button)`** — Handle local pane toggle button.
 
 - **`_on_operation_error(_manager, message)`** — Handle operation error with toast.
+
+- **`_on_panes_size_changed(panes, pspec)`** — Handle panes widget size changes to maintain proportional split.
 
 - **`_on_path_changed(pane, path, user_data=None)`** — Handles path changed.
 
@@ -632,11 +638,15 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_schedule_remote_move_cleanup(future, source_path, pane)`** — Handles schedule remote move cleanup.
 
+- **`_set_initial_split_position()`** — Set the initial proportional split position after the widget is realized.
+
 - **`_show_progress(fraction, message)`** — Update progress dialog if active.
 
 - **`_show_progress_dialog(operation_type, filename, future)`** — Show and manage the progress dialog for a file operation.
 
 - **`_update_paste_targets()`** — Updates paste targets.
+
+- **`_update_split_position(width=None)`** — Update the split position, preserving user adjustments where possible.
 
 - **`detach_for_embedding(parent=None)`** — Detach the window content for embedding in another container.
 
@@ -985,6 +995,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`on_help(action, param)`** — Handle help action
 
 - **`on_local_terminal(action, param)`** — Handle local terminal action
+
+- **`on_manage_files(action, param)`** — Handle manage files shortcut.
 
 - **`on_new_connection(action, param)`** — Handle new connection action
 
@@ -1438,7 +1450,7 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`__init__(connection)`** — Handles init.
 
-- **`_apply_host_label_text()`** — Handles apply host label text.
+- **`_apply_host_label_text(include_port=None)`** — Handles apply host label text.
 
 - **`_install_pf_css()`** — Handles install pf css.
 

--- a/sshpilot/shortcut_editor.py
+++ b/sshpilot/shortcut_editor.py
@@ -51,6 +51,7 @@ ACTION_LABELS: Dict[str, str] = {
     'toggle-list': _('Focus Connection List'),
     'search': _('Search Connections'),
     'new-key': _('Copy Key to Server'),
+    'manage-files': _('Manage Files'),
     'edit-ssh-config': _('SSH Config Editor'),
     'local-terminal': _('Local Terminal'),
     'preferences': _('Preferences'),
@@ -241,6 +242,7 @@ class ShortcutsPreferencesPage(PreferencesPageBase):
             'toggle-list',
             'search',
             'new-key',
+            'manage-files',
             'edit-ssh-config',
             'quick-connect',
         ]

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1580,7 +1580,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
         # Manage files button (visibility controlled dynamically)
         self.manage_files_button = Gtk.Button.new_from_icon_name('folder-symbolic')
-        self.manage_files_button.set_tooltip_text('Open file manager for remote server')
+        primary_label = get_primary_modifier_label()
+        self.manage_files_button.set_tooltip_text(
+            f"Open file manager for remote server ({primary_label}+Shift+O)"
+        )
         self.manage_files_button.set_sensitive(False)
         self.manage_files_button.connect('clicked', self.on_manage_files_button_clicked)
         self.manage_files_button.set_visible(not should_hide_file_manager_options())
@@ -2976,6 +2979,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             ('quick-connect', _('Quick Connect')),
             ('open-new-connection-tab', _('Open New Tab')),
             ('new-key', _('Copy Key to Server')),
+            ('manage-files', _('Manage Files')),
         ]
         
         for action_name, title in connection_actions:
@@ -3080,6 +3084,8 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             title=_('Focus Connection List'), accelerator=f"{primary}l"))
         group_connections.add_shortcut(Gtk.ShortcutsShortcut(
             title=_('Quick Connect'), accelerator=f"{primary}<Alt>c"))
+        group_connections.add_shortcut(Gtk.ShortcutsShortcut(
+            title=_('Manage Files'), accelerator=f"{primary}<Shift>o"))
         section.add_group(group_connections)
 
         # Terminal shortcuts


### PR DESCRIPTION
## Summary
- add a global Manage Files accelerator tied to Ctrl/Cmd+Shift+O
- expose the shortcut in the shortcut viewer, editor, and file manager tooltip
- regenerate the function reference documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50979f13c83289ba9b5f8fe748fed