### PR TITLE
Add configurable colors to connection groups

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -898,7 +898,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_update_group_orders(groups_list, parent_id)`** — Update the order field for groups at a given level
 
-- **`create_group(name, parent_id=None)`** — Create a new group and return its ID
+- **`create_group(name, parent_id=None, color=None)`** — Create a new group and return its ID
+- **`set_group_color(group_id, color)`** — Update a group's color and persist the change.
 
 - **`delete_group(group_id)`** — Delete a group and move its contents to parent or root
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -6011,7 +6011,50 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             entry.set_activates_default(True)
             entry.set_hexpand(True)
             content_area.append(entry)
-            
+
+            # Color selector
+            color_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+            color_row.set_hexpand(True)
+            color_label = Gtk.Label(label=_("Group color"))
+            color_label.set_xalign(0)
+            color_label.set_hexpand(True)
+            color_row.append(color_label)
+
+            color_controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            color_button = Gtk.ColorButton()
+            color_button.set_use_alpha(True)
+            color_button.set_title(_("Select group color"))
+            rgba = Gdk.RGBA()
+            rgba.red = rgba.green = rgba.blue = 0
+            rgba.alpha = 0
+            color_button.set_rgba(rgba)
+            color_controls.append(color_button)
+
+            color_selected = False
+
+            def on_color_set(_button):
+                nonlocal color_selected
+                color_selected = True
+
+            color_button.connect('color-set', on_color_set)
+
+            clear_color_button = Gtk.Button(label=_("Clear"))
+            clear_color_button.add_css_class('flat')
+
+            def on_clear_color(_button):
+                nonlocal color_selected
+                color_selected = False
+                cleared = Gdk.RGBA()
+                cleared.red = cleared.green = cleared.blue = 0
+                cleared.alpha = 0
+                color_button.set_rgba(cleared)
+
+            clear_color_button.connect('clicked', on_clear_color)
+            color_controls.append(clear_color_button)
+
+            color_row.append(color_controls)
+            content_area.append(color_row)
+
             # Add buttons
             dialog.add_button(_('Cancel'), Gtk.ResponseType.CANCEL)
             create_button = dialog.add_button(_('Create'), Gtk.ResponseType.OK)
@@ -6023,7 +6066,11 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 if response == Gtk.ResponseType.OK:
                     group_name = entry.get_text().strip()
                     if group_name:
-                        self.group_manager.create_group(group_name)
+                        selected_color = None
+                        rgba_value = color_button.get_rgba()
+                        if color_selected and rgba_value.alpha > 0:
+                            selected_color = rgba_value.to_string()
+                        self.group_manager.create_group(group_name, color=selected_color)
                         self.rebuild_connection_list()
                     else:
                         # Show error for empty name
@@ -6102,7 +6149,66 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             entry.set_activates_default(True)
             entry.set_hexpand(True)
             content_area.append(entry)
-            
+
+            # Color selector
+            color_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+            color_row.set_hexpand(True)
+            color_label = Gtk.Label(label=_("Group color"))
+            color_label.set_xalign(0)
+            color_label.set_hexpand(True)
+            color_row.append(color_label)
+
+            color_controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            color_button = Gtk.ColorButton()
+            color_button.set_use_alpha(True)
+            color_button.set_title(_("Select group color"))
+
+            color_selected = False
+            rgba = Gdk.RGBA()
+            existing_color = group_info.get('color')
+            if existing_color:
+                try:
+                    if rgba.parse(existing_color):
+                        color_button.set_rgba(rgba)
+                        color_selected = True
+                    else:
+                        rgba.red = rgba.green = rgba.blue = 0
+                        rgba.alpha = 0
+                        color_button.set_rgba(rgba)
+                except Exception:
+                    rgba.red = rgba.green = rgba.blue = 0
+                    rgba.alpha = 0
+                    color_button.set_rgba(rgba)
+                    color_selected = False
+            else:
+                rgba.red = rgba.green = rgba.blue = 0
+                rgba.alpha = 0
+                color_button.set_rgba(rgba)
+
+            def on_color_set(_button):
+                nonlocal color_selected
+                color_selected = True
+
+            color_button.connect('color-set', on_color_set)
+            color_controls.append(color_button)
+
+            clear_color_button = Gtk.Button(label=_("Clear"))
+            clear_color_button.add_css_class('flat')
+
+            def on_clear_color(_button):
+                nonlocal color_selected
+                color_selected = False
+                cleared = Gdk.RGBA()
+                cleared.red = cleared.green = cleared.blue = 0
+                cleared.alpha = 0
+                color_button.set_rgba(cleared)
+
+            clear_color_button.connect('clicked', on_clear_color)
+            color_controls.append(clear_color_button)
+
+            color_row.append(color_controls)
+            content_area.append(color_row)
+
             # Add buttons
             dialog.add_button(_('Cancel'), Gtk.ResponseType.CANCEL)
             save_button = dialog.add_button(_('Save'), Gtk.ResponseType.OK)
@@ -6115,7 +6221,11 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     new_name = entry.get_text().strip()
                     if new_name:
                         group_info['name'] = new_name
-                        self.group_manager._save_groups()
+                        rgba_value = color_button.get_rgba()
+                        selected_color = None
+                        if color_selected and rgba_value.alpha > 0:
+                            selected_color = rgba_value.to_string()
+                        self.group_manager.set_group_color(group_id, selected_color)
                         self.rebuild_connection_list()
                     else:
                         # Show error for empty name

--- a/tests/test_group_connection_rename.py
+++ b/tests/test_group_connection_rename.py
@@ -59,3 +59,44 @@ def test_rename_connection_cleans_stale_root_entries():
     assert gm2.root_connections == []
     assert gm2.groups[gid]['connections'] == ["new"]
 
+
+def test_group_color_defaults_and_updates():
+    cfg = DummyConfig()
+    gm = GroupManager(cfg)
+
+    gid = gm.create_group("Colorful", color="#ff0000ff")
+    assert gm.groups[gid]['color'] == "#ff0000ff"
+
+    gm.set_group_color(gid, None)
+    assert gm.groups[gid]['color'] is None
+
+    gm.set_group_color(gid, "#123456ff")
+    hierarchy = gm.get_group_hierarchy()
+    assert hierarchy[0]['color'] == "#123456ff"
+
+    all_groups = gm.get_all_groups()
+    assert any(group['color'] == "#123456ff" for group in all_groups)
+
+
+def test_load_groups_backfills_missing_color():
+    legacy_group_id = "legacy"
+    cfg = DummyConfig()
+    cfg.set_setting('connection_groups', {
+        'groups': {
+            legacy_group_id: {
+                'id': legacy_group_id,
+                'name': 'Legacy',
+                'parent_id': None,
+                'children': [],
+                'connections': [],
+                'expanded': True,
+                'order': 0,
+            }
+        },
+        'connections': {},
+        'root_connections': [],
+    })
+
+    gm = GroupManager(cfg)
+    assert gm.groups[legacy_group_id]['color'] is None
+


### PR DESCRIPTION
## Summary
- add color metadata to saved connection groups and migrate legacy configs
- expose a setter so group colors can be updated persistently
- surface a color picker in the create/edit group dialogs and document the API change
- extend tests to cover color defaults, updates, and migration handling

## Testing
- pytest *(fails: ImportError: cannot import name 'Vte' from 'gi.repository')*


------
https://chatgpt.com/codex/tasks/task_e_68dd19cdee748328b5ae747e22ee5c39