### PR TITLE
Update pass-through mode help text

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -452,7 +452,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.pass_through_switch = Adw.SwitchRow()
             self.pass_through_switch.set_title("Terminal Shortcut Pass-through")
             self.pass_through_switch.set_subtitle(
-                "Use the terminal's native copy, paste, and zoom shortcuts"
+                "Disable all keyboard shortcuts, pass all key events directly to terminal"
             )
             try:
                 pass_through_active = bool(


### PR DESCRIPTION
## Summary
- update the terminal pass-through preference subtitle to clarify that all keyboard shortcuts are disabled and key events go directly to the terminal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ab525b788328be6ca5dfcbbb2c7b