### PR TITLE
Restore terminal passthrough default with TERM placeholder

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -161,6 +161,7 @@ class Config(GObject.Object):
                 'scrollback_lines': 10000,
                 'cursor_blink': True,
                 'audible_bell': False,
+                'term': None,
                 'pass_through_mode': False,
             },
             'ui': {


### PR DESCRIPTION
## Summary
- add the TERM placeholder to the terminal defaults while preserving the passthrough flag

## Testing
- pytest *(fails: ImportError: cannot import name 'Vte' from 'gi.repository')*

------
https://chatgpt.com/codex/tasks/task_e_68d7a063796c832896b8185fb14ca8a9