### PR TITLE
Add group color preferences for terminal tabs and sessions

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -173,6 +173,8 @@ class Config(GObject.Object):
                 'window_height': 800,
                 'sidebar_width': 250,
                 'group_color_display': 'fill',
+                'use_group_color_in_tab': False,
+                'use_group_color_in_terminal': False,
             },
             'welcome': {
                 'background_color': None,  # None for default, or CSS string for custom
@@ -741,6 +743,20 @@ class Config(GObject.Object):
             if ui_cfg.get('group_color_display') != normalized:
                 ui_cfg['group_color_display'] = normalized
                 updated = True
+
+        if 'use_group_color_in_tab' not in ui_cfg:
+            ui_cfg['use_group_color_in_tab'] = False
+            updated = True
+        elif not isinstance(ui_cfg['use_group_color_in_tab'], bool):
+            ui_cfg['use_group_color_in_tab'] = bool(ui_cfg['use_group_color_in_tab'])
+            updated = True
+
+        if 'use_group_color_in_terminal' not in ui_cfg:
+            ui_cfg['use_group_color_in_terminal'] = False
+            updated = True
+        elif not isinstance(ui_cfg['use_group_color_in_terminal'], bool):
+            ui_cfg['use_group_color_in_terminal'] = bool(ui_cfg['use_group_color_in_terminal'])
+            updated = True
 
         ssh_cfg = config.get('ssh')
         if not isinstance(ssh_cfg, dict):

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -342,6 +342,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self._shortcuts_row = None
         self._shortcuts_button = None
         self._group_display_sync = False
+        self._tab_color_sync = False
+        self._terminal_color_sync = False
         self._config_signal_id = None
 
         if hasattr(self.config, 'connect'):
@@ -658,6 +660,42 @@ class PreferencesWindow(Adw.PreferencesWindow):
             )
 
             interface_appearance_group.add(self.group_color_display_row)
+
+            # Toggle for coloring tabs using group colors
+            self.tab_group_color_row = Adw.SwitchRow()
+            self.tab_group_color_row.set_title("Color Tabs by Group")
+            self.tab_group_color_row.set_subtitle(
+                "Tint terminal tabs using the selected group's color"
+            )
+            try:
+                tab_pref = bool(
+                    self.config.get_setting('ui.use_group_color_in_tab', False)
+                )
+            except Exception:
+                tab_pref = False
+            self.tab_group_color_row.set_active(tab_pref)
+            self.tab_group_color_row.connect(
+                'notify::active', self.on_use_group_color_in_tab_toggled
+            )
+            interface_appearance_group.add(self.tab_group_color_row)
+
+            # Toggle for applying group colors inside terminals
+            self.terminal_group_color_row = Adw.SwitchRow()
+            self.terminal_group_color_row.set_title("Color Terminals by Group")
+            self.terminal_group_color_row.set_subtitle(
+                "Adjust terminal background and highlights using group colors"
+            )
+            try:
+                terminal_pref = bool(
+                    self.config.get_setting('ui.use_group_color_in_terminal', False)
+                )
+            except Exception:
+                terminal_pref = False
+            self.terminal_group_color_row.set_active(terminal_pref)
+            self.terminal_group_color_row.connect(
+                'notify::active', self.on_use_group_color_in_terminal_toggled
+            )
+            interface_appearance_group.add(self.terminal_group_color_row)
 
             # Color overrides section
             color_override_group = Adw.PreferencesGroup()
@@ -1236,6 +1274,64 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if not getattr(self, '_config_signal_id', None):
             self._trigger_sidebar_refresh()
 
+    def on_use_group_color_in_tab_toggled(self, switch_row, _param):
+        if getattr(self, '_tab_color_sync', False):
+            return
+
+        new_value = bool(switch_row.get_active())
+
+        try:
+            current_value = bool(
+                self.config.get_setting('ui.use_group_color_in_tab', False)
+            )
+        except Exception:
+            current_value = False
+
+        if new_value == current_value:
+            self._trigger_terminal_style_refresh()
+            return
+
+        try:
+            self.config.set_setting('ui.use_group_color_in_tab', new_value)
+        except Exception as exc:
+            logger.error(
+                "Failed to update tab group color preference: %s", exc,
+            )
+            self._sync_use_group_color_in_tab(current_value)
+            return
+
+        if not getattr(self, '_config_signal_id', None):
+            self._trigger_terminal_style_refresh()
+
+    def on_use_group_color_in_terminal_toggled(self, switch_row, _param):
+        if getattr(self, '_terminal_color_sync', False):
+            return
+
+        new_value = bool(switch_row.get_active())
+
+        try:
+            current_value = bool(
+                self.config.get_setting('ui.use_group_color_in_terminal', False)
+            )
+        except Exception:
+            current_value = False
+
+        if new_value == current_value:
+            self._trigger_terminal_style_refresh()
+            return
+
+        try:
+            self.config.set_setting('ui.use_group_color_in_terminal', new_value)
+        except Exception as exc:
+            logger.error(
+                "Failed to update terminal group color preference: %s", exc,
+            )
+            self._sync_use_group_color_in_terminal(current_value)
+            return
+
+        if not getattr(self, '_config_signal_id', None):
+            self._trigger_terminal_style_refresh()
+
     def _trigger_sidebar_refresh(self):
         parent = self.get_transient_for() or self.parent_window
         if not parent:
