### PR TITLE
Adjust drag source exclusivity

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -315,6 +315,8 @@ class GroupRow(Adw.ActionRow):
     def _setup_drag_source(self):
         drag_source = Gtk.DragSource()
         drag_source.set_actions(Gdk.DragAction.MOVE)
+        drag_source.set_exclusive(False)
+        drag_source.set_button(getattr(Gdk, "BUTTON_PRIMARY", 1))
         drag_source.connect("prepare", self._on_drag_prepare)
         drag_source.connect("drag-begin", self._on_drag_begin)
         drag_source.connect("drag-end", self._on_drag_end)
@@ -539,6 +541,8 @@ class ConnectionRow(Adw.ActionRow):
     def _setup_drag_source(self):
         drag_source = Gtk.DragSource()
         drag_source.set_actions(Gdk.DragAction.MOVE)
+        drag_source.set_exclusive(False)
+        drag_source.set_button(getattr(Gdk, "BUTTON_PRIMARY", 1))
         drag_source.connect("prepare", self._on_drag_prepare)
         drag_source.connect("drag-begin", self._on_drag_begin)
         drag_source.connect("drag-end", self._on_drag_end)


### PR DESCRIPTION
## Summary
- allow sidebar group and connection drag sources to remain non-exclusive so clicks still activate rows
- restrict drag initiation to the primary pointer button while retaining move actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6e7a964c8328a1923bf25fb8ce75