### PR TITLE
Add pass-through toggle and notice to shortcut editor

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -719,11 +719,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
                     owner_window=self.parent_window,
                 )
 
-                groups_added = 0
-                for group in self.shortcuts_editor_page.iter_groups():
-                    shortcuts_page.add(group)
-                    groups_added += 1
-                    logger.debug(f"Added shortcut group: {group.get_title()}")
+                groups_added = len(list(self.shortcuts_editor_page.iter_groups()))
+                editor_widget = self.shortcuts_editor_page.create_editor_widget()
+                shortcuts_page.add(editor_widget)
+                logger.debug(
+                    "Added shortcut editor widget with %d groups", groups_added
+                )
 
                 try:
                     self.shortcuts_editor_page.set_pass_through_enabled(


### PR DESCRIPTION
## Summary
- add a pass-through switch to the shortcut editor header that syncs with the stored preference
- introduce a shared notice banner and shortcuts container that grey out editing controls while pass-through is active
- embed the updated shortcuts editor layout in the preferences window and remove per-row subtitle mutations

## Testing
- python -m compileall sshpilot/sshpilot/shortcut_editor.py sshpilot/sshpilot/preferences.py

------
https://chatgpt.com/codex/tasks/task_e_68d94034a7e0832894d8c319ee9cd663