### PR TITLE
Respect user SSH host key options

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -12,7 +12,7 @@ import subprocess
 import shlex
 import signal
 import re
-from typing import Dict, List, Optional, Any, Tuple, Union
+from typing import Dict, List, Optional, Any, Tuple, Union, Set
 
 from .ssh_config_utils import resolve_ssh_config_files, get_effective_ssh_config
 from .platform_utils import is_macos, get_config_dir, get_ssh_dir
@@ -74,6 +74,8 @@ class Connection:
         self.connection = None
         self.forwarders: List[asyncio.Task] = []
         self.listeners: List[asyncio.Server] = []
+        self.resolved_ssh_config: Dict[str, Any] = {}
+        self.resolved_user_known_hosts: List[str] = []
 
         raw_quick = data.get('quick_connect_command', '') if isinstance(data, dict) else ''
         if isinstance(raw_quick, str):
@@ -257,6 +259,93 @@ class Connection:
 
             ssh_cmd = ['ssh']
 
+            def _parse_option_token(token: str) -> Tuple[str, bool]:
+                token = str(token or '').strip()
+                if not token:
+                    return '', False
+                if '=' in token:
+                    key, _ = token.split('=', 1)
+                    return key.strip(), True
+                return token, False
+
+            def _collect_option_keys(cmd: List[str]) -> Set[str]:
+                keys: Set[str] = set()
+                i = 0
+                length = len(cmd)
+                while i < length:
+                    arg = cmd[i]
+                    if arg == '-o':
+                        i += 1
+                        if i < length:
+                            opt = cmd[i]
+                            key, has_value = _parse_option_token(opt)
+                            if key:
+                                keys.add(key.lower())
+                            if (not has_value) and (i + 1 < length):
+                                lookahead = cmd[i + 1]
+                                if not str(lookahead).startswith('-'):
+                                    i += 1
+                    elif isinstance(arg, str) and arg.startswith('-o'):
+                        remainder = arg[2:].lstrip()
+                        if remainder:
+                            key, has_value = _parse_option_token(remainder)
+                            if key:
+                                keys.add(key.lower())
+                            if (not has_value) and (i + 1 < length):
+                                lookahead = cmd[i + 1]
+                                if not str(lookahead).startswith('-'):
+                                    i += 1
+                    i += 1
+                return keys
+
+            def _has_option(cmd: List[str], option_key: str) -> bool:
+                key = str(option_key or '').strip().lower()
+                if not key:
+                    return False
+                return key in _collect_option_keys(cmd)
+
+            stored_alias = ''
+            if isinstance(self.data, dict):
+                stored_alias = str(self.data.get('host') or '')
+            alias_fallback = (
+                stored_alias
+                or self.nickname
+                or self.host
+                or self.hostname
+            )
+
+            target_alias = self.nickname or self.hostname
+            config_override = self._resolve_config_override_path()
+            effective_cfg: Dict[str, Union[str, List[str]]] = {}
+            if target_alias:
+                if config_override:
+                    effective_cfg = get_effective_ssh_config(
+                        target_alias, config_file=config_override
+                    )
+                else:
+                    effective_cfg = get_effective_ssh_config(target_alias)
+
+            if not isinstance(effective_cfg, dict):
+                effective_cfg = {}
+
+            self.resolved_ssh_config = dict(effective_cfg)
+
+            raw_known_hosts = effective_cfg.get('userknownhostsfile')
+            resolved_known_hosts: List[str] = []
+            if isinstance(raw_known_hosts, list):
+                resolved_known_hosts = [
+                    str(path)
+                    for path in raw_known_hosts
+                    if str(path).strip()
+                ]
+            elif isinstance(raw_known_hosts, str) and raw_known_hosts.strip():
+                resolved_known_hosts = [raw_known_hosts.strip()]
+            self.resolved_user_known_hosts = resolved_known_hosts
+
+            effective_strict = str(
+                effective_cfg.get('stricthostkeychecking', '') or ''
+            ).strip()
+
             # Pull advanced SSH defaults from config when available
             try:
                 from .config import Config  # avoid circular import at top level
@@ -276,22 +365,35 @@ class Connection:
 
             # Apply advanced args only when user explicitly enabled them
             if apply_adv:
-                if batch_mode:
+                if batch_mode and not _has_option(ssh_cmd, 'batchmode'):
                     ssh_cmd.extend(['-o', 'BatchMode=yes'])
