### PR TITLE
Remove sidebar pulse effect

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -1916,7 +1916,7 @@ Application accelerators now remain available even while the terminal widget is 
 
 - **`_set_sidebar_widget(widget)`** — Sets sidebar widget.
 
-- **`_setup_interaction_stop_pulse()`** — Set up event controllers to stop pulse effect on user interaction
+- **`_setup_connection_list_interactions()`** — Set up event controllers for connection list interaction handling
 
 - **`_show_duplicate_connection_error(connection, error)`** — Display an error dialog when duplication fails.
 
@@ -1934,10 +1934,6 @@ Application accelerators now remain available even while the terminal widget is 
 
 - **`_start_scp_upload_flow(connection)`** — Kick off the upload flow using a portal-aware file chooser.
 
-- **`_stop_pulse_on_interaction(controller, *args)`** — Stop any ongoing pulse effect when user interacts
-
-- **`_test_css_pulse(action, param)`** — Simple test to manually toggle CSS class
-
 - **`_toggle_class(widget, name, on)`** — Helper to toggle CSS class on a widget
 
 - **`_toggle_sidebar_visibility(is_visible)`** — Helper method to toggle sidebar visibility
@@ -1947,8 +1943,6 @@ Application accelerators now remain available even while the terminal widget is 
 - **`_update_tab_button_visibility()`** — Update TabButton visibility based on number of tabs
 
 - **`_update_tab_titles()`** — Update tab titles
-
-- **`_wire_pulses()`** — Wire pulse effects to trigger on focus-in only
 
 - **`add_connection_row(connection, indent_level=0)`** — Add a connection row to the list with optional indentation
 
@@ -2057,8 +2051,6 @@ Application accelerators now remain available even while the terminal widget is 
 - **`open_help_url()`** — Open the SSH Pilot wiki in the default browser
 
 - **`open_in_system_terminal(connection)`** — Open the connection in the system's default terminal
-
-- **`pulse_selected_row(list_box, repeats=3, duration_ms=280)`** — Pulse the selected row with highlight effect
 
 - **`rebuild_connection_list()`** — Rebuild the connection list with groups
 

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -120,7 +120,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         self._startup_tasks_scheduled = False
         self._startup_complete = False
         self._pending_focus_operations = []
-        self._suppress_focus_pulse = False
         if hasattr(self.config, 'connect'):
             try:
                 self._config_changed_handler = self.config.connect('setting-changed', self._on_config_setting_changed)
