### PR TITLE
Restore custom sidebar styling

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -215,7 +215,7 @@ class GroupRow(Adw.ActionRow):
 
     def __init__(self, group_info: Dict, group_manager: GroupManager, connections_dict: Dict | None = None):
         super().__init__()
-        self.add_css_class("navigation-sidebar")
+        self.add_css_class("sshpilot-sidebar")
         self.group_info = group_info
         self.group_manager = group_manager
         self.group_id = group_info["id"]
@@ -460,7 +460,7 @@ class ConnectionRow(Adw.ActionRow):
 
     def __init__(self, connection: Connection, group_manager: GroupManager, config):
         super().__init__()
-        self.add_css_class("navigation-sidebar")
+        self.add_css_class("sshpilot-sidebar")
         self.connection = connection
         self.group_manager = group_manager
         self.config = config

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -359,12 +359,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
               opacity: 1;
             }
             
-            /* Smooth transitions for connection rows during drag */
-            .navigation-sidebar {
+            /* Smooth transitions and comfortable spacing for sidebar rows */
+            row.sshpilot-sidebar {
+              padding: 6px 12px;
+              min-height: 36px;
               transition: transform 0.1s ease-out, opacity 0.1s ease-out;
             }
-            
-            .navigation-sidebar.dragging {
+
+            row.sshpilot-sidebar.dragging {
               opacity: 0.7;
               transform: scale(0.98);
             }
@@ -1285,7 +1287,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         self.connection_scrolled.set_vexpand(True)
         
         self.connection_list = Gtk.ListBox()
-        self.connection_list.add_css_class("navigation-sidebar")
+        self.connection_list.add_css_class("sshpilot-sidebar")
         self.connection_list.set_selection_mode(Gtk.SelectionMode.MULTIPLE)
         try:
             self.connection_list.set_can_focus(True)


### PR DESCRIPTION
## Summary
- replace the generic navigation-sidebar class with a project-specific sshpilot-sidebar on the sidebar list and rows
- refresh the sidebar CSS to target the new class while restoring comfortable row padding and drag animations

## Testing
- python3 -m compileall sshpilot

------
https://chatgpt.com/codex/tasks/task_e_68dd7a989528832883c8a2af16b91779