### PR TITLE
Fix TerminalManager else indentation

### DIFF
--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -51,9 +51,9 @@ class TerminalManager:
         if use_external and not should_hide_external_terminal_options():
             window._open_connection_in_external_terminal(connection)
             return
-        group_color = self._resolve_group_color(connection)
-
         else:
+            group_color = self._resolve_group_color(connection)
+
             terminal = TerminalWidget(
                 connection,
                 window.config,


### PR DESCRIPTION
## Summary
- move group color resolution inside the else branch for the external terminal check to restore valid syntax

## Testing
- python3 -m compileall sshpilot/terminal_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2df1ad888328b374cc66b6960591