### PR TITLE
Document optional Flask backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,16 @@ Optional terminal backends
 --------------------------
 
 The default terminal uses the native VTE widget. sshPilot also ships with a
-vendored copy of `pyxtermjs` (version 0.5.0.2), so the optional PyXterm.js
-backend works out of the box without requiring any additional Python
-packages.
+vendored copy of `pyxtermjs` (version 0.5.0.2). To enable the optional
+PyXterm.js backend and its Flask Socket.IO server, install the extra
+dependencies with:
+
+```
+pip install "sshpilot[pyxterm]"
+```
+
+Manual setups can also install `Flask>=2.3` and `flask-socketio>=5.3`
+directly if preferred.
 
 ### Telegram channel
 https://t.me/sshpilot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "psutil>=5.9.0",
 ]
 
+[project.optional-dependencies]
+pyxterm = [
+    "Flask>=2.3",
+    "flask-socketio>=5.3",
+]
+
 [tool.setuptools.packages.find]
 include = ["sshpilot*"]
 exclude = ["packaging*", "screenshots*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ psutil>=5.9.0
 
 # Optional terminal backends
 # PyXterm.js backend is bundled via sshpilot.vendor.pyxtermjs (0.5.0.2)
+# Install these packages to enable the Flask Socket.IO backend used by PyXterm.js
+Flask>=2.3
+flask-socketio>=5.3
 
 
 


### PR DESCRIPTION
## Summary
- add a `pyxterm` optional dependency extra for the Flask Socket.IO backend
- list the matching Flask dependencies in `requirements.txt`
- document how to install the optional backend dependencies in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de344c429083289f63c072f6df45fd