### PR TITLE
Fix pyxterm Socket.IO path

### DIFF
--- a/sshpilot/resources/pyxtermjs_clean.html
+++ b/sshpilot/resources/pyxtermjs_clean.html
@@ -118,7 +118,7 @@
       term.attachCustomKeyEventHandler(handleClipboardShortcuts);
       term.open(terminalContainer);
 
-      const socket = io({ path: "/pty" });
+      const socket = io("/pty", { path: "/socket.io" });
 
       socket.on("connect", () => {
         updateStatus("connected", "#34d399");


### PR DESCRIPTION
## Summary
- update the pyxterm template to connect to the /pty namespace while using the default Socket.IO path exposed by the server

## Testing
- Manual pyxtermjs smoke test (fails: CDN scripts blocked in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6e0ef80bc83289c0b560affcd5f4e