@@ -1246,6 +1342,22 @@ class PreferencesWindow(Adw.PreferencesWindow):
                 parent.rebuild_connection_list()
             except Exception as exc:
                 logger.debug("Failed to rebuild connection list after preference change: %s", exc)
+
+    def _trigger_terminal_style_refresh(self):
+        parent = self.get_transient_for() or self.parent_window
+        if not parent:
+            return
+
+        manager = getattr(parent, 'terminal_manager', None)
+        if not manager or not hasattr(manager, 'restyle_open_terminals'):
+            return
+
+        try:
+            manager.restyle_open_terminals()
+        except Exception as exc:
+            logger.debug(
+                "Failed to restyle terminals after preference change: %s", exc
+            )
 
     def _sync_group_color_display_row(self, value):
         if not hasattr(self, 'group_color_display_row') or self.group_color_display_row is None:
@@ -1273,6 +1385,40 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if key == 'ui.group_color_display':
             self._sync_group_color_display_row(value)
             self._trigger_sidebar_refresh()
+        elif key == 'ui.use_group_color_in_tab':
+            self._sync_use_group_color_in_tab(value)
+            self._trigger_terminal_style_refresh()
+        elif key == 'ui.use_group_color_in_terminal':
+            self._sync_use_group_color_in_terminal(value)
+            self._trigger_terminal_style_refresh()
+
+    def _sync_use_group_color_in_tab(self, value):
+        if not hasattr(self, 'tab_group_color_row') or self.tab_group_color_row is None:
+            return
+
+        target_state = bool(value)
+        if self.tab_group_color_row.get_active() == target_state:
+            return
+
+        self._tab_color_sync = True
+        try:
+            self.tab_group_color_row.set_active(target_state)
+        finally:
+            self._tab_color_sync = False
+
+    def _sync_use_group_color_in_terminal(self, value):
+        if not hasattr(self, 'terminal_group_color_row') or self.terminal_group_color_row is None:
+            return
+
+        target_state = bool(value)
+        if self.terminal_group_color_row.get_active() == target_state:
+            return
+
+        self._terminal_color_sync = True
+        try:
+            self.terminal_group_color_row.set_active(target_state)
+        finally:
+            self._terminal_color_sync = False
 
     def _on_destroy(self, *_args):
         if getattr(self, '_config_signal_id', None) and hasattr(self.config, 'disconnect'):

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -18,6 +18,7 @@ import weakref
 import subprocess
 import pwd
 from datetime import datetime
+from typing import Optional
 from .port_utils import get_port_checker
 from .platform_utils import is_macos
 
@@ -201,15 +202,16 @@ class TerminalWidget(Gtk.Box):
         'title-changed': (GObject.SignalFlags.RUN_FIRST, None, (str,)),
     }
     
-    def __init__(self, connection, config, connection_manager):
+    def __init__(self, connection, config, connection_manager, group_color=None):
         # Initialize as a vertical Gtk.Box
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
-        
+
         # Store references
         self.connection = connection
         self.config = config
         self.connection_manager = connection_manager
-        
+        self.group_color = group_color
+
         # Process tracking
         self.process = None
         self.process_pid = None
@@ -1235,7 +1237,7 @@ class TerminalWidget(Gtk.Box):
         
     def apply_theme(self, theme_name=None):
         """Apply terminal theme and font settings
-        
+
         Args:
             theme_name (str, optional): Name of the theme to apply. If None, uses the saved theme.
         """
@@ -1267,19 +1269,35 @@ class TerminalWidget(Gtk.Box):
             # Set colors
             fg_color = Gdk.RGBA()
             fg_color.parse(profile['foreground'])
-            
+
             bg_color = Gdk.RGBA()
             bg_color.parse(profile['background'])
-            
+
             cursor_color = Gdk.RGBA()
             cursor_color.parse(profile.get('cursor_color', profile['foreground']))
-            
+
             highlight_bg = Gdk.RGBA()
             highlight_bg.parse(profile.get('highlight_background', '#4A90E2'))
-            
+
             highlight_fg = Gdk.RGBA()
             highlight_fg.parse(profile.get('highlight_foreground', profile['foreground']))
-            
+
+            override_rgba = self._get_group_color_rgba()
+            use_group_color = False
+            try:
+                use_group_color = bool(
+                    self.config.get_setting('ui.use_group_color_in_terminal', False)
+                )
+            except Exception:
+                use_group_color = False
+
+            if use_group_color and override_rgba is not None:
+                bg_color = self._mix_with_white(override_rgba, 0.35)
+                fg_color = self._get_contrast_color(bg_color)
+                highlight_bg = self._clone_rgba(override_rgba)
+                highlight_fg = self._get_contrast_color(highlight_bg)
+                cursor_color = self._clone_rgba(highlight_fg)
+
             # Prepare palette colors (16 ANSI colors)
             palette_colors = None
             if 'palette' in profile and profile['palette']:
@@ -1338,6 +1356,69 @@ class TerminalWidget(Gtk.Box):
             
         except Exception as e:
             logger.error(f"Failed to apply terminal theme: {e}")
+
+    def _clone_rgba(self, rgba: Gdk.RGBA) -> Gdk.RGBA:
+        clone = Gdk.RGBA()
+        clone.red = rgba.red
+        clone.green = rgba.green
+        clone.blue = rgba.blue
+        clone.alpha = rgba.alpha
+        return clone
+
+    def _get_group_color_rgba(self) -> Optional[Gdk.RGBA]:
+        color_value = getattr(self, 'group_color', None)
+        if not color_value:
+            return None
+
+        rgba = Gdk.RGBA()
+        try:
+            if rgba.parse(str(color_value)):
+                rgba.alpha = 1.0 if rgba.alpha == 0 else rgba.alpha
+                return rgba
+        except Exception:
+            logger.debug("Failed to parse group color '%s'", color_value, exc_info=True)
+        return None
+
+    def _mix_with_white(self, rgba: Gdk.RGBA, ratio: float = 0.35) -> Gdk.RGBA:
+        ratio = max(0.0, min(1.0, ratio))
+        mixed = Gdk.RGBA()
+        mixed.red = min(1.0, rgba.red * ratio + (1 - ratio))
+        mixed.green = min(1.0, rgba.green * ratio + (1 - ratio))
+        mixed.blue = min(1.0, rgba.blue * ratio + (1 - ratio))
+        mixed.alpha = 1.0
+        return mixed
+
+    def _relative_luminance(self, rgba: Gdk.RGBA) -> float:
+        def to_linear(channel: float) -> float:
+            if channel <= 0.03928:
+                return channel / 12.92
+            return ((channel + 0.055) / 1.055) ** 2.4
+
+        r_lin = to_linear(rgba.red)
+        g_lin = to_linear(rgba.green)
+        b_lin = to_linear(rgba.blue)
+        return 0.2126 * r_lin + 0.7152 * g_lin + 0.0722 * b_lin
+
+    def _get_contrast_color(self, background: Gdk.RGBA) -> Gdk.RGBA:
+        luminance = self._relative_luminance(background)
+        contrast = Gdk.RGBA()
+        if luminance > 0.5:
+            contrast.parse('#1B1B1D')
+        else:
+            contrast.parse('#FFFFFF')
+        contrast.alpha = 1.0
+        return contrast
+
+    def set_group_color(self, color_value, force: bool = False):
+        normalized = color_value or None
+        if not force and normalized == getattr(self, 'group_color', None):
+            return
+
+        self.group_color = normalized
+        try:
+            self.apply_theme()
+        except Exception:
+            logger.debug("Failed to reapply theme after group color update", exc_info=True)
             
     def force_style_refresh(self):
         """Force a style refresh of the terminal widget."""

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -2321,6 +2321,15 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             vadj = self.connection_scrolled.get_vadjustment()
             if vadj:
                 GLib.idle_add(lambda: vadj.set_value(scroll_position))
+
+        if hasattr(self, 'terminal_manager'):
+            try:
+                self.terminal_manager.restyle_open_terminals()
+            except Exception as exc:
+                logger.debug(
+                    "Failed to restyle terminals after rebuilding connection list: %s",
+                    exc,
+                )
     def _build_grouped_list(self, hierarchy, connections_dict, level):
         """Recursively build the grouped connection list"""
         for group_info in hierarchy:
@@ -5262,6 +5271,25 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     "Failed to rebuild connection list for color display change: %s",
                     exc,
                 )
+            if hasattr(self, 'terminal_manager'):
+                try:
+                    self.terminal_manager.restyle_open_terminals()
+                except Exception as refresh_error:
+                    logger.debug(
+                        "Failed to restyle terminals after color display change: %s",
+                        refresh_error,
+                    )
+            return
+
+        if key in {'ui.use_group_color_in_tab', 'ui.use_group_color_in_terminal'}:
+            if hasattr(self, 'terminal_manager'):
+                try:
+                    self.terminal_manager.restyle_open_terminals()
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to restyle terminals after preference update: %s",
+                        exc,
+                    )
             return
 
     def on_window_size_changed(self, window, param):


### PR DESCRIPTION
## Summary
- add new UI preferences to control whether group colors tint tabs and terminal sessions
- resolve group colors when opening terminals and apply indicators/backgrounds based on the new settings
- restyle open pages when preferences or group assignments change so existing sessions stay consistent

## Testing
- pytest *(fails: missing gi.repository.Vte in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd24353d0083288e44b595ab7123bf