### PR TITLE
Restore sidebar icon spacing in sidebar rows

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -228,6 +228,7 @@ class GroupRow(Adw.ActionRow):
         # Add folder icon as prefix
         icon = Gtk.Image.new_from_icon_name("folder-symbolic")
         icon.set_icon_size(Gtk.IconSize.NORMAL)
+        icon.set_margin_end(8)
         self.add_prefix(icon)
 
         # Add expand button as suffix
@@ -472,6 +473,7 @@ class ConnectionRow(Adw.ActionRow):
         # Add computer icon as prefix
         icon = Gtk.Image.new_from_icon_name("computer-symbolic")
         icon.set_icon_size(Gtk.IconSize.NORMAL)
+        icon.set_margin_end(8)
         self.add_prefix(icon)
 
         # Add status icon as suffix

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -366,6 +366,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
               transition: transform 0.1s ease-out, opacity 0.1s ease-out;
             }
 
+            row.sshpilot-sidebar .prefixes {
+              margin-right: 10px;
+            }
+
+            row.sshpilot-sidebar .suffixes {
+              margin-left: 10px;
+            }
+
             row.sshpilot-sidebar.dragging {
               opacity: 0.7;
               transform: scale(0.98);


### PR DESCRIPTION
## Summary
- add CSS margins for sshpilot sidebar rows so prefixes and suffixes retain navigation sidebar spacing
- set explicit end margins on sidebar prefix icons to guarantee consistent gaps

## Testing
- python3 -m compileall sshpilot

------
https://chatgpt.com/codex/tasks/task_e_68dd7f7fac0c8328b2cb1af9cf82e99c