### PR TITLE
Ensure native SSH overrides apply regardless of native toggle

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -497,7 +497,6 @@ class Connection:
             except Exception:
                 ssh_cfg = {}
 
-            native_toggle = bool(ssh_cfg.get('native_connect', False))
             overrides = ssh_cfg.get('ssh_overrides', [])
             sanitized_overrides: List[str] = []
             if isinstance(overrides, (list, tuple)):
@@ -508,7 +507,7 @@ class Connection:
                     if flag:
                         sanitized_overrides.append(flag)
 
-            if native_toggle and sanitized_overrides:
+            if sanitized_overrides:
                 ssh_cmd.extend(sanitized_overrides)
 
             ssh_cmd.append(host_label)

--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -126,13 +126,13 @@ def test_apply_default_clears_overrides():
     ]
 
 
-def test_native_connect_appends_stored_overrides(monkeypatch):
+def test_native_connect_appends_overrides_even_when_native_disabled(monkeypatch):
     overrides = ['-o', 'ConnectTimeout=10', '-C']
 
     class NativeConfig:
         def get_ssh_config(self):
             return {
-                'native_connect': True,
+                'native_connect': False,
                 'ssh_overrides': overrides,
             }
 


### PR DESCRIPTION
## Summary
- ensure `Connection.native_connect` always applies saved SSH overrides when present
- adjust regression test to cover overrides being honored even when the native connect flag is false

## Testing
- pytest tests/test_ssh_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68e0cc6d73008328a7379b54ffc3031f