### PR TITLE
Add group color preferences for tabs and terminals

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -173,6 +173,8 @@ class Config(GObject.Object):
                 'window_height': 800,
                 'sidebar_width': 250,
                 'group_color_display': 'fill',
+                'use_group_color_in_tab': False,
+                'use_group_color_in_terminal': False,
             },
             'welcome': {
                 'background_color': None,  # None for default, or CSS string for custom
@@ -741,6 +743,20 @@ class Config(GObject.Object):
             if ui_cfg.get('group_color_display') != normalized:
                 ui_cfg['group_color_display'] = normalized
                 updated = True
+
+        if 'use_group_color_in_tab' not in ui_cfg:
+            ui_cfg['use_group_color_in_tab'] = False
+            updated = True
+        elif not isinstance(ui_cfg['use_group_color_in_tab'], bool):
+            ui_cfg['use_group_color_in_tab'] = bool(ui_cfg['use_group_color_in_tab'])
+            updated = True
+
+        if 'use_group_color_in_terminal' not in ui_cfg:
+            ui_cfg['use_group_color_in_terminal'] = False
+            updated = True
+        elif not isinstance(ui_cfg['use_group_color_in_terminal'], bool):
+            ui_cfg['use_group_color_in_terminal'] = bool(ui_cfg['use_group_color_in_terminal'])
+            updated = True
 
         ssh_cfg = config.get('ssh')
         if not isinstance(ssh_cfg, dict):

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -5264,6 +5264,15 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 )
             return
 
+        if key in {'ui.use_group_color_in_tab', 'ui.use_group_color_in_terminal', 'connection_groups'}:
+            manager = getattr(self, 'terminal_manager', None)
+            if manager is not None:
+                try:
+                    manager.restyle_open_terminals()
+                except Exception as exc:
+                    logger.debug("Failed to restyle terminals after preference change: %s", exc)
+            return
+
     def on_window_size_changed(self, window, param):
         """Handle window size change"""
         width = self.get_default_size()[0]


### PR DESCRIPTION
## Summary
- add configuration defaults and preference toggles for tinting tabs and terminals with group colors
- resolve each connection's group color when opening terminals to decorate the tab indicator and refresh open pages when settings change
- allow TerminalWidget to receive group colors and blend them into the terminal theme when the preference is enabled

## Testing
- pytest *(fails: GI Vte bindings are unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd27259cac8328916329946e955303