### PR TITLE
Allow default SSH mode when running under Flatpak

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 from gi.repository import Gio, GLib, GObject
-from .platform_utils import get_config_dir, is_flatpak
+from .platform_utils import get_config_dir
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +185,7 @@ class Config(GObject.Object):
                 'verbosity': 0,
                 'debug_enabled': False,
                 'native_connect': False,
-                'use_isolated_config': is_flatpak(),
+                'use_isolated_config': False,
             },
             'file_manager': {
                 'force_internal': False,
@@ -693,6 +693,19 @@ class Config(GObject.Object):
             if 'open_externally' not in file_manager_cfg:
                 file_manager_cfg['open_externally'] = False
                 updated = True
+
+        ssh_cfg = config.get('ssh')
+        if not isinstance(ssh_cfg, dict):
+            default_ssh = self.get_default_config().get('ssh', {}).copy()
+            config['ssh'] = default_ssh
+            updated = True
+            ssh_cfg = config['ssh']
+        if 'use_isolated_config' not in ssh_cfg:
+            ssh_cfg['use_isolated_config'] = False
+            updated = True
+        elif not isinstance(ssh_cfg['use_isolated_config'], bool):
+            ssh_cfg['use_isolated_config'] = bool(ssh_cfg['use_isolated_config'])
+            updated = True
 
         return config, updated
 

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -42,7 +42,7 @@ if not load_resources():
     sys.exit(1)
 
 from .window import MainWindow
-from .platform_utils import is_macos, get_data_dir, is_flatpak
+from .platform_utils import is_macos, get_data_dir
 from .preferences import should_hide_file_manager_options
 
 class SshPilotApplication(Adw.Application):
@@ -85,14 +85,8 @@ class SshPilotApplication(Adw.Application):
             # Apply color overrides
             self.apply_color_overrides(cfg)
 
-            flatpak = is_flatpak()
-            self.isolated_mode = (
-                True
-                if flatpak
-                else isolated or bool(cfg.get_setting('ssh.use_isolated_config', False))
-            )
-            if flatpak:
-                cfg.set_setting('ssh.use_isolated_config', True)
+            configured_isolated = bool(cfg.get_setting('ssh.use_isolated_config', False))
+            self.isolated_mode = bool(isolated or configured_isolated)
 
             # Update native connect state from configuration when not overridden
             try:
@@ -108,7 +102,7 @@ class SshPilotApplication(Adw.Application):
                 # Override already active, ensure attribute is boolean
                 self.native_connect_enabled = bool(self.native_connect_enabled or native_cfg)
         except Exception:
-            self.isolated_mode = True if is_flatpak() else isolated
+            self.isolated_mode = bool(isolated)
             if self.native_connect_override is None:
                 self.native_connect_enabled = bool(native_connect)
 

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -754,12 +754,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.isolated_mode_row.set_activatable_widget(self.isolated_mode_radio)
             operation_group.add(self.isolated_mode_row)
 
-            flatpak = is_flatpak()
-            use_isolated = True if flatpak else bool(self.config.get_setting('ssh.use_isolated_config', False))
+            use_isolated = bool(self.config.get_setting('ssh.use_isolated_config', False))
             self.isolated_mode_radio.set_active(use_isolated)
             self.default_mode_radio.set_active(not use_isolated)
-            if flatpak:
-                self.default_mode_row.set_sensitive(False)
 
             self.default_mode_radio.connect('toggled', self.on_operation_mode_toggled)
             self.isolated_mode_radio.connect('toggled', self.on_operation_mode_toggled)

--- a/tests/test_flatpak_isolated_config.py
+++ b/tests/test_flatpak_isolated_config.py
@@ -1,11 +1,26 @@
 import importlib
+import json
 
 import sshpilot.config as config
 
 
-def test_isolated_config_default_on_flatpak(monkeypatch, tmp_path):
+def test_default_mode_is_default_on_flatpak(monkeypatch, tmp_path):
     importlib.reload(config)
-    monkeypatch.setattr(config, "is_flatpak", lambda: True)
     monkeypatch.setattr(config, "get_config_dir", lambda: str(tmp_path))
+    cfg = config.Config()
+    assert cfg.get_setting('ssh.use_isolated_config', True) is False
+
+
+def test_existing_flatpak_isolated_config_preserved(monkeypatch, tmp_path):
+    importlib.reload(config)
+    monkeypatch.setattr(config, "get_config_dir", lambda: str(tmp_path))
+
+    config_data = {
+        "config_version": config.CONFIG_VERSION,
+        "ssh": {"use_isolated_config": True},
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config_data))
+
     cfg = config.Config()
     assert cfg.get_setting('ssh.use_isolated_config', False) is True


### PR DESCRIPTION
## Summary
- default new configurations to Default Mode even when running inside Flatpak
- stop forcing isolated mode in the application and preferences UI while preserving existing settings
- cover the new Flatpak behavior with regression tests for defaults and legacy configs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54a988110832884fb2dec50fe1dad