### PR TITLE
Add terminal backend selection and optional pyxterm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ Enable verbose debugging with:
 python3 run.py --verbose
 ```
 
+Optional terminal backends
+--------------------------
+
+The default terminal uses the native VTE widget. To enable the optional
+PyXterm.js backend install the extra dependency bundle:
+
+```
+pip install "sshpilot[pyxterm]"
+```
+
+or install `pyxtermjs` manually if you prefer:
+
+```
+pip install pyxtermjs
+```
+
 ### Telegram channel
 https://t.me/sshpilot
 

--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -680,6 +680,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_format_size(size_bytes)`** — Handles format size.
 
+- **`_get_file_manager_window()`** — Return the controlling FileManagerWindow if available.
+
 - **`_get_primary_selection_index()`** — Returns primary selection index.
 
 - **`_get_selected_indices()`** — Returns selected indices.
@@ -797,6 +799,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`restore_persisted_folder()`** — Restore access to a previously granted folder on app launch (Flatpak only).
 
 - **`set_can_paste(can_paste)`** — Sets can paste.
+
+- **`set_file_manager_window(window)`** — Associate this pane with its owning file manager window.
 
 - **`set_partner_pane(partner)`** — Sets partner pane.
 
@@ -1134,13 +1138,21 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_apply_default_advanced_settings(update_toggle=True)`** — Restore advanced SSH settings to defaults and update the UI.
 
+- **`_build_backend_choices()`** — Builds backend choices.
+
+- **`_detect_pyxterm_backend()`** — Handles detect pyxterm backend.
+
 - **`_is_internal_file_manager_enabled()`** — Return ``True`` when the application uses the built-in file manager.
+
+- **`_on_backend_row_changed(combo_row, _param)`** — Handles backend row changed.
 
 - **`_populate_terminal_dropdown()`** — Populate the terminal dropdown with available terminals
 
 - **`_set_color_button(button, row, setting_name, default_rgba, default_subtitle)`** — Sets color button.
 
 - **`_set_terminal_dropdown_selection(terminal_name)`** — Set the dropdown selection to the specified terminal
+
+- **`_update_backend_row_subtitle(index)`** — Updates backend row subtitle.
 
 - **`_update_external_file_manager_row()`** — Sync the external window preference with the current availability.
 
@@ -1612,9 +1624,15 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_cleanup_process(pid)`** — Clean up a process by PID
 
+- **`_connect_backend_signals()`** — Connect to backend signals and store handler IDs.
+
 - **`_connect_ssh()`** — Connect to SSH host
 
 - **`_connect_ssh_thread()`** — SSH connection thread: directly spawn SSH and rely on its output for errors.
+
+- **`_create_backend(preferred=None)`** — Create the terminal backend based on configuration.
+
+- **`_disconnect_backend_signals(backend=None)`** — Disconnect previously connected backend signals.
 
 - **`_fallback_hide_spinner()`** — Fallback method to hide spinner if spawn completion doesn't fire
 
