### PR TITLE
Add Windows test workflow

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,25 @@
+name: Windows Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: python -m pip install pytest paramiko cryptography keyring psutil pycairo
+      - name: Run tests
+        run: python -m pytest


### PR DESCRIPTION
## Summary
- add a Windows CI workflow that exercises the pytest suite on Python 3.11 and 3.12
- install runtime dependencies individually to avoid PyGObject packaging issues on Windows runners

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5c4fb77648328a493361a19cabfb3