### PR TITLE
Log native SSH spawn command when native mode is enabled

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     integration: Integration-level tests that exercise GTK components without full UI automation.
     e2e: End-to-end UI tests that rely on Dogtail and AT-SPI.
+    asyncio: Tests that require an asyncio event loop.

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -10,6 +10,7 @@ import signal
 import time
 import json
 import re
+import shlex
 import gi
 from gettext import gettext as _
 import asyncio
@@ -1002,6 +1003,14 @@ class TerminalWidget(Gtk.Box):
                 env_list.append(f"{key}={value}")
             
             # Log the command being executed for debugging
+            if native_mode_enabled:
+                try:
+                    cmd_parts = [str(part) for part in ssh_cmd]
+                    formatted_cmd = shlex.join(cmd_parts)
+                except Exception:
+                    formatted_cmd = ' '.join(str(part) for part in ssh_cmd)
+                logger.info("Native SSH spawn command: %s", formatted_cmd)
+
             logger.debug(f"Spawning SSH command: {ssh_cmd}")
             logger.debug(f"Environment PATH: {env.get('PATH', 'NOT_SET')}")
             

--- a/tests/test_native_connect.py
+++ b/tests/test_native_connect.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from sshpilot.connection_manager import Connection
+from sshpilot import config as config_module
+
+
+class DummyConfig:
+    def __init__(self):
+        self._ssh_config = {
+            'apply_advanced': True,
+            'batch_mode': True,
+            'connection_timeout': 15,
+            'connection_attempts': 4,
+            'keepalive_interval': 30,
+            'keepalive_count_max': 2,
+            'strict_host_key_checking': 'no',
+            'auto_add_host_keys': False,
+            'exit_on_forward_failure': True,
+            'compression': False,
+        }
+
+    def get_ssh_config(self):
+        return self._ssh_config
+
+
+def test_native_connect_includes_advanced_options(monkeypatch):
+    monkeypatch.setattr(config_module, 'Config', DummyConfig)
+
+    loop = asyncio.new_event_loop()
+    old_loop = None
+    try:
+        try:
+            old_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            old_loop = None
+        asyncio.set_event_loop(loop)
+
+        connection = Connection(
+            {
+                'hostname': 'example.com',
+                'nickname': 'example',
+                'username': 'alice',
+                'extra_ssh_config': 'Compression yes\nUserKnownHostsFile /tmp/custom_known_hosts',
+            }
+        )
+
+        assert loop.run_until_complete(connection.native_connect()) is True
+    finally:
+        loop.close()
+        asyncio.set_event_loop(old_loop)
+
+    ssh_cmd = connection.ssh_cmd
+    host_label = connection.resolve_host_identifier()
+    assert ssh_cmd[-1] == host_label
+
+    host_index = ssh_cmd.index(host_label)
+    advanced_section = ssh_cmd[:host_index]
+
+    def has_option(value: str) -> bool:
+        return any(value == token for token in advanced_section)
+
+    assert has_option('ConnectTimeout=15')
+    assert has_option('ConnectionAttempts=4')
+    assert has_option('ServerAliveInterval=30')
+    assert has_option('ServerAliveCountMax=2')
+    assert has_option('StrictHostKeyChecking=no')
+    assert has_option('ExitOnForwardFailure=yes')
+    assert has_option('Compression=yes')
+    assert has_option('UserKnownHostsFile=/tmp/custom_known_hosts')


### PR DESCRIPTION
## Summary
- log the formatted native SSH command that will be used to spawn the terminal

## Testing
- pytest tests/test_native_connect.py

------
https://chatgpt.com/codex/tasks/task_e_68e01a648c488328a2217ea7fa9a5884