### PR TITLE
Add terminal pass-through mode toggle

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -20,6 +20,25 @@ logger = logging.getLogger(__name__)
 class WindowActions:
     """Mixin providing action handlers for :class:`MainWindow`."""
 
+    def _update_sidebar_accelerators(self):
+        """Apply sidebar accelerators respecting pass-through settings."""
+        app = None
+        try:
+            if hasattr(self, 'get_application'):
+                app = self.get_application()
+        except Exception:
+            app = None
+
+        if not app:
+            return
+
+        shortcuts = ['F9']
+        if is_macos():
+            shortcuts.append('<Meta>b')
+
+        enabled = getattr(app, 'accelerators_enabled', True)
+        app.set_accels_for_action('win.toggle_sidebar', shortcuts if enabled else [])
+
     def on_toggle_sidebar_action(self, action, param):
         """Handle sidebar toggle action (for keyboard shortcuts)"""
         try:
@@ -736,9 +755,6 @@ def register_window_actions(window):
         window.add_action(sidebar_action)
         app = window.get_application()
         if app:
-            shortcuts = ['F9']
-            if is_macos():
-                shortcuts.append('<Meta>b')
-            app.set_accels_for_action('win.toggle_sidebar', shortcuts)
+            window._update_sidebar_accelerators()
     except Exception as e:
         logger.error(f"Failed to register sidebar toggle action: {e}")

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -161,6 +161,7 @@ class Config(GObject.Object):
                 'scrollback_lines': 10000,
                 'cursor_blink': True,
                 'audible_bell': False,
