### PR TITLE
Ensure terminal defaults preserve passthrough behavior

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -692,6 +692,19 @@ class Config(GObject.Object):
         elif not isinstance(terminal_cfg['pass_through_mode'], bool):
             terminal_cfg['pass_through_mode'] = bool(terminal_cfg['pass_through_mode'])
             updated = True
+        if 'term' not in terminal_cfg:
+            terminal_cfg['term'] = None
+            updated = True
+        else:
+            term_value = terminal_cfg['term']
+            normalized_term = None
+            if isinstance(term_value, str):
+                normalized_term = term_value.strip() or None
+            elif term_value is None:
+                normalized_term = None
+            if normalized_term != term_value:
+                terminal_cfg['term'] = normalized_term
+                updated = True
 
         file_manager_cfg = config.get('file_manager')
         if not isinstance(file_manager_cfg, dict):


### PR DESCRIPTION
## Summary
- keep the terminal defaults for both passthrough mode and TERM when generating configs
- normalize stored TERM values when upgrading existing configuration files

## Testing
- pytest *(fails: ImportError: cannot import name 'Vte' from 'gi.repository')*

------
https://chatgpt.com/codex/tasks/task_e_68d7b0644dbc832898c7fc32d8e99c30