@@ -1668,15 +1686,23 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_show_forwarding_error_dialog(message)`** — Shows forwarding error dialog.
 
+- **`_teardown_context_menu()`** — Remove any previously installed context menu resources.
+
 - **`_terminate_process_tree(pid)`** — Terminate a process and all its children
 
-- **`apply_theme(theme_name=None)`** — Apply terminal theme and font settings
+- **`apply_theme(theme_name=None)`** — Delegate theme application to the backend.
 
 - **`copy_text()`** — Copy selected text to clipboard
 
 - **`disconnect()`** — Close the SSH connection and clean up resources
 
+- **`ensure_backend(backend_name)`** — Handles ensure backend.
+
+- **`feed_child(data)`** — Handles feed child.
+
 - **`force_style_refresh()`** — Force a style refresh of the terminal widget.
+
+- **`get_backend_name()`** — Returns backend name.
 
 - **`get_connection_info()`** — Get connection information
 
@@ -1694,6 +1720,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`paste_text()`** — Paste text from clipboard
 
+- **`queue_draw_terminal()`** — Handles queue draw terminal.
+
 - **`reconnect()`** — Reconnect the terminal with updated connection settings
 
 - **`reset_and_clear()`** — Reset and clear terminal
@@ -1706,13 +1734,195 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`select_all()`** — Select all text in terminal
 
+- **`set_font(font_desc)`** — Sets font.
+
 - **`setup_local_shell()`** — Set up the terminal for local shell (not SSH)
 
-- **`setup_terminal()`** — Initialize the VTE terminal with appropriate settings.
+- **`setup_terminal()`** — Initialize the terminal backend with appropriate settings.
+
+- **`show_terminal_widget()`** — Shows terminal widget.
+
+- **`switch_backend(backend_name)`** — Handles switch backend.
 
 - **`zoom_in()`** — Zoom in the terminal font
 
 - **`zoom_out()`** — Zoom out the terminal font
+
+
+
+## Module: `sshpilot.terminal_backends`
+
+### Class: `BaseTerminalBackend`
+
+- **`apply_theme(theme_name=None)`** — Apply the current theme to the terminal widget.
+
+- **`connect_child_exited(callback)`** — Connect to the child exited signal for the backend.
+
+- **`connect_termprops_changed(callback)`** — Connect to the termprops-changed signal if supported.
+
+- **`connect_title_changed(callback)`** — Connect to a signal emitted when the terminal title changes.
+
+- **`copy_clipboard()`** — Copy the current terminal selection to the clipboard.
+
+- **`destroy()`** — Release backend resources.
+
+- **`disconnect(handler_id)`** — Disconnect a previously registered signal handler.
+
+- **`feed(data)`** — Feed raw data to the terminal display.
+
+- **`feed_child(data)`** — Feed raw bytes to the child process input if supported.
+
+- **`get_child_pgid()`** — Return the process group id of the running child process if available.
+
+- **`get_child_pid()`** — Return the PID of the running child process if available.
+
+- **`get_font_scale()`** — Return the current font scale.
+
+- **`get_pty()`** — Return the PTY instance if the backend exposes one.
+
+- **`grab_focus()`** — Give keyboard focus to the terminal widget.
+
+- **`initialize()`** — Perform backend specific initialisation and register internal state.
+
+- **`paste_clipboard()`** — Paste clipboard contents into the terminal.
+
+- **`queue_draw()`** — Queue a redraw of the backend widget if supported.
+
+- **`reset(clear_scrollback, clear_screen)`** — Reset the terminal content.
+
+- **`search_find_next()`** — Search forward using the configured regex.
+
+- **`search_find_previous()`** — Search backwards using the configured regex.
+
+- **`search_set_regex(regex)`** — Configure the search regex for the backend, if supported.
+
+- **`select_all()`** — Select all content in the terminal.
+
+- **`set_font(font_desc)`** — Set the font for the backend if supported.
+
+- **`set_font_scale(scale)`** — Set the font scale for the terminal.
+
+- **`show()`** — Ensure the backend widget is visible.
+
+- **`spawn_async(argv, env=None, cwd=None, flags=0, child_setup=None, callback=None, user_data=None)`** — Spawn a new process attached to the backend terminal.
+
+- **`supports_feature(feature)`** — Return True if the backend supports the given feature name.
+
+### Class: `PyXtermTerminalBackend`
+
+- **`__init__(owner)`** — Handles init.
+
+- **`apply_theme(theme_name=None)`** — Handles apply theme.
+
+- **`connect_child_exited(callback)`** — Connects child exited.
+
+- **`connect_termprops_changed(callback)`** — Connects termprops changed.
+
+- **`connect_title_changed(callback)`** — Connects title changed.
+
+- **`copy_clipboard()`** — Handles copy clipboard.
+
+- **`destroy()`** — Handles destroy.
+
+- **`disconnect(handler_id)`** — Handles disconnect.
+
+- **`feed(data)`** — Handles feed.
+
+- **`feed_child(data)`** — Handles feed child.
+
+- **`get_child_pgid()`** — Returns child pgid.
+
+- **`get_child_pid()`** — Returns child pid.
+
+- **`get_font_scale()`** — Returns font scale.
+
+- **`get_pty()`** — Returns pty.
+
+- **`grab_focus()`** — Handles grab focus.
+
+- **`initialize()`** — Handles initialize.
+
+- **`paste_clipboard()`** — Handles paste clipboard.
+
+- **`queue_draw()`** — Handles queue draw.
+
+- **`reset(clear_scrollback, clear_screen)`** — Handles reset.
+
+- **`search_find_next()`** — Handles search find next.
+
+- **`search_find_previous()`** — Handles search find previous.
+
+- **`search_set_regex(regex)`** — Handles search set regex.
+
+- **`select_all()`** — Handles select all.
+
+- **`set_font(font_desc)`** — Sets font.
+
+- **`set_font_scale(scale)`** — Sets font scale.
+
+- **`show()`** — Handles show.
+
+- **`spawn_async(argv, env=None, cwd=None, flags=0, child_setup=None, callback=None, user_data=None)`** — Handles spawn async.
+
+- **`supports_feature(feature)`** — Handles supports feature.
+
+### Class: `VTETerminalBackend`
+
+- **`__init__(owner)`** — Handles init.
+
+- **`apply_theme(theme_name=None)`** — Handles apply theme.
+
+- **`connect_child_exited(callback)`** — Connects child exited.
+
+- **`connect_termprops_changed(callback)`** — Connects termprops changed.
+
+- **`connect_title_changed(callback)`** — Connects title changed.
+
+- **`copy_clipboard()`** — Handles copy clipboard.
+
+- **`destroy()`** — Handles destroy.
+
+- **`disconnect(handler_id)`** — Handles disconnect.
+
+- **`feed(data)`** — Handles feed.
+
+- **`feed_child(data)`** — Handles feed child.
+
+- **`get_child_pgid()`** — Returns child pgid.
+
+- **`get_child_pid()`** — Returns child pid.
+
+- **`get_font_scale()`** — Returns font scale.
+
+- **`get_pty()`** — Returns pty.
+
+- **`grab_focus()`** — Handles grab focus.
+
+- **`initialize()`** — Handles initialize.
+
+- **`paste_clipboard()`** — Handles paste clipboard.
+
+- **`queue_draw()`** — Handles queue draw.
+
+- **`reset(clear_scrollback, clear_screen)`** — Handles reset.
+
+- **`search_find_next()`** — Handles search find next.
+
+- **`search_find_previous()`** — Handles search find previous.
+
+- **`search_set_regex(regex)`** — Handles search set regex.
+
+- **`select_all()`** — Handles select all.
+
+- **`set_font(font_desc)`** — Sets font.
+
+- **`set_font_scale(scale)`** — Sets font scale.
+
+- **`show()`** — Handles show.
+
+- **`spawn_async(argv, env=None, cwd=None, flags=0, child_setup=None, callback=None, user_data=None)`** — Handles spawn async.
+
+- **`supports_feature(feature)`** — Handles supports feature.
 
 
 
@@ -1723,6 +1933,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`__init__(window)`** — Handles init.
 
 - **`_add_terminal_tab(terminal_widget, title)`** — Adds terminal tab.
+
+- **`_ensure_backend_alignment(terminal)`** — Ensure the given terminal uses the configured backend.
 
 - **`_on_disconnect_confirmed(dialog, response_id, connection)`** — Handles disconnect confirmed.
 
@@ -1741,6 +1953,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`on_terminal_disconnected(terminal)`** — Handles terminal disconnected.
 
 - **`on_terminal_title_changed(terminal, title)`** — Handles terminal title changed.
+
+- **`refresh_backends()`** — Ensure all existing terminals use the configured backend.
 
 - **`show_local_terminal()`** — Shows local terminal.
 
@@ -1897,6 +2111,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`_resolve_connection_list_event(x, y, scrolled_window=None)`** — Resolve the target row and viewport coordinates for a pointer event on the connection list.
 
 - **`_save_window_state()`** — Save window state before quitting
+
+- **`_schedule_startup_tasks()`** — Schedule one-time startup behaviors such as focus and welcome state.
 
 - **`_select_only_row(row)`** — Select only the provided row, clearing any other selections.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dependencies = [
     "psutil>=5.9.0",
 ]
 
+[project.optional-dependencies]
+pyxterm = [
+    "pyxtermjs>=0.2.2",
+]
+
 [tool.setuptools.packages.find]
 include = ["sshpilot*"]
 exclude = ["packaging*", "screenshots*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ keyring>=24.3
 # System utilities
 psutil>=5.9.0
 
+# Optional terminal backends
+# pyxtermjs>=0.2.2  # Enable web-based terminal backend support
 
 
 

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -161,6 +161,7 @@ class Config(GObject.Object):
                 'scrollback_lines': 10000,
                 'cursor_blink': True,
                 'audible_bell': False,
+                'backend': 'vte',
             },
             'ui': {
                 'show_hostname': True,
@@ -677,6 +678,15 @@ class Config(GObject.Object):
         shortcuts = config.get('shortcuts')
         if not isinstance(shortcuts, dict):
             config['shortcuts'] = {}
+            updated = True
+
+        terminal_cfg = config.get('terminal')
+        if not isinstance(terminal_cfg, dict):
+            config['terminal'] = self.get_default_config().get('terminal', {}).copy()
+            updated = True
+            terminal_cfg = config['terminal']
+        if 'backend' not in terminal_cfg:
+            terminal_cfg['backend'] = 'vte'
             updated = True
 
         file_manager_cfg = config.get('file_manager')

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -1,5 +1,6 @@
 """Preferences dialog and font selection utilities."""
 
+import importlib.util
 import os
 import logging
 import subprocess
@@ -339,6 +340,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.set_modal(True)
         self.parent_window = parent_window
         self.config = config
+        self._backend_choice_data = self._build_backend_choices()
+        self._backend_last_valid_index = 0
         
         # Set window properties
         self.set_title("Preferences")
@@ -346,12 +349,82 @@ class PreferencesWindow(Adw.PreferencesWindow):
         
         # Initialize the preferences UI
         self.setup_preferences()
-        
+
         # Apply any existing color overrides
         self.apply_color_overrides()
 
         # Save on close to persist advanced SSH settings
         self.connect('close-request', self.on_close_request)
+
+    def _detect_pyxterm_backend(self):
+        try:
+            spec = importlib.util.find_spec('pyxtermjs')
+            if spec is None:
+                raise ImportError('pyxtermjs module not found')
+            __import__('pyxtermjs')
+            return True, None
+        except Exception as exc:
+            return False, str(exc)
+
+    def _build_backend_choices(self):
+        choices = [
+            {
+                'id': 'vte',
+                'label': 'VTE (default)',
+                'description': 'Native VTE-based terminal',
+                'available': True,
+                'error': None,
+            }
+        ]
+        pyxterm_available, pyxterm_error = self._detect_pyxterm_backend()
+        if pyxterm_available:
+            choices.append(
+                {
+                    'id': 'pyxterm',
+                    'label': 'PyXterm.js',
+                    'description': 'Web-based terminal (pyxtermjs)',
+                    'available': True,
+                    'error': None,
+                }
+            )
+        else:
+            choices.append(
+                {
+                    'id': 'pyxterm',
+                    'label': 'PyXterm.js (requires pyxtermjs)',
+                    'description': 'pyxtermjs package not available',
+                    'available': False,
+                    'error': pyxterm_error,
+                }
+            )
+        return choices
+
+    def _update_backend_row_subtitle(self, index: int):
+        if not hasattr(self, 'backend_row'):
+            return
+        if 0 <= index < len(self._backend_choice_data):
+            desc = self._backend_choice_data[index].get('description')
+            if desc:
+                self.backend_row.set_subtitle(desc)
+
+    def _on_backend_row_changed(self, combo_row, _param):
+        index = combo_row.get_selected()
+        if index < 0 or index >= len(self._backend_choice_data):
+            return
+        option = self._backend_choice_data[index]
+        if not option.get('available'):
+            combo_row.set_selected(self._backend_last_valid_index)
+            logger.warning("PyXterm backend unavailable: %s", option.get('error'))
+            return
+        self._backend_last_valid_index = index
+        backend_id = option.get('id', 'vte')
+        self.config.set_setting('terminal.backend', backend_id)
+        self._update_backend_row_subtitle(index)
+        if self.parent_window and hasattr(self.parent_window, 'terminal_manager'):
+            try:
+                self.parent_window.terminal_manager.refresh_backends()
+            except Exception as exc:
+                logger.error("Failed to refresh terminal backends: %s", exc)
     
     def setup_preferences(self):
         """Set up preferences UI with current values"""
@@ -375,8 +448,39 @@ class PreferencesWindow(Adw.PreferencesWindow):
             font_button.set_label("Choose")
             font_button.connect('clicked', self.on_font_button_clicked)
             self.font_row.add_suffix(font_button)
-            
+
             appearance_group.add(self.font_row)
+
+            # Terminal backend selector
+            backend_model = Gtk.StringList()
+            for option in self._backend_choice_data:
+                backend_model.append(option.get('label', ''))
+
+            self.backend_row = Adw.ComboRow()
+            self.backend_row.set_title("Terminal Backend")
+            self.backend_row.set_model(backend_model)
+
+            current_backend = self.config.get_setting('terminal.backend', 'vte')
+            selected_index = 0
+            for idx, option in enumerate(self._backend_choice_data):
+                if option.get('id') == current_backend:
+                    selected_index = idx
+                    break
+
+            if not self._backend_choice_data[selected_index].get('available', True):
+                for idx, option in enumerate(self._backend_choice_data):
+                    if option.get('available'):
+                        selected_index = idx
+                        if option.get('id') != current_backend:
+                            self.config.set_setting('terminal.backend', option.get('id', 'vte'))
+                        break
+
+            self.backend_row.set_selected(selected_index)
+            self._backend_last_valid_index = selected_index
+            self._update_backend_row_subtitle(selected_index)
+            self.backend_row.connect('notify::selected', self._on_backend_row_changed)
+
+            appearance_group.add(self.backend_row)
             
             # Terminal color scheme
             self.color_scheme_row = Adw.ComboRow()
@@ -1016,7 +1120,11 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 count = 0
                 for terms in parent_window.connection_to_terminals.values():
                     for terminal in terms:
-                        if hasattr(terminal, 'vte'):
+                        setter = getattr(terminal, 'set_font', None)
+                        if callable(setter):
+                            setter(font_desc)
+                            count += 1
+                        elif hasattr(terminal, 'vte'):
                             terminal.vte.set_font(font_desc)
                             count += 1
                 logger.info(f"Applied font {font_string} to {count} terminals")

--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -17,12 +17,61 @@ class TerminalManager:
     def __init__(self, window):
         self.window = window
 
+    def _ensure_backend_alignment(self, terminal) -> None:
+        """Ensure the given terminal uses the configured backend."""
+        if not terminal or not hasattr(self.window, 'config'):
+            return
+        desired = self.window.config.get_setting('terminal.backend', 'vte')
+        getter = getattr(terminal, 'get_backend_name', None)
+        current = getter() if callable(getter) else 'vte'
+        if isinstance(desired, str) and isinstance(current, str):
+            if current.lower() == (desired or 'vte').lower():
+                return
+        aligner = getattr(terminal, 'ensure_backend', None)
+        if callable(aligner):
+            try:
+                aligner(desired)
+            except Exception:
+                logger.error("Failed to align terminal backend", exc_info=True)
+
+    def refresh_backends(self) -> None:
+        """Ensure all existing terminals use the configured backend."""
+        seen = set()
+        collections = []
+        connection_terms = getattr(self.window, 'connection_to_terminals', None)
+        if isinstance(connection_terms, dict):
+            collections.extend(connection_terms.values())
+        active = getattr(self.window, 'active_terminals', None)
+        if isinstance(active, dict):
+            collections.append(active.values())
+        for group in collections:
+            for term in list(group):
+                if term in seen:
+                    continue
+                self._ensure_backend_alignment(term)
+                seen.add(term)
+        tab_view = getattr(self.window, 'tab_view', None)
+        if tab_view is not None and hasattr(tab_view, 'get_n_pages'):
+            try:
+                for index in range(tab_view.get_n_pages()):
+                    page = tab_view.get_nth_page(index)
+                    if page is None:
+                        continue
+                    term = page.get_child()
+                    if term is None or term in seen:
+                        continue
+                    self._ensure_backend_alignment(term)
+                    seen.add(term)
+            except Exception:
+                logger.debug("Failed to iterate tab view while refreshing backends", exc_info=True)
+
     # Connecting/disconnecting hosts
     def connect_to_host(self, connection, force_new: bool = False):
         window = self.window
         if not force_new:
             if connection in window.active_terminals:
                 terminal = window.active_terminals[connection]
+                self._ensure_backend_alignment(terminal)
                 page = window.tab_view.get_page(terminal)
                 if page is not None:
                     window.tab_view.set_selected_page(page)
@@ -36,6 +85,7 @@ class TerminalManager:
             for t in reversed(existing_terms):
                 page = window.tab_view.get_page(t)
                 if page is not None:
+                    self._ensure_backend_alignment(t)
                     window.active_terminals[connection] = t
                     window.tab_view.set_selected_page(page)
                     return
@@ -117,7 +167,9 @@ class TerminalManager:
                         logger.error(f"Failed to prepare SSH command: {prep_err}")
 
                 terminal.apply_theme()
-                terminal.vte.queue_draw()
+                refresher = getattr(terminal, 'queue_draw_terminal', None)
+                if callable(refresher):
+                    refresher()
                 if not terminal._connect_ssh():
                     logger.error('Failed to establish SSH connection')
                     _cleanup_failed_terminal()
@@ -201,7 +253,7 @@ class TerminalManager:
             window.active_terminals[local_connection] = terminal_widget
 
             GLib.idle_add(terminal_widget.show)
-            GLib.idle_add(terminal_widget.vte.show)
+            GLib.idle_add(getattr(terminal_widget, 'show_terminal_widget', terminal_widget.show))
             logger.info("Local terminal tab created successfully")
         except Exception as e:
             logger.error(f"Failed to show local terminal: {e}")
@@ -227,7 +279,7 @@ class TerminalManager:
             if page is None:
                 continue
             terminal_widget = page.get_child()
-            if terminal_widget is None or not hasattr(terminal_widget, 'vte'):
+            if terminal_widget is None or not hasattr(terminal_widget, 'feed_child'):
                 continue
             if hasattr(terminal_widget, 'connection'):
                 if (hasattr(terminal_widget.connection, 'nickname') and
@@ -236,7 +288,9 @@ class TerminalManager:
                 if not hasattr(terminal_widget.connection, 'hostname'):
                     continue
                 try:
-                    terminal_widget.vte.feed_child(cmd)
+                    if not terminal_widget.feed_child(cmd):
+                        failed_count += 1
+                        continue
                     sent_count += 1
                     logger.debug(
                         f"Sent command to SSH terminal: {terminal_widget.connection.nickname}")

--- a/tests/test_cleanup_process.py
+++ b/tests/test_cleanup_process.py
@@ -17,7 +17,13 @@ def test_cleanup_process_sends_sigterm_to_pgid(monkeypatch):
     )
     repo.GLib = types.SimpleNamespace()
     repo.Vte = types.SimpleNamespace()
-    repo.Pango = types.SimpleNamespace()
+    repo.Pango = types.SimpleNamespace(
+        FontDescription=type(
+            "FontDescription",
+            (),
+            {"from_string": staticmethod(lambda *_: object())},
+        )
+    )
     repo.Gdk = types.SimpleNamespace()
     repo.Gio = types.SimpleNamespace()
     repo.Adw = types.SimpleNamespace()

--- a/tests/test_preferences_backend.py
+++ b/tests/test_preferences_backend.py
@@ -1,0 +1,93 @@
+import types
+
+
+def test_backend_choices_missing_dependency(monkeypatch):
+    from sshpilot.preferences import PreferencesWindow
+
+    window = PreferencesWindow.__new__(PreferencesWindow)
+    monkeypatch.setattr(window, "_detect_pyxterm_backend", lambda: (False, "missing"))
+
+    choices = PreferencesWindow._build_backend_choices(window)
+
+    pyxterm_choice = next(choice for choice in choices if choice['id'] == 'pyxterm')
+    assert not pyxterm_choice['available']
+    assert 'requires' in pyxterm_choice['label']
+
+
+def test_backend_row_updates_config(monkeypatch):
+    from sshpilot.preferences import PreferencesWindow
+
+    window = PreferencesWindow.__new__(PreferencesWindow)
+    record: dict[str, object] = {}
+
+    class ConfigStub:
+        def set_setting(self, key, value):
+            record['key'] = key
+            record['value'] = value
+
+        def get_setting(self, key, default=None):
+            return default
+
+    refreshed = {'count': 0}
+
+    class ManagerStub:
+        def refresh_backends(self):
+            refreshed['count'] += 1
+
+    window.config = ConfigStub()
+    window.parent_window = types.SimpleNamespace(terminal_manager=ManagerStub())
+    window.backend_row = types.SimpleNamespace(set_subtitle=lambda value: record.setdefault('subtitle', value))
+    window._backend_choice_data = [
+        {'id': 'vte', 'available': True, 'description': 'VTE'},
+        {'id': 'pyxterm', 'available': True, 'description': 'PyXterm'},
+    ]
+    window._backend_last_valid_index = 0
+
+    class ComboStub:
+        def __init__(self, selected):
+            self._selected = selected
+            self.reset_to = None
+
+        def get_selected(self):
+            return self._selected
+
+        def set_selected(self, value):
+            self.reset_to = value
+
+    combo = ComboStub(1)
+    window._on_backend_row_changed(combo, None)
+
+    assert record['key'] == 'terminal.backend'
+    assert record['value'] == 'pyxterm'
+    assert record['subtitle'] == 'PyXterm'
+    assert refreshed['count'] == 1
+    assert combo.reset_to is None
+
+
+def test_backend_row_rejects_unavailable(monkeypatch):
+    from sshpilot.preferences import PreferencesWindow
+
+    window = PreferencesWindow.__new__(PreferencesWindow)
+    window.config = types.SimpleNamespace(set_setting=lambda *a, **k: None, get_setting=lambda *a, **k: None)
+    window.parent_window = types.SimpleNamespace(terminal_manager=types.SimpleNamespace(refresh_backends=lambda: None))
+    window.backend_row = types.SimpleNamespace(set_subtitle=lambda value: None)
+    window._backend_choice_data = [
+        {'id': 'vte', 'available': True, 'description': 'VTE'},
+        {'id': 'pyxterm', 'available': False, 'description': 'missing'},
+    ]
+    window._backend_last_valid_index = 0
+
+    class ComboStub:
+        def __init__(self):
+            self.reset_to = None
+
+        def get_selected(self):
+            return 1
+
+        def set_selected(self, value):
+            self.reset_to = value
+
+    combo = ComboStub()
+    window._on_backend_row_changed(combo, None)
+
+    assert combo.reset_to == 0

--- a/tests/test_proxy_directives.py
+++ b/tests/test_proxy_directives.py
@@ -78,14 +78,50 @@ def test_terminal_widget_uses_prepared_proxy_command(monkeypatch):
 
     from sshpilot import terminal as terminal_mod
 
-    class DummyVte:
+    class DummyBackend:
         def __init__(self):
             self.last_cmd = None
+            self.widget = None
 
-        def spawn_async(self, *args):
-            self.last_cmd = list(args[2])
+        def spawn_async(
+            self,
+            argv,
+            env=None,
+            cwd=None,
+            flags=0,
+            child_setup=None,
+            callback=None,
+            user_data=None,
+        ):
+            self.last_cmd = list(argv)
+            if callback:
+                try:
+                    callback(self.widget or object(), 0, None, user_data)
+                except TypeError:
+                    callback(self.widget or object(), None)
+
+        def get_pty(self):
+            return object()
 
         def grab_focus(self):
+            pass
+
+        def connect_child_exited(self, *args, **kwargs):
+            return 0
+
+        def connect_title_changed(self, *args, **kwargs):
+            return 0
+
+        def connect_termprops_changed(self, *args, **kwargs):
+            return 0
+
+        def disconnect(self, handler_id):
+            pass
+
+        def apply_theme(self, *args, **kwargs):
+            pass
+
+        def initialize(self, *args, **kwargs):
             pass
 
     widget = terminal_mod.TerminalWidget.__new__(terminal_mod.TerminalWidget)
@@ -96,11 +132,13 @@ def test_terminal_widget_uses_prepared_proxy_command(monkeypatch):
         prepare_key_for_connection=lambda *a, **k: True,
         known_hosts_path="",
     )
-    widget.vte = DummyVte()
+    widget.backend = DummyBackend()
+    widget.vte = None
     widget.apply_theme = lambda *a, **k: None
     widget._show_forwarding_error_dialog = lambda *a, **k: None
     widget._set_connecting_overlay_visible = lambda *a, **k: None
     widget._set_disconnected_banner_visible = lambda *a, **k: None
+
     def _fail(*_args, **_kwargs):
         raise AssertionError("unexpected failure")
 
@@ -141,7 +179,7 @@ def test_terminal_widget_uses_prepared_proxy_command(monkeypatch):
 
     widget._setup_ssh_terminal()
 
-    cmd = widget.vte.last_cmd
+    cmd = widget.backend.last_cmd
     assert cmd is not None
     assert any(arg == "ProxyCommand=ssh -W %h:%p bastion" for arg in cmd)
     assert any(arg == "ProxyJump=b1,b2" for arg in cmd)
@@ -219,13 +257,23 @@ def test_terminal_manager_prepares_connection_before_spawn(monkeypatch):
             self.connection = connection
             self.config = config
             self.connection_manager = connection_manager
-            self.vte = types.SimpleNamespace(queue_draw=lambda: None)
+            self._backend_name = 'vte'
 
         def connect(self, *args, **kwargs):
             return 0
 
         def apply_theme(self):
             pass
+
+        def queue_draw_terminal(self):
+            pass
+
+        def ensure_backend(self, backend):
+            self._backend_name = backend
+            return False
+
+        def get_backend_name(self):
+            return self._backend_name
 
         def _connect_ssh(self):
             recorded_cmd["value"] = list(self.connection.ssh_cmd)


### PR DESCRIPTION
## Summary
- add a preferences combo for selecting the terminal backend and refresh existing tabs when the choice changes
- extend the terminal backend abstraction so runtime code and tests avoid direct VTE access, adding optional PyXterm.js wiring and docs
- declare the PyXterm.js extra dependency and update configuration helpers, docs, and tests to cover backend availability cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6797098188328a7f23de5c85b1a58