+                'pass_through_mode': False,
             },
             'ui': {
                 'show_hostname': True,
@@ -677,6 +678,18 @@ class Config(GObject.Object):
         shortcuts = config.get('shortcuts')
         if not isinstance(shortcuts, dict):
             config['shortcuts'] = {}
+            updated = True
+
+        terminal_cfg = config.get('terminal')
+        if not isinstance(terminal_cfg, dict):
+            config['terminal'] = self.get_default_config().get('terminal', {}).copy()
+            terminal_cfg = config['terminal']
+            updated = True
+        if 'pass_through_mode' not in terminal_cfg:
+            terminal_cfg['pass_through_mode'] = False
+            updated = True
+        elif not isinstance(terminal_cfg['pass_through_mode'], bool):
+            terminal_cfg['pass_through_mode'] = bool(terminal_cfg['pass_through_mode'])
             updated = True
 
         file_manager_cfg = config.get('file_manager')

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -68,11 +68,24 @@ class SshPilotApplication(Adw.Application):
         self.config = None
         self._default_shortcuts = {}
         self._action_order = []
+        self._accelerators_enabled = True
+        self.accelerators_enabled = True
+        self._config_handler = None
 
         try:
             from .config import Config
             cfg = Config()
             self.config = cfg
+            try:
+                self._accelerators_enabled = not bool(cfg.get_setting('terminal.pass_through_mode', False))
+            except Exception:
+                self._accelerators_enabled = True
+            self.accelerators_enabled = self._accelerators_enabled
+            if hasattr(cfg, 'connect'):
+                try:
+                    self._config_handler = cfg.connect('setting-changed', self._on_config_setting_changed)
+                except Exception:
+                    self._config_handler = None
             saved_theme = str(cfg.get_setting('app-theme', 'default'))
             style_manager = Adw.StyleManager.get_default()
             if saved_theme == 'light':
@@ -213,6 +226,14 @@ class SshPilotApplication(Adw.Application):
     def on_shutdown(self, app):
         """Clean up all resources when application is shutting down"""
         logging.info("Application shutdown initiated, cleaning up...")
+        if self._config_handler is not None and self.config is not None:
+            try:
+                self.config.disconnect(self._config_handler)
+            except Exception:
+                pass
+            finally:
+                self._config_handler = None
+        self.accelerators_enabled = getattr(self, '_accelerators_enabled', True)
         from .terminal import process_manager
         process_manager.cleanup_all()
         logging.info("Cleanup completed")
@@ -278,6 +299,26 @@ class SshPilotApplication(Adw.Application):
         logging.getLogger('sshpilot').setLevel(app_level)
         logging.getLogger(__name__).setLevel(app_level)
 
+    def _on_config_setting_changed(self, _config, key, value):
+        if key != 'terminal.pass_through_mode':
+            return
+
+        self._accelerators_enabled = not bool(value)
+        self.accelerators_enabled = self._accelerators_enabled
+        self.apply_shortcut_overrides()
+
+        try:
+            windows = list(self.get_windows())
+        except Exception:
+            windows = []
+
+        for win in windows:
+            if hasattr(win, '_update_sidebar_accelerators'):
+                try:
+                    win._update_sidebar_accelerators()
+                except Exception:
+                    logging.debug("Failed to update window accelerators for pass-through toggle")
+
     def create_action(self, name, callback, shortcuts=None):
         """Create a GAction with optional keyboard shortcuts"""
         action = Gio.SimpleAction.new(name, None)
@@ -304,6 +345,13 @@ class SshPilotApplication(Adw.Application):
             source = 'override'
 
         action_name = f"app.{name}"
+        if not getattr(self, '_accelerators_enabled', True):
+            self.set_accels_for_action(action_name, [])
+            logging.debug(
+                "Skipping accelerators for action '%s' because terminal pass-through mode is active",
+                name,
+            )
+            return
         if effective is None:
             self.set_accels_for_action(action_name, [])
             logging.debug(f"Registered action '{name}' without shortcuts")

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -187,6 +187,13 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
     def _on_config_setting_changed(self, _config, key, value):
         """Synchronize runtime state when configuration values change."""
+        if key == 'terminal.pass_through_mode':
+            try:
+                self._update_sidebar_accelerators()
+            except Exception:
+                pass
+            return
+
         if key != 'ssh.native_connect':
             return
 

--- a/tests/test_terminal_pass_through.py
+++ b/tests/test_terminal_pass_through.py
@@ -1,0 +1,48 @@
+"""Regression tests for terminal pass-through shortcut handling."""
+
+import types
+
+from sshpilot import terminal as terminal_mod
+
+
+def test_pass_through_mode_allows_ctrl_shift_v(monkeypatch):
+    """When pass-through mode is enabled, custom controllers are removed so Ctrl+Shift+V reaches VTE."""
+
+    terminal_cls = terminal_mod.TerminalWidget
+    terminal = terminal_cls.__new__(terminal_cls)
+
+    removed_controllers = []
+
+    class DummyVte:
+        def remove_controller(self, controller):
+            removed_controllers.append(controller)
+
+    terminal.vte = DummyVte()
+    terminal._shortcut_controller = 'shortcut-controller'
+    terminal._scroll_controller = 'scroll-controller'
+    terminal._pass_through_mode = False
+
+    monkeypatch.setattr(terminal_mod, 'is_macos', lambda: False)
+    monkeypatch.setattr(terminal_cls, '_setup_mouse_wheel_zoom', lambda self: None, raising=False)
+
+    installs = []
+
+    def fake_install(self):
+        installs.append('install')
+        self._shortcut_controller = 'new-shortcut'
+
+    terminal._install_shortcuts = types.MethodType(fake_install, terminal)
+
+    terminal._apply_pass_through_mode(True)
+
+    assert removed_controllers == ['shortcut-controller', 'scroll-controller']
+    assert terminal._shortcut_controller is None
+    assert terminal._scroll_controller is None
+    assert terminal._pass_through_mode is True
+    assert installs == []
+
+    terminal._apply_pass_through_mode(False)
+
+    assert installs == ['install']
+    assert terminal._shortcut_controller == 'new-shortcut'
+    assert terminal._pass_through_mode is False


### PR DESCRIPTION
## Summary
- add a pass-through mode preference and persist it in the configuration defaults
- disable application and window accelerators plus terminal-local shortcut controllers when pass-through mode is active
- update the shortcut editor UI to reflect the disabled shortcuts state and add regression coverage for pass-through behavior

## Testing
- pytest tests/test_terminal_pass_through.py

------
https://chatgpt.com/codex/tasks/task_e_68d798cf11208328b23ffadcc14bb04e