-                if connect_timeout is not None:
+                if connect_timeout is not None and not _has_option(
+                    ssh_cmd, 'connecttimeout'
+                ):
                     ssh_cmd.extend(['-o', f'ConnectTimeout={connect_timeout}'])
-                if connection_attempts is not None:
+                if connection_attempts is not None and not _has_option(
+                    ssh_cmd, 'connectionattempts'
+                ):
                     ssh_cmd.extend(['-o', f'ConnectionAttempts={connection_attempts}'])
-                if strict_host:
+                if strict_host and not _has_option(
+                    ssh_cmd, 'stricthostkeychecking'
+                ):
                     ssh_cmd.extend(['-o', f'StrictHostKeyChecking={strict_host}'])
                 if compression:
                     ssh_cmd.append('-C')
-            ssh_cmd.extend(['-o', 'ExitOnForwardFailure=yes'])
-            ssh_cmd.extend(['-o', 'NumberOfPasswordPrompts=1'])
+            if not _has_option(ssh_cmd, 'exitonforwardfailure'):
+                ssh_cmd.extend(['-o', 'ExitOnForwardFailure=yes'])
+            if not _has_option(ssh_cmd, 'numberofpasswordprompts'):
+                ssh_cmd.extend(['-o', 'NumberOfPasswordPrompts=1'])
 
             # Apply default host key behavior when not explicitly set
             try:
-                if (not strict_host) and auto_add_host_keys:
+                if (
+                    (not strict_host)
+                    and auto_add_host_keys
+                    and not effective_strict
+                    and not _has_option(ssh_cmd, 'stricthostkeychecking')
+                ):
                     ssh_cmd.extend(['-o', 'StrictHostKeyChecking=accept-new'])
             except Exception:
                 pass
@@ -311,28 +413,6 @@ class Connection:
                     ssh_cmd.extend(['-o', 'LogLevel=DEBUG'])
             except Exception:
                 pass
-
-            # Resolve effective SSH configuration for this nickname/host
-            effective_cfg: Dict[str, Union[str, List[str]]] = {}
-            target_alias = self.nickname or self.hostname
-            stored_alias = ""
-            if isinstance(self.data, dict):
-                stored_alias = str(self.data.get('host') or '')
-            alias_fallback = (
-                stored_alias
-                or self.nickname
-                or self.host
-                or self.hostname
-            )
-            config_override = self._resolve_config_override_path()
-            if target_alias:
-                if config_override:
-                    effective_cfg = get_effective_ssh_config(
-                        target_alias, config_file=config_override
-                    )
-                else:
-                    effective_cfg = get_effective_ssh_config(target_alias)
-
 
             # Determine final parameters, falling back to resolved config when needed
             existing_hostname = self.hostname or ''

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -587,8 +587,54 @@ class TerminalWidget(Gtk.Box):
                 if using_prepared_cmd and host_arg is None:
                     needs_host_append = False
 
+                def _parse_option_token(token: str):
+                    token = str(token or '').strip()
+                    if not token:
+                        return '', False
+                    if '=' in token:
+                        key, _ = token.split('=', 1)
+                        return key.strip(), True
+                    return token, False
+
+                def _collect_option_keys(cmd):
+                    keys = set()
+                    i = 0
+                    length = len(cmd)
+                    while i < length:
+                        arg = cmd[i]
+                        if arg == '-o':
+                            i += 1
+                            if i < length:
+                                opt = cmd[i]
+                                key, has_value = _parse_option_token(opt)
+                                if key:
+                                    keys.add(key.lower())
+                                if (not has_value) and (i + 1 < length):
+                                    lookahead = cmd[i + 1]
+                                    if not str(lookahead).startswith('-'):
+                                        i += 1
+                        elif isinstance(arg, str) and arg.startswith('-o'):
+                            remainder = arg[2:].lstrip()
+                            if remainder:
+                                key, has_value = _parse_option_token(remainder)
+                                if key:
+                                    keys.add(key.lower())
+                                if (not has_value) and (i + 1 < length):
+                                    lookahead = cmd[i + 1]
+                                    if not str(lookahead).startswith('-'):
+                                        i += 1
+                        i += 1
+                    return keys
+
+                def option_key_present(key_name: str) -> bool:
+                    key = str(key_name or '').strip().lower()
+                    if not key:
+                        return False
+                    return key in _collect_option_keys(ssh_cmd)
+
                 def ensure_option(option: str):
-                    if option not in ssh_cmd:
+                    option_key = str(option or '').split('=', 1)[0].strip().lower()
+                    if option_key and not option_key_present(option_key):
                         ssh_cmd.extend(['-o', option])
 
                 def ensure_flag(flag: str):
