### PR TITLE
Scope sidebar fill CSS to non-selected rows

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -159,7 +159,12 @@ def _set_css_background(provider: Gtk.CssProvider, rgba: Optional[Gdk.RGBA]):
             color_value = 'transparent'
 
     try:
-        css_data = f"* {{ background-color: {color_value}; }}"
+        css_data = "\n".join(
+            [
+                f"*:not(:selected):not(:checked) {{ background-color: {color_value}; }}",
+                "*:selected, *:checked { background-color: transparent; }",
+            ]
+        )
         provider.load_from_data(css_data.encode('utf-8'))
         logger.debug(f"Applied CSS background: {css_data}")
     except Exception:


### PR DESCRIPTION
## Summary
- scope the sidebar fill color CSS so it only applies when rows are not selected or checked
- keep the transparent reset behaviour for rows without a configured color while allowing selected highlights to show

## Testing
- not run (manual UI verification required)

------
https://chatgpt.com/codex/tasks/task_e_68dd7643684c8328a2fecbf92de492d5