### PR TITLE
Move hidden file toggle into pane toolbar

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1896,6 +1896,7 @@ class PaneControls(Gtk.Box):
 class PaneToolbar(Gtk.Box):
     __gsignals__ = {
         "view-changed": (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        "show-hidden-toggled": (GObject.SignalFlags.RUN_LAST, None, (bool,)),
     }
 
     def __init__(self):
@@ -1927,6 +1928,19 @@ class PaneToolbar(Gtk.Box):
         # Right side (compact, flush-right)
         right = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         self._current_view = "list"
+
+        # Toggle for showing hidden files shares state across both panes via the window
+        self._show_hidden_button = Gtk.ToggleButton()
+        self._show_hidden_button.set_valign(Gtk.Align.CENTER)
+        self._show_hidden_button.add_css_class("flat")
+        self._show_hidden_image = Gtk.Image.new_from_icon_name("view-conceal-symbolic")
+        self._show_hidden_button.set_child(self._show_hidden_image)
+        self._show_hidden_handler_id = self._show_hidden_button.connect(
+            "toggled", self._on_show_hidden_toggled
+        )
+        self._update_show_hidden_icon(False)
+        right.append(self._show_hidden_button)
+
         self.sort_split_button = self._create_sort_split_button()
         right.append(self.sort_split_button)
         bar.append(right)
@@ -1962,7 +1976,34 @@ class PaneToolbar(Gtk.Box):
         self._current_view = "grid" if self._current_view == "list" else "list"
         self.sort_split_button.set_icon_name("view-grid-symbolic" if self._current_view == "grid" else "view-list-symbolic")
         self.emit("view-changed", self._current_view)
-    
+
+    def _on_show_hidden_toggled(self, button: Gtk.ToggleButton) -> None:
+        state = button.get_active()
+        self._update_show_hidden_icon(state)
+        self.emit("show-hidden-toggled", state)
+
+    def set_show_hidden_state(self, show_hidden: bool) -> None:
+        if not hasattr(self, "_show_hidden_button"):
+            return
+        current = self._show_hidden_button.get_active()
+        if current == show_hidden:
+            self._update_show_hidden_icon(show_hidden)
+            return
+        if self._show_hidden_handler_id is not None:
+            self._show_hidden_button.handler_block(self._show_hidden_handler_id)
+        try:
+            self._show_hidden_button.set_active(show_hidden)
+        finally:
+            if self._show_hidden_handler_id is not None:
+                self._show_hidden_button.handler_unblock(self._show_hidden_handler_id)
+        self._update_show_hidden_icon(show_hidden)
+
+    def _update_show_hidden_icon(self, show_hidden: bool) -> None:
+        icon_name = "view-reveal-symbolic" if show_hidden else "view-conceal-symbolic"
+        tooltip = "Hide Hidden Files" if show_hidden else "Show Hidden Files"
+        self._show_hidden_image.set_from_icon_name(icon_name)
+        self._show_hidden_button.set_tooltip_text(tooltip)
+
     def get_header_bar(self):
         """Get the actual header bar for toolbar view."""
         return None  # No longer using Adw.HeaderBar
@@ -2502,6 +2543,7 @@ class FilePane(Gtk.Box):
 
         # Connect to view-changed signal from toolbar
         self.toolbar.connect("view-changed", self._on_view_toggle)
+        self.toolbar.connect("show-hidden-toggled", self._on_toolbar_show_hidden_toggled)
         self.toolbar.path_entry.connect("activate", self._on_path_entry)
         # Wire navigation buttons
         self.toolbar.controls.up_button.connect("clicked", self._on_up_clicked)
@@ -2518,6 +2560,7 @@ class FilePane(Gtk.Box):
         self._cached_entries: List[FileEntry] = []
         self._raw_entries: List[FileEntry] = []
         self._show_hidden = False
+        self.toolbar.set_show_hidden_state(self._show_hidden)
         self._sort_key = "name"  # Default sort by name
         self._sort_descending = False  # Default ascending order
 
@@ -2621,6 +2664,11 @@ class FilePane(Gtk.Box):
         self._stack.set_visible_child_name(view_name)
         # Update the split button icon to reflect current view
         self._update_view_button_icon()
+
+    def _on_toolbar_show_hidden_toggled(self, _toolbar, show_hidden: bool) -> None:
+        window = self._get_file_manager_window()
+        if isinstance(window, FileManagerWindow):
+            window.set_show_hidden(show_hidden)
 
     def _on_path_entry(self, entry: Gtk.Entry) -> None:
         self.emit("path-changed", entry.get_text() or "/")
@@ -3090,6 +3138,16 @@ class FilePane(Gtk.Box):
             return
         self._can_paste = can_paste
         self._update_menu_state()
+
+    def set_show_hidden(self, show_hidden: bool, *, preserve_selection: bool = True) -> None:
+        """Update the hidden file visibility state and refresh entries."""
+
+        self.toolbar.set_show_hidden_state(show_hidden)
+        if self._show_hidden == show_hidden:
+            return
+
+        self._show_hidden = show_hidden
+        self._apply_entry_filter(preserve_selection=preserve_selection)
 
     def _on_menu_download(self) -> None:
         if not self._is_remote:
@@ -4062,9 +4120,6 @@ class FileManagerWindow(Adw.Window):
         self._local_pane_toggle.connect("toggled", self._on_local_pane_toggle)
         header_bar.pack_start(self._local_pane_toggle)
         
-        # Create menu button for headerbar
-        self._create_headerbar_menu(header_bar)
-        
         # Create toast overlay first and set it as toolbar content
         self._toast_overlay = Adw.ToastOverlay()
         self._progress_dialog: Optional[SFTPProgressDialog] = None
@@ -4182,6 +4237,9 @@ class FileManagerWindow(Adw.Window):
             self._left_pane: None,
             self._right_pane: None,
         }
