### PR TITLE
Normalize TERM environment for embedded terminals

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -161,6 +161,7 @@ class Config(GObject.Object):
                 'scrollback_lines': 10000,
                 'cursor_blink': True,
                 'audible_bell': False,
+                'term': None,
             },
             'ui': {
                 'show_hostname': True,

--- a/tests/test_terminal_env.py
+++ b/tests/test_terminal_env.py
@@ -1,0 +1,40 @@
+import pytest
+
+from sshpilot import terminal as terminal_mod
+
+
+class DummyConfig:
+    def __init__(self, term=None):
+        self._term = term
+
+    def get_setting(self, key, default=None):
+        if key in {'terminal.term', 'terminal.term_override'}:
+            return self._term if self._term is not None else default
+        return default
+
+
+@pytest.fixture
+def widget():
+    term_widget = terminal_mod.TerminalWidget.__new__(terminal_mod.TerminalWidget)
+    term_widget.config = DummyConfig()
+    return term_widget
+
+
+def test_normalize_spawn_env_defaults_to_xterm256(widget):
+    env = {}
+    widget._normalize_spawn_env(env)
+    assert env['TERM'] == 'xterm-256color'
+
+
+def test_normalize_spawn_env_preserves_known_alias(widget):
+    env = {'TERM': 'xterm'}
+    widget._normalize_spawn_env(env)
+    assert env['TERM'] == 'xterm'
+
+
+def test_normalize_spawn_env_honors_user_override(monkeypatch):
+    term_widget = terminal_mod.TerminalWidget.__new__(terminal_mod.TerminalWidget)
+    term_widget.config = DummyConfig('ansi')
+    env = {'TERM': 'dumb'}
+    term_widget._normalize_spawn_env(env)
+    assert env['TERM'] == 'ansi'


### PR DESCRIPTION
## Summary
- normalize the TERM value used when spawning SSH sessions and fall back to xterm-256color when needed
- reuse the same TERM normalization for local shells while honoring a user-provided override setting
- add unit coverage to ensure TerminalWidget sanitizes TERM as expected

## Testing
- pytest tests/test_terminal_env.py

------
https://chatgpt.com/codex/tasks/task_e_68d79d21e1248328a53d6ffd02e59118