### PR TITLE
Ensure shortcut rows reflect pass-through state

### DIFF
--- a/sshpilot/shortcut_editor.py
+++ b/sshpilot/shortcut_editor.py
@@ -591,6 +591,10 @@ class ShortcutsPreferencesPage(PreferencesPageBase):
             return
 
         row = row_data['row']
+        try:
+            row.set_sensitive(not self._pass_through_enabled)
+        except Exception:
+            logger.debug('Failed to update sensitivity for row %s', action_name)
         base = row_data.get('base_subtitle', row.get_subtitle() or '')
         if row.get_subtitle() != base:
             row.set_subtitle(base)


### PR DESCRIPTION
## Summary
- update shortcut row sensitivity to mirror the pass-through mode state
- retain individual widget updates so controls stay in sync when pass-through changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc057fa7e883288932d72d0f75f8f3