+
+        self._show_hidden = False
+        self.set_show_hidden(self._show_hidden)
 
 
         self._clipboard_entries: List[FileEntry] = []
@@ -4338,50 +4396,14 @@ class FileManagerWindow(Adw.Window):
                 # Dialog might be destroyed or invalid, ignore
                 pass
 
-    def _create_headerbar_menu(self, header_bar: Adw.HeaderBar) -> None:
-        """Create and add menu button to headerbar."""
-        # Create menu model
-        menu_model = Gio.Menu()
-        
-        # Add "Show Hidden Files" toggle action
-        menu_model.append("Show Hidden Files", "win.show-hidden")
-        
-        # Create action group for window actions
-        self._window_action_group = Gio.SimpleActionGroup()
-        self.insert_action_group("win", self._window_action_group)
-        
-        # Create action for show hidden files
-        self._show_hidden_action = Gio.SimpleAction.new_stateful(
-            "show-hidden", 
-            None, 
-            GLib.Variant.new_boolean(False)
-        )
-        self._show_hidden_action.connect("activate", self._on_show_hidden_action)
-        self._window_action_group.add_action(self._show_hidden_action)
-        
-        # Create menu button
-        menu_button = Gtk.MenuButton()
-        menu_button.set_icon_name("open-menu-symbolic")
-        menu_button.set_menu_model(menu_model)
-        menu_button.set_tooltip_text("Main menu")
-        
-        # Add to headerbar
-        header_bar.pack_end(menu_button)
+    def set_show_hidden(self, show_hidden: bool) -> None:
+        """Synchronise hidden file visibility across both panes."""
 
-    def _on_show_hidden_action(self, action: Gio.SimpleAction, _parameter: Optional[GLib.Variant]) -> None:
-        """Handle show hidden files action from menu."""
-        # Toggle the state
-        current_state = action.get_state().get_boolean()
-        new_state = not current_state
-        action.set_state(GLib.Variant.new_boolean(new_state))
-        
-        # Apply to both panes
-        self._left_pane._show_hidden = new_state
-        self._right_pane._show_hidden = new_state
-        
-        # Refresh both panes
-        self._left_pane._apply_entry_filter(preserve_selection=True)
-        self._right_pane._apply_entry_filter(preserve_selection=True)
+        self._show_hidden = bool(show_hidden)
+
+        for pane in (self._left_pane, self._right_pane):
+            if isinstance(pane, FilePane):
+                pane.set_show_hidden(self._show_hidden, preserve_selection=True)
 
     def _on_local_pane_toggle(self, toggle_button: Gtk.ToggleButton) -> None:
         """Handle local pane toggle button."""


### PR DESCRIPTION
## Summary
- move the Show Hidden Files control from the header bar menu into the pane toolbar alongside the view toggle
- synchronize hidden file visibility across both panes through FileManagerWindow.set_show_hidden

## Testing
- pytest *(fails: ImportError: cannot import name 'Vte' from 'gi.repository')*

------
https://chatgpt.com/codex/tasks/task_e_68de02a4f1588328ab972c637fb38735