### PR TITLE
Persist advanced SSH override flags for native SSH mode

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -192,6 +192,7 @@ class Config(GObject.Object):
                 'debug_enabled': False,
                 'native_connect': False,
                 'use_isolated_config': False,
+                'ssh_overrides': [],
             },
             'file_manager': {
                 'force_internal': False,
@@ -606,6 +607,7 @@ class Config(GObject.Object):
             'strict_host_key_checking': 'accept-new',
             'use_isolated_config': False,
             'verbosity': 0,
+            'ssh_overrides': [],
         }
 
         bool_keys = {
@@ -656,6 +658,16 @@ class Config(GObject.Object):
                             value = 'accept-new' if normalized == 'accept-new' else normalized
                         else:
                             value = default_value
+            elif key == 'ssh_overrides':
+                if isinstance(value, (list, tuple)):
+                    coerced: List[str] = []
+                    for entry in value:
+                        if entry is None:
+                            continue
+                        coerced.append(str(entry))
+                    value = coerced
+                else:
+                    value = []
 
             config[key] = value
 

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -4,6 +4,7 @@ import os
 import logging
 import subprocess
 import shutil
+from typing import List
 
 from .platform_utils import get_config_dir, is_flatpak, is_macos
 from .file_manager_integration import (
@@ -1746,8 +1747,21 @@ class PreferencesWindow(Gtk.Window):
     def save_advanced_ssh_settings(self):
         """Persist advanced SSH settings from the preferences UI"""
         try:
+            apply_advanced_enabled = False
+            native_value = False
+            connect_timeout = None
+            connection_attempts = None
+            keepalive_interval = None
+            keepalive_count = None
+            strict_host_value = ''
+            batch_mode_enabled = False
+            compression_enabled = False
+            verbosity_value = 0
+            debug_enabled = False
+
             if hasattr(self, 'apply_advanced_row'):
-                self.config.set_setting('ssh.apply_advanced', bool(self.apply_advanced_row.get_active()))
+                apply_advanced_enabled = bool(self.apply_advanced_row.get_active())
+                self.config.set_setting('ssh.apply_advanced', apply_advanced_enabled)
             if hasattr(self, 'native_connect_row'):
                 native_value = bool(self.native_connect_row.get_active())
                 self.config.set_setting('ssh.native_connect', native_value)
@@ -1762,26 +1776,72 @@ class PreferencesWindow(Gtk.Window):
                 if self.parent_window and hasattr(self.parent_window, 'connection_manager'):
                     self.parent_window.connection_manager.native_connect_enabled = native_value
             if hasattr(self, 'connect_timeout_row'):
-                self.config.set_setting('ssh.connection_timeout', int(self.connect_timeout_row.get_value()))
+                connect_timeout = int(self.connect_timeout_row.get_value())
+                self.config.set_setting('ssh.connection_timeout', connect_timeout)
             if hasattr(self, 'connection_attempts_row'):
-                self.config.set_setting('ssh.connection_attempts', int(self.connection_attempts_row.get_value()))
+                connection_attempts = int(self.connection_attempts_row.get_value())
+                self.config.set_setting('ssh.connection_attempts', connection_attempts)
             if hasattr(self, 'keepalive_interval_row'):
-                self.config.set_setting('ssh.keepalive_interval', int(self.keepalive_interval_row.get_value()))
+                keepalive_interval = int(self.keepalive_interval_row.get_value())
+                self.config.set_setting('ssh.keepalive_interval', keepalive_interval)
             if hasattr(self, 'keepalive_count_row'):
-                self.config.set_setting('ssh.keepalive_count_max', int(self.keepalive_count_row.get_value()))
+                keepalive_count = int(self.keepalive_count_row.get_value())
+                self.config.set_setting('ssh.keepalive_count_max', keepalive_count)
             if hasattr(self, 'strict_host_row'):
                 options = ["accept-new", "yes", "no", "ask"]
                 idx = self.strict_host_row.get_selected()
-                value = options[idx] if 0 <= idx < len(options) else 'accept-new'
-                self.config.set_setting('ssh.strict_host_key_checking', value)
+                strict_host_value = options[idx] if 0 <= idx < len(options) else 'accept-new'
+                self.config.set_setting('ssh.strict_host_key_checking', strict_host_value)
             if hasattr(self, 'batch_mode_row'):
-                self.config.set_setting('ssh.batch_mode', bool(self.batch_mode_row.get_active()))
+                batch_mode_enabled = bool(self.batch_mode_row.get_active())
+                self.config.set_setting('ssh.batch_mode', batch_mode_enabled)
             if hasattr(self, 'compression_row'):
-                self.config.set_setting('ssh.compression', bool(self.compression_row.get_active()))
+                compression_enabled = bool(self.compression_row.get_active())
+                self.config.set_setting('ssh.compression', compression_enabled)
             if hasattr(self, 'verbosity_row'):
-                self.config.set_setting('ssh.verbosity', int(self.verbosity_row.get_value()))
+                verbosity_value = int(self.verbosity_row.get_value())
+                self.config.set_setting('ssh.verbosity', verbosity_value)
             if hasattr(self, 'debug_enabled_row'):
-                self.config.set_setting('ssh.debug_enabled', bool(self.debug_enabled_row.get_active()))
+                debug_enabled = bool(self.debug_enabled_row.get_active())
+                self.config.set_setting('ssh.debug_enabled', debug_enabled)
+
+            overrides: List[str] = []
+            if apply_advanced_enabled:
+                if batch_mode_enabled:
+                    overrides.extend(['-o', 'BatchMode=yes'])
+                if connect_timeout is not None:
+                    overrides.extend(['-o', f'ConnectTimeout={connect_timeout}'])
+                if connection_attempts is not None:
+                    overrides.extend(['-o', f'ConnectionAttempts={connection_attempts}'])
+                if keepalive_interval is not None:
+                    overrides.extend(['-o', f'ServerAliveInterval={keepalive_interval}'])
+                if keepalive_count is not None:
+                    overrides.extend(['-o', f'ServerAliveCountMax={keepalive_count}'])
+                if strict_host_value:
+                    overrides.extend(['-o', f'StrictHostKeyChecking={strict_host_value}'])
+                if compression_enabled:
+                    overrides.append('-C')
+
+                safe_verbosity = max(0, min(3, verbosity_value))
+                for _ in range(safe_verbosity):
+                    overrides.append('-v')
+
+                log_level = None
+                if safe_verbosity == 1:
+                    log_level = 'VERBOSE'
+                elif safe_verbosity == 2:
+                    log_level = 'DEBUG2'
+                elif safe_verbosity >= 3:
+                    log_level = 'DEBUG3'
+                elif debug_enabled:
+                    log_level = 'DEBUG'
+
+                if log_level:
+                    overrides.extend(['-o', f'LogLevel={log_level}'])
+            else:
+                overrides = []
+
+            self.config.set_setting('ssh.ssh_overrides', overrides)
             if getattr(self, 'force_internal_file_manager_row', None) is not None:
                 self.config.set_setting(
                     'file_manager.force_internal',
@@ -1801,6 +1861,7 @@ class PreferencesWindow(Gtk.Window):
             defaults = self.config.get_default_config().get('ssh', {})
             # Persist defaults and ensure advanced options are disabled
             self.config.set_setting('ssh.apply_advanced', False)
+            self.config.set_setting('ssh.ssh_overrides', [])
 
             if update_toggle and hasattr(self, 'apply_advanced_row'):
                 self.apply_advanced_row.set_active(False)

--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -1,0 +1,147 @@
+import asyncio
+
+from sshpilot.connection_manager import Connection
+from sshpilot.preferences import PreferencesWindow
+
+
+class DummyConfig:
+    def __init__(self):
+        self.settings = {}
+        self.default_config = {
+            'ssh': {
+                'connection_timeout': 30,
+                'connection_attempts': 1,
+                'keepalive_interval': 60,
+                'keepalive_count_max': 3,
+                'auto_add_host_keys': True,
+                'batch_mode': True,
+                'compression': False,
+                'verbosity': 0,
+                'debug_enabled': False,
+                'ssh_overrides': [],
+            },
+            'file_manager': {
+                'force_internal': False,
+                'open_externally': False,
+            },
+        }
+
+    def set_setting(self, key, value):
+        self.settings[key] = value
+
+    def get_setting(self, key, default=None):
+        return self.settings.get(key, default)
+
+    def get_default_config(self):
+        return {
+            'ssh': dict(self.default_config['ssh']),
+            'file_manager': dict(self.default_config['file_manager']),
+        }
+
+
+class DummySwitchRow:
+    def __init__(self, active=False):
+        self._active = bool(active)
+
+    def get_active(self):
+        return self._active
+
+    def set_active(self, value):
+        self._active = bool(value)
+
+
+class DummySpinRow:
+    def __init__(self, value=0):
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+    def set_value(self, value):
+        self._value = value
+
+
+class DummyComboRow:
+    def __init__(self, selected=0):
+        self._selected = selected
+
+    def get_selected(self):
+        return self._selected
+
+    def set_selected(self, value):
+        self._selected = value
+
+
+def _build_preferences(**values):
+    prefs = PreferencesWindow.__new__(PreferencesWindow)
+    prefs.config = values.get('config', DummyConfig())
+    prefs.parent_window = values.get('parent_window', None)
+    prefs.apply_advanced_row = values.get('apply_advanced_row', DummySwitchRow(True))
+    prefs.native_connect_row = values.get('native_connect_row', DummySwitchRow(True))
+    prefs.connect_timeout_row = values.get('connect_timeout_row', DummySpinRow(12))
+    prefs.connection_attempts_row = values.get('connection_attempts_row', DummySpinRow(4))
+    prefs.keepalive_interval_row = values.get('keepalive_interval_row', DummySpinRow(45))
+    prefs.keepalive_count_row = values.get('keepalive_count_row', DummySpinRow(6))
+    prefs.strict_host_row = values.get('strict_host_row', DummyComboRow(1))
+    prefs.batch_mode_row = values.get('batch_mode_row', DummySwitchRow(True))
+    prefs.compression_row = values.get('compression_row', DummySwitchRow(True))
+    prefs.verbosity_row = values.get('verbosity_row', DummySpinRow(2))
+    prefs.debug_enabled_row = values.get('debug_enabled_row', DummySwitchRow(True))
+    prefs.force_internal_file_manager_row = values.get('force_internal_file_manager_row', None)
+    prefs.open_file_manager_externally_row = values.get('open_file_manager_externally_row', None)
+    return prefs
+
+
+def test_save_advanced_ssh_settings_persists_overrides():
+    prefs = _build_preferences()
+    prefs.save_advanced_ssh_settings()
+
+    overrides = prefs.config.settings.get('ssh.ssh_overrides')
+    assert overrides == [
+        '-o', 'BatchMode=yes',
+        '-o', 'ConnectTimeout=12',
+        '-o', 'ConnectionAttempts=4',
+        '-o', 'ServerAliveInterval=45',
+        '-o', 'ServerAliveCountMax=6',
+        '-o', 'StrictHostKeyChecking=yes',
+        '-C',
+        '-v', '-v',
+        '-o', 'LogLevel=DEBUG2',
+    ]
+
+
+def test_apply_default_clears_overrides():
+    config = DummyConfig()
+    config.set_setting('ssh.ssh_overrides', ['-o', 'Something'])
+    prefs = _build_preferences(config=config)
+
+    prefs._apply_default_advanced_settings()
+
+    assert prefs.config.settings['ssh.ssh_overrides'] == []
+    assert prefs.apply_advanced_row.get_active() is False
+
+
+def test_native_connect_appends_stored_overrides(monkeypatch):
+    overrides = ['-o', 'ConnectTimeout=10', '-C']
+
+    class NativeConfig:
+        def get_ssh_config(self):
+            return {
+                'apply_advanced': True,
+                'native_connect': True,
+                'ssh_overrides': overrides,
+            }
+
+    monkeypatch.setattr('sshpilot.config.Config', lambda: NativeConfig())
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        connection = Connection({'host': 'example.com', 'nickname': 'example'})
+        result = loop.run_until_complete(connection.native_connect())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    assert result is True
+    assert connection.ssh_cmd == ['ssh', '-o', 'ConnectTimeout=10', '-C', 'example.com']


### PR DESCRIPTION
## Summary
- Build and persist SSH override flags when saving advanced preferences and add config support for the stored list.
- Append saved overrides to the native SSH command when native mode runs with advanced options enabled.
- Add regression tests covering override persistence/reset and native-mode command behavior.

## Testing
- pytest tests/test_ssh_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68e03350422c8328908e95eae41897a7