### PR TITLE
Always apply advanced SSH settings

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -1133,7 +1133,7 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`__init__(parent_window, config)`** — Handles init.
 
-- **`_apply_default_advanced_settings(update_toggle=True)`** — Restore advanced SSH settings to defaults and update the UI.
+- **`_apply_default_advanced_settings()`** — Restore advanced SSH settings to defaults and update the UI.
 
 - **`_is_internal_file_manager_enabled()`** — Return ``True`` when the application uses the built-in file manager.
 

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -594,7 +594,6 @@ class Config(GObject.Object):
         """
 
         defaults: Dict[str, Any] = {
-            'apply_advanced': False,
             'auto_add_host_keys': True,
             'batch_mode': True,
             'compression': False,
@@ -611,7 +610,6 @@ class Config(GObject.Object):
         }
 
         bool_keys = {
-            'apply_advanced',
             'auto_add_host_keys',
             'batch_mode',
             'compression',
@@ -851,6 +849,9 @@ class Config(GObject.Object):
             config['ssh'] = default_ssh
             updated = True
             ssh_cfg = config['ssh']
+        elif 'apply_advanced' in ssh_cfg:
+            del ssh_cfg['apply_advanced']
+            updated = True
         if 'use_isolated_config' not in ssh_cfg:
             ssh_cfg['use_isolated_config'] = False
             updated = True

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1118,18 +1118,16 @@ class AsyncSFTPManager(GObject.GObject):
             except (TypeError, ValueError):
                 return default
 
-        apply_advanced = bool(ssh_cfg.get("apply_advanced", False))
         keepalive_interval = 0
         keepalive_count_max = 0
-        if apply_advanced:
-            keepalive_interval = max(
-                0,
-                _coerce_int(ssh_cfg.get("keepalive_interval", 60), 60),
-            )
-            keepalive_count_max = max(
-                0,
-                _coerce_int(ssh_cfg.get("keepalive_count_max", 3), 3),
-            )
+        keepalive_interval = max(
+            0,
+            _coerce_int(ssh_cfg.get("keepalive_interval", 60), 60),
+        )
+        keepalive_count_max = max(
+            0,
+            _coerce_int(ssh_cfg.get("keepalive_count_max", 3), 3),
+        )
 
         with self._lock:
             self._keepalive_interval = keepalive_interval

--- a/tests/test_config_upgrade.py
+++ b/tests/test_config_upgrade.py
@@ -98,7 +98,6 @@ def test_get_ssh_config_defaults(tmp_path, monkeypatch):
 
     assert ssh_cfg['strict_host_key_checking'] == 'accept-new'
     assert ssh_cfg['batch_mode'] is True
-    assert ssh_cfg['apply_advanced'] is False
 
 
 def test_get_ssh_config_respects_saved_values(tmp_path, monkeypatch):

--- a/tests/test_file_manager_auth.py
+++ b/tests/test_file_manager_auth.py
@@ -427,7 +427,6 @@ def test_async_sftp_manager_configures_keepalive(monkeypatch):
         connection_manager=None,
         ssh_config={
             "auto_add_host_keys": True,
-            "apply_advanced": True,
             "keepalive_interval": 5,
             "keepalive_count_max": 2,
         },

--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -76,7 +76,6 @@ def _build_preferences(**values):
     prefs = PreferencesWindow.__new__(PreferencesWindow)
     prefs.config = values.get('config', DummyConfig())
     prefs.parent_window = values.get('parent_window', None)
-    prefs.apply_advanced_row = values.get('apply_advanced_row', DummySwitchRow(True))
     prefs.native_connect_row = values.get('native_connect_row', DummySwitchRow(True))
     prefs.connect_timeout_row = values.get('connect_timeout_row', DummySpinRow(12))
     prefs.connection_attempts_row = values.get('connection_attempts_row', DummySpinRow(4))
@@ -117,8 +116,14 @@ def test_apply_default_clears_overrides():
 
     prefs._apply_default_advanced_settings()
 
-    assert prefs.config.settings['ssh.ssh_overrides'] == []
-    assert prefs.apply_advanced_row.get_active() is False
+    assert prefs.config.settings['ssh.ssh_overrides'] == [
+        '-o', 'BatchMode=yes',
+        '-o', 'ConnectTimeout=30',
+        '-o', 'ConnectionAttempts=1',
+        '-o', 'ServerAliveInterval=60',
+        '-o', 'ServerAliveCountMax=3',
+        '-o', 'StrictHostKeyChecking=accept-new',
+    ]
 
 
 def test_native_connect_appends_stored_overrides(monkeypatch):
@@ -127,7 +132,6 @@ def test_native_connect_appends_stored_overrides(monkeypatch):
     class NativeConfig:
         def get_ssh_config(self):
             return {
-                'apply_advanced': True,
                 'native_connect': True,
                 'ssh_overrides': overrides,
             }


### PR DESCRIPTION
## Summary
- remove the "Use custom connection options" toggle from preferences and persist advanced SSH overrides directly from each control
- drop the legacy `ssh.apply_advanced` config handling and ensure components (terminal, connection manager, file manager, ssh utils) always honour the saved advanced options
- refresh related documentation and tests to match the always-on advanced behaviour

## Testing
- pytest *(fails: import errors for optional Gtk/Graphene components in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c776bbec8328b4d6b47038dc45e6