### PR TITLE
Ensure terminal shortcuts consume GTK callbacks

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1615,7 +1615,7 @@ class TerminalWidget(Gtk.Box):
                     return False
 
                 GLib.idle_add(_runner)
-                return False
+                return True
 
             def _cb_copy(widget, *args):
                 if not self.vte.get_has_selection():


### PR DESCRIPTION
## Summary
- return True from the scheduled VTE shortcut helper so callbacks are consumed by Gtk

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8e7760c048328b2e4240d463efc3f