### PR TITLE
Refine native SSH command option assembly

### DIFF
--- a/tests/test_native_connect.py
+++ b/tests/test_native_connect.py
@@ -56,14 +56,21 @@ def test_native_connect_includes_advanced_options(monkeypatch):
     host_index = ssh_cmd.index(host_label)
     advanced_section = ssh_cmd[:host_index]
 
-    def has_option(value: str) -> bool:
-        return any(value == token for token in advanced_section)
+    def has_option_pair(value: str) -> bool:
+        return any(
+            advanced_section[idx] == '-o' and advanced_section[idx + 1] == value
+            for idx in range(len(advanced_section) - 1)
+        )
 
-    assert has_option('ConnectTimeout=15')
-    assert has_option('ConnectionAttempts=4')
-    assert has_option('ServerAliveInterval=30')
-    assert has_option('ServerAliveCountMax=2')
-    assert has_option('StrictHostKeyChecking=no')
-    assert has_option('ExitOnForwardFailure=yes')
-    assert has_option('Compression=yes')
-    assert has_option('UserKnownHostsFile=/tmp/custom_known_hosts')
+    assert has_option_pair('BatchMode=yes')
+    assert has_option_pair('ConnectTimeout=15')
+    assert has_option_pair('ConnectionAttempts=4')
+    assert has_option_pair('ServerAliveInterval=30')
+    assert has_option_pair('ServerAliveCountMax=2')
+    assert has_option_pair('StrictHostKeyChecking=no')
+    assert has_option_pair('ExitOnForwardFailure=yes')
+    assert has_option_pair('Compression=yes')
+    assert has_option_pair('UserKnownHostsFile=/tmp/custom_known_hosts')
+
+    assert '-i' not in advanced_section
+    assert '-X' not in advanced_section


### PR DESCRIPTION
## Summary
- inline the construction of advanced SSH -o pairs within Connection.native_connect
- ensure extra SSH directives are converted into -o options before the host argument and exclude helper-specific flags
- extend native_connect test coverage to validate option pairing and absence of ssh-copy-id/X11 flags

## Testing
- pytest tests/test_native_connect.py

------
https://chatgpt.com/codex/tasks/task_e_68e021bafd188328a3de99c20b7225af