@@ -609,6 +655,31 @@ class TerminalWidget(Gtk.Box):
                 auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))
                 batch_mode = bool(ssh_cfg.get('batch_mode', False)) if apply_adv else False
                 compression = bool(ssh_cfg.get('compression', False)) if apply_adv else False
+
+                resolved_cfg = {}
+                try:
+                    resolved_cfg = getattr(self.connection, 'resolved_ssh_config', {}) or {}
+                except Exception:
+                    resolved_cfg = {}
+                resolved_strict_cfg = ''
+                has_known_hosts_override = False
+                if isinstance(resolved_cfg, dict):
+                    resolved_strict_cfg = str(
+                        resolved_cfg.get('stricthostkeychecking', '') or ''
+                    ).strip()
+                    raw_known_hosts = resolved_cfg.get('userknownhostsfile')
+                    if isinstance(raw_known_hosts, list):
+                        has_known_hosts_override = any(
+                            str(item).strip() for item in raw_known_hosts
+                        )
+                    elif isinstance(raw_known_hosts, str):
+                        has_known_hosts_override = bool(raw_known_hosts.strip())
+                if not has_known_hosts_override:
+                    try:
+                        overrides = getattr(self.connection, 'resolved_user_known_hosts', [])
+                        has_known_hosts_override = bool(overrides)
+                    except Exception:
+                        has_known_hosts_override = False
 
                 # Determine auth method from connection and retrieve any saved password
                 try:
@@ -651,7 +722,12 @@ class TerminalWidget(Gtk.Box):
 
                 # Default to accepting new host keys non-interactively on fresh installs
                 try:
-                    if (not strict_host) and auto_add_host_keys:
+                    if (
+                        (not strict_host)
+                        and auto_add_host_keys
+                        and not resolved_strict_cfg
+                        and not option_key_present('StrictHostKeyChecking')
+                    ):
                         ensure_option('StrictHostKeyChecking=accept-new')
                 except Exception:
                     pass
@@ -660,7 +736,12 @@ class TerminalWidget(Gtk.Box):
                 try:
                     if getattr(self, 'connection_manager', None):
                         kh_path = getattr(self.connection_manager, 'known_hosts_path', '')
-                        if kh_path and os.path.exists(kh_path):
+                        if (
+                            kh_path
+                            and os.path.exists(kh_path)
+                            and not option_key_present('UserKnownHostsFile')
+                            and not has_known_hosts_override
+                        ):
                             ensure_option(f'UserKnownHostsFile={kh_path}')
                 except Exception:
                     logger.debug('Failed to set UserKnownHostsFile option', exc_info=True)

--- a/tests/test_proxy_directives.py
+++ b/tests/test_proxy_directives.py
@@ -3,6 +3,8 @@ import importlib
 import sys
 import types
 
+import sshpilot.connection_manager as connection_manager_mod
+
 from sshpilot.connection_manager import Connection, ConnectionManager
 
 
@@ -62,6 +64,34 @@ def test_connection_passes_proxy_options():
     assert "ProxyJump=b1,b2" in conn3.ssh_cmd
     assert "-A" in conn3.ssh_cmd
     assert "ForwardAgent=yes" in conn3.ssh_cmd
+
+
+def test_connection_manager_respects_user_strict_host(monkeypatch):
+    loop = asyncio.get_event_loop()
+    conn = Connection({"host": "example.com"})
+
+    monkeypatch.setattr(
+        connection_manager_mod,
+        "get_effective_ssh_config",
+        lambda *a, **k: {
+            "stricthostkeychecking": "no",
+            "userknownhostsfile": "/dev/null",
+        },
+    )
+    monkeypatch.setattr(
+        connection_manager_mod,
+        "Config",
+        lambda *a, **k: types.SimpleNamespace(get_ssh_config=lambda: {}),
+        raising=False,
+    )
+
+    loop.run_until_complete(conn.connect())
+
+    assert not any(
+        "StrictHostKeyChecking=accept-new" in part for part in conn.ssh_cmd
+    )
+    assert conn.resolved_ssh_config.get("stricthostkeychecking") == "no"
+    assert conn.resolved_user_known_hosts == ["/dev/null"]
 
 
 def test_terminal_widget_uses_prepared_proxy_command(monkeypatch):
