### PR TITLE
Adjust startup focus for terminal and welcome modes

### DIFF
--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -202,6 +202,22 @@ class TerminalManager:
 
             GLib.idle_add(terminal_widget.show)
             GLib.idle_add(terminal_widget.vte.show)
+
+            def _focus_local_terminal(attempt=[0]):
+                attempt[0] += 1
+                try:
+                    if hasattr(terminal_widget, 'get_mapped') and not terminal_widget.get_mapped():
+                        return attempt[0] < 20
+                    if hasattr(terminal_widget, 'vte') and hasattr(terminal_widget.vte, 'grab_focus'):
+                        terminal_widget.vte.grab_focus()
+                    elif hasattr(terminal_widget, 'grab_focus'):
+                        terminal_widget.grab_focus()
+                    return False
+                except Exception as focus_error:
+                    logger.debug(f"Failed to focus local terminal: {focus_error}")
+                    return False
+
+            GLib.timeout_add(100, _focus_local_terminal)
             logger.info("Local terminal tab created successfully")
         except Exception as e:
             logger.error(f"Failed to show local terminal: {e}")


### PR DESCRIPTION
## Summary
- respect the configured startup behavior when scheduling initial focus
- ensure the terminal startup path keeps focus on the created local terminal tab
- let the local terminal tab grab focus once it has been realized

## Testing
- not run (headless environment)


------
https://chatgpt.com/codex/tasks/task_e_68d798556d6c8328801aa6a11792e2d7