### PR TITLE
Log native SSH command before wrapper augmentation

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -454,6 +454,16 @@ class Connection:
 
     async def native_connect(self):
         """Prepare a minimal SSH command deferring to the user's SSH configuration."""
+
+        def format_ssh_command(parts: List[str]) -> str:
+            joiner = getattr(shlex, 'join', None)
+            if callable(joiner):
+                try:
+                    return joiner(parts)
+                except Exception:
+                    pass
+            return ' '.join(parts)
+
         try:
             quick_cmd = getattr(self, 'quick_connect_command', '')
             if isinstance(quick_cmd, str) and quick_cmd.strip():
@@ -461,6 +471,10 @@ class Connection:
                     ssh_cmd = shlex.split(quick_cmd)
                 except ValueError:
                     ssh_cmd = quick_cmd.split()
+                logger.info(
+                    "Prepared native SSH command: %s",
+                    format_ssh_command(ssh_cmd),
+                )
                 self.ssh_cmd = ssh_cmd
                 self.is_connected = True
                 return True
@@ -502,6 +516,11 @@ class Connection:
                 ssh_cmd.extend(advanced_options)
 
             ssh_cmd.append(host_label)
+
+            logger.info(
+                "Prepared native SSH command: %s",
+                format_ssh_command(ssh_cmd),
+            )
 
             self.ssh_cmd = ssh_cmd
             self.is_connected = True


### PR DESCRIPTION
## Summary
- log the native SSH command immediately after it is constructed so the pristine invocation is captured
- add a regression test to ensure the command string is recorded in the connection manager logs

## Testing
- pytest tests/test_native_connect.py

------
https://chatgpt.com/codex/tasks/task_e_68e021e428648328907b5f3af88ab62b