@@ -319,18 +318,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 return
             provider = Gtk.CssProvider()
             css = """
-            /* Pulse highlight for selected rows */
-            .pulse-highlight {
-              background: rgba(53, 132, 228, 0.5);
-              border-radius: 8px;
-              box-shadow: 0 0 0 0.5px rgba(53, 132, 228, 0.28) inset;
-              opacity: 0;
-              transition: opacity 0.3s ease-in-out;
-            }
-            .pulse-highlight.on {
-              opacity: 1;
-            }
-
             /* optional: a subtle focus ring while the list is focused */
             row:selected:focus-within {
               /* box-shadow: 0 0 8px 2px @accent_bg_color inset; */
@@ -686,81 +673,25 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
 
 
-    def pulse_selected_row(self, list_box: Gtk.ListBox, repeats=3, duration_ms=280):
-        """Pulse the selected row with highlight effect"""
-        row = list_box.get_selected_row() or (list_box.get_selected_rows()[0] if list_box.get_selected_rows() else None)
-        if not row:
-            return
-        if not hasattr(row, "_pulse"):
-            return
-        # Ensure it's realized so opacity changes render
-        if not row.get_mapped():
-            row.realize()
-        
-        # Use CSS-based pulse for now
-        pulse = row._pulse
-        cycle_duration = max(300, duration_ms // repeats)  # Minimum 300ms per cycle for faster pulses
-        
-        def do_cycle(count):
-            if count == 0:
-                return False
-            pulse.add_css_class("on")
-            # Keep the pulse visible for a shorter time for snappier effect
-            GLib.timeout_add(cycle_duration // 2, lambda: (
-                pulse.remove_css_class("on"),
-                # Add a shorter delay before the next pulse
-                GLib.timeout_add(cycle_duration // 2, lambda: do_cycle(count - 1)) or True
-            ) and False)
-            return False
-
-        GLib.idle_add(lambda: do_cycle(repeats))
-
-    def _test_css_pulse(self, action, param):
-        """Simple test to manually toggle CSS class"""
-        row = self.connection_list.get_selected_row()
-        if row and hasattr(row, "_pulse"):
-            pulse = row._pulse
-            pulse.add_css_class("on")
-            GLib.timeout_add(1000, lambda: (
-                pulse.remove_css_class("on")
-            ) or False)
-
-    def _setup_interaction_stop_pulse(self):
-        """Set up event controllers to stop pulse effect on user interaction"""
+    def _setup_connection_list_interactions(self):
+        """Set up event controllers for connection list interaction"""
         # Mouse click controller
         click_ctl = Gtk.GestureClick()
-        click_ctl.connect("pressed", self._stop_pulse_on_interaction)
         click_ctl.connect("pressed", self._on_connection_list_pressed)
         self.connection_list.add_controller(click_ctl)
         logger.debug("GestureClick controller added to connection_list")
-        
+
         # Key controller
         key_ctl = Gtk.EventControllerKey()
         key_ctl.connect("key-pressed", self._on_connection_list_key_pressed)
         self.connection_list.add_controller(key_ctl)
-        
-        # Scroll controller
-        scroll_ctl = Gtk.EventControllerScroll()
-        scroll_ctl.connect("scroll", self._stop_pulse_on_interaction)
-        self.connection_list.add_controller(scroll_ctl)
 
     def _on_connection_list_pressed(self, gesture, n_press, x, y):
-        """Handle primary button presses on the connection list"""
-        button = None
-        try:
-            button = gesture.get_current_button()
-        except Exception:
-            button = None
-        primary_button = getattr(Gdk, 'BUTTON_PRIMARY', 1)
-        if button == primary_button and not self.connection_list.has_focus():
-            self._suppress_focus_pulse = True
+        """Handle button presses on the connection list"""
         self.on_connection_click(gesture, n_press, x, y)
 
     def _on_connection_list_key_pressed(self, controller, keyval, keycode, state):
         """Handle key presses in the connection list"""
-        # Stop pulse effect on any key press
-        self._stop_pulse_on_interaction(controller)
-        
         # Handle Enter key for both group and connection rows
         if keyval == Gdk.KEY_Return or keyval == Gdk.KEY_KP_Enter:
             selected_row = self.connection_list.get_selected_row()
@@ -790,39 +721,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
             return False
         return False
-
-    def _stop_pulse_on_interaction(self, controller, *args):
-        """Stop any ongoing pulse effect when user interacts"""
-        # Stop pulse on any row that has the 'on' class
-        for row in self.connection_list:
-            if hasattr(row, "_pulse"):
-                pulse = row._pulse
-                if "on" in pulse.get_css_classes():
-                    pulse.remove_css_class("on")
-
-    def _wire_pulses(self):
-        """Wire pulse effects to trigger on focus-in only"""
-        # Track if this is the initial startup focus
-        self._is_initial_focus = True
-        
-        # When list gains keyboard focus (e.g., after Ctrl/⌘+L)
-        focus_ctl = Gtk.EventControllerFocus()
-        def on_focus_enter(*args):
-            # Don't pulse on initial startup focus
-            if self._is_initial_focus:
-                self._is_initial_focus = False
-                return
-            if self._suppress_focus_pulse:
-                self._suppress_focus_pulse = False
-                return
-            self.pulse_selected_row(self.connection_list, repeats=1, duration_ms=600)
-        focus_ctl.connect("enter", on_focus_enter)
-        self.connection_list.add_controller(focus_ctl)
-        
-        # Stop pulse effect when user interacts with the list
-        self._setup_interaction_stop_pulse()
-        
-        # Sidebar toggle action registered via register_window_actions
 
     def setup_window(self):
         """Configure main window properties"""
@@ -1367,8 +1265,8 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         except Exception:
             pass
         
-        # Wire pulse effects
-        self._wire_pulses()
+        # Set up controllers for connection list interactions
+        self._setup_connection_list_interactions()
         
         # Connect signals
         self.connection_list.connect('row-selected', self.on_connection_selected)  # For button sensitivity
@@ -1401,9 +1299,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             def _on_right_click(gesture, n_press, x, y):
                 try:
                     logger.debug("Simple right-click detected - showing context menu for selected row")
-                    
-                    # Clear any existing pulse effects to prevent multiple highlights
-                    self._stop_pulse_on_interaction(None)
                     
                     # Try to detect the clicked row, but fall back to selected row if detection fails
                     row = None
@@ -1627,11 +1522,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             def _on_middle_click(gesture, n_press, x, y):
                 if n_press != 1:
                     return
-
-                try:
-                    self._stop_pulse_on_interaction(None)
-                except Exception:
-                    pass
 
                 row, _, _ = self._resolve_connection_list_event(x, y)
 
@@ -2603,9 +2493,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         logger.debug(f"Focus connection list - selected first row: {first_row}")
                 
                 self.connection_list.grab_focus()
-                
-                # Pulse the selected row
-                self.pulse_selected_row(self.connection_list, repeats=1, duration_ms=600)
                 
                 # Show toast notification
                 toast = Adw.Toast.new(


### PR DESCRIPTION
## Summary
- remove the CSS and helper logic that produced the sidebar pulse highlight
- streamline the connection list interaction controllers to avoid unused pulse handling
- update the function reference documentation to reflect the new helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de8f6238608328b4f7de1f7a6b07cf