@@ -146,6 +176,100 @@ def test_terminal_widget_uses_prepared_proxy_command(monkeypatch):
     assert any(arg == "ProxyCommand=ssh -W %h:%p bastion" for arg in cmd)
     assert any(arg == "ProxyJump=b1,b2" for arg in cmd)
     assert cmd.count(conn.ssh_cmd[-1]) == 1
+
+
+def test_terminal_widget_preserves_known_hosts_override(monkeypatch, tmp_path):
+    conn = Connection({"host": "example.com"})
+    conn.ssh_cmd = [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-oUserKnownHostsFile=/dev/null",
+        "example.com",
+    ]
+    conn.resolved_ssh_config = {
+        "stricthostkeychecking": "no",
+        "userknownhostsfile": "/dev/null",
+    }
+    conn.resolved_user_known_hosts = ["/dev/null"]
+
+    from sshpilot import terminal as terminal_mod
+
+    class DummyVte:
+        def __init__(self):
+            self.last_cmd = None
+
+        def spawn_async(self, *args):
+            self.last_cmd = list(args[2])
+
+        def grab_focus(self):
+            pass
+
+    widget = terminal_mod.TerminalWidget.__new__(terminal_mod.TerminalWidget)
+    widget.connection = conn
+    widget.config = types.SimpleNamespace(get_ssh_config=lambda: {})
+    known_hosts_path = tmp_path / "known_hosts"
+    known_hosts_path.write_text("")
+    widget.connection_manager = types.SimpleNamespace(
+        get_password=lambda *a, **k: None,
+        prepare_key_for_connection=lambda *a, **k: True,
+        known_hosts_path=str(known_hosts_path),
+        native_connect_enabled=False,
+    )
+    widget.vte = DummyVte()
+    widget.apply_theme = lambda *a, **k: None
+    widget._show_forwarding_error_dialog = lambda *a, **k: None
+    widget._set_connecting_overlay_visible = lambda *a, **k: None
+    widget._set_disconnected_banner_visible = lambda *a, **k: None
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("unexpected failure")
+
+    widget._on_connection_failed = _fail
+    widget._on_spawn_complete = lambda *a, **k: None
+    widget._fallback_hide_spinner = lambda *a, **k: False
+    widget._fallback_to_askpass = lambda *a, **k: None
+    widget.connecting_bg = types.SimpleNamespace(set_visible=lambda *a, **k: None)
+    widget.connecting_box = types.SimpleNamespace(set_visible=lambda *a, **k: None)
+    widget._fallback_timer_id = None
+    widget._is_quitting = False
+
+    monkeypatch.setattr(
+        terminal_mod,
+        "get_port_checker",
+        lambda: types.SimpleNamespace(get_port_conflicts=lambda ports, addr: []),
+    )
+    monkeypatch.setattr(
+        terminal_mod.Vte,
+        "Pty",
+        types.SimpleNamespace(new_sync=lambda *a, **k: object()),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        terminal_mod.Vte,
+        "PtyFlags",
+        types.SimpleNamespace(DEFAULT=0),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        terminal_mod.GLib,
+        "SpawnFlags",
+        types.SimpleNamespace(DEFAULT=0),
+        raising=False,
+    )
+    monkeypatch.setattr(terminal_mod.GLib, "timeout_add_seconds", lambda *a, **k: 0, raising=False)
+    if not hasattr(terminal_mod.GLib, "source_remove"):
+        monkeypatch.setattr(terminal_mod.GLib, "source_remove", lambda *a, **k: None, raising=False)
+
+    widget._setup_ssh_terminal()
+
+    cmd = widget.vte.last_cmd
+    assert cmd is not None
+    assert not any("StrictHostKeyChecking=accept-new" in part for part in cmd)
+    assert any("StrictHostKeyChecking=no" in part for part in cmd)
+    assert any("UserKnownHostsFile=/dev/null" in part for part in cmd)
+    assert not any(
+        f"UserKnownHostsFile={known_hosts_path}" in part for part in cmd
+    )
 
 
 def test_terminal_manager_prepares_connection_before_spawn(monkeypatch):


### PR DESCRIPTION
## Summary
- capture the effective ssh configuration when building commands so defaults such as StrictHostKeyChecking are not re-added when already defined
- update the terminal widget to detect existing `-o` arguments and honor StrictHostKeyChecking/UserKnownHostsFile overrides instead of forcing application defaults
- add regression coverage to ensure prepared commands with custom host key options are left untouched by connection setup

## Testing
- pytest tests/test_proxy_directives.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe8c13bf08328bfe07e2c4a047ccb