### PR TITLE
Add preference for group color display and update sidebar rendering

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -172,6 +172,7 @@ class Config(GObject.Object):
                 'window_width': 1200,
                 'window_height': 800,
                 'sidebar_width': 250,
+                'group_color_display': 'fill',
             },
             'welcome': {
                 'background_color': None,  # None for default, or CSS string for custom
@@ -719,6 +720,26 @@ class Config(GObject.Object):
                 updated = True
             if 'open_externally' not in file_manager_cfg:
                 file_manager_cfg['open_externally'] = False
+                updated = True
+
+        ui_cfg = config.get('ui')
+        if not isinstance(ui_cfg, dict):
+            default_ui = self.get_default_config().get('ui', {}).copy()
+            config['ui'] = default_ui
+            ui_cfg = default_ui
+            updated = True
+        display_value = ui_cfg.get('group_color_display') if isinstance(ui_cfg, dict) else None
+        if display_value is None:
+            ui_cfg['group_color_display'] = 'fill'
+            updated = True
+        else:
+            if not isinstance(display_value, str):
+                display_value = str(display_value)
+            normalized = display_value.lower()
+            if normalized not in {'fill', 'badge'}:
+                normalized = 'fill'
+            if ui_cfg.get('group_color_display') != normalized:
+                ui_cfg['group_color_display'] = normalized
                 updated = True
 
         ssh_cfg = config.get('ssh')

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -2358,7 +2358,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
     
     def add_connection_row(self, connection: Connection, indent_level: int = 0):
         """Add a connection row to the list with optional indentation"""
-        row = ConnectionRow(connection)
+        row = ConnectionRow(connection, self.group_manager, self.config)
         
         # Apply indentation for grouped connections
         if indent_level > 0:
@@ -5252,6 +5252,17 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             for terms in self.connection_to_terminals.values():
                 for terminal in terms:
                     terminal.apply_theme()
+            return
+
+        if key == 'ui.group_color_display':
+            try:
+                self.rebuild_connection_list()
+            except Exception as exc:
+                logger.debug(
+                    "Failed to rebuild connection list for color display change: %s",
+                    exc,
+                )
+            return
 
     def on_window_size_changed(self, window, param):
         """Handle window size change"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,11 @@ if 'gi' not in sys.modules:
     # Provide concrete stubs for modules referenced in tests
     gobject_module = _DummyGIModule('gi.repository.GObject')
     setattr(gobject_module, 'Object', _make_dummy_gi_type('Object'))
-    setattr(gobject_module, 'SignalFlags', types.SimpleNamespace(RUN_FIRST=None))
+    setattr(
+        gobject_module,
+        'SignalFlags',
+        types.SimpleNamespace(RUN_FIRST=None, RUN_LAST=None),
+    )
     setattr(repository, 'GObject', gobject_module)
     sys.modules['gi.repository.GObject'] = gobject_module
 

--- a/tests/test_window_search_groups.py
+++ b/tests/test_window_search_groups.py
@@ -61,6 +61,11 @@ class DummyConnectionManager:
         return list(self._connections)
 
 
+class DummyConfig:
+    def get_setting(self, key, default=None):
+        return default
+
+
 class DummyGroupManager:
     def __init__(self, groups):
         self.groups = groups
@@ -89,12 +94,12 @@ class StubGroupRow(DummyRowBase):
 
 
 class StubConnectionRow(DummyRowBase):
-    def __init__(self, connection):
+    def __init__(self, connection, group_manager=None, config=None):
         super().__init__()
         self.connection = connection
         self.indentation = 0
         self.hide_hosts = None
-
+        
     def set_indentation(self, level):
         self.indentation = level
 
@@ -153,6 +158,7 @@ def test_search_results_include_matching_groups(monkeypatch):
     test_window.connection_scrolled = None
     test_window.connection_manager = DummyConnectionManager([grouped_connection, direct_connection])
     test_window.group_manager = DummyGroupManager(group_data)
+    test_window.config = DummyConfig()
     test_window.search_entry = DummySearchEntry("prod")
     test_window._hide_hosts = False
 


### PR DESCRIPTION
## Summary
- add a `ui.group_color_display` default and backfill logic for existing configs
- expose a sidebar color display preference in the Interface section and react to changes
- teach sidebar group and connection rows to honour the selected display mode when rendering colors

## Testing
- pytest tests/test_window_search_groups.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1c3892888328bdb64055f80871cf