### PR TITLE
Remove opacity animation from sidebar rows

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -366,7 +366,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             .adw-action-row.sshpilot-sidebar {
               margin: 1px 8px;  /* 6px vertical, 8px horizontal margin */
               padding: 0;
-              transition: transform 0.1s ease-out, opacity 0.1s ease-out;
+              transition: transform 0.1s ease-out;
             }
             
             /* Selected state - only override text color */


### PR DESCRIPTION
## Summary
- remove the opacity transition from the sidebar row CSS so the selection highlight appears immediately

## Testing
- python3 run.py *(fails: ModuleNotFoundError: No module named 'gi')*


------
https://chatgpt.com/codex/tasks/task_e_68de87abff40832895fe51480d0e9460