### PR TITLE
Update BatchMode defaults to be disabled

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -188,6 +188,7 @@ class Config(GObject.Object):
                 'keepalive_interval': 60,
                 'compression': False,
                 'auto_add_host_keys': True,
+                'batch_mode': False,
                 'verbosity': 0,
                 'debug_enabled': False,
                 'native_connect': False,
@@ -595,7 +596,7 @@ class Config(GObject.Object):
 
         defaults: Dict[str, Any] = {
             'auto_add_host_keys': True,
-            'batch_mode': True,
+            'batch_mode': False,
             'compression': False,
             'connection_attempts': 1,
             'connection_timeout': 30,

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -643,7 +643,7 @@ class Connection:
             keepalive_interval = int(ssh_cfg.get('keepalive_interval', 30))
             keepalive_count = int(ssh_cfg.get('keepalive_count_max', 3))
             strict_host = str(ssh_cfg.get('strict_host_key_checking', 'accept-new'))
-            batch_mode = bool(ssh_cfg.get('batch_mode', True))
+            batch_mode = bool(ssh_cfg.get('batch_mode', False))
 
             # Robust non-interactive options to prevent hangs
             if batch_mode:

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -1104,7 +1104,7 @@ class PreferencesWindow(Gtk.Window):
             # BatchMode (non-interactive)
             self.batch_mode_row = Adw.SwitchRow()
             self.batch_mode_row.set_title("BatchMode (disable prompts)")
-            self.batch_mode_row.set_active(bool(self.config.get_setting('ssh.batch_mode', True)))
+            self.batch_mode_row.set_active(bool(self.config.get_setting('ssh.batch_mode', False)))
             advanced_group.add(self.batch_mode_row)
 
             # Compression
@@ -1862,8 +1862,8 @@ class PreferencesWindow(Gtk.Window):
                 self.config.set_setting('ssh.strict_host_key_checking', 'accept-new')
             self.config.set_setting('ssh.auto_add_host_keys', defaults.get('auto_add_host_keys'))
             if hasattr(self, 'batch_mode_row'):
-                self.config.set_setting('ssh.batch_mode', bool(defaults.get('batch_mode', True)))
-                self.batch_mode_row.set_active(bool(defaults.get('batch_mode', True)))
+                self.config.set_setting('ssh.batch_mode', bool(defaults.get('batch_mode', False)))
+                self.batch_mode_row.set_active(bool(defaults.get('batch_mode', False)))
             if hasattr(self, 'compression_row'):
                 self.config.set_setting('ssh.compression', bool(defaults.get('compression', False)))
                 self.compression_row.set_active(bool(defaults.get('compression', False)))

--- a/tests/test_config_upgrade.py
+++ b/tests/test_config_upgrade.py
@@ -97,7 +97,7 @@ def test_get_ssh_config_defaults(tmp_path, monkeypatch):
     ssh_cfg = cfg.get_ssh_config()
 
     assert ssh_cfg['strict_host_key_checking'] == 'accept-new'
-    assert ssh_cfg['batch_mode'] is True
+    assert ssh_cfg['batch_mode'] is False
 
 
 def test_get_ssh_config_respects_saved_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- set the BatchMode SSH option to default to disabled across configuration, UI, and connection manager usage
- update preference handling and tests so BatchMode=yes is only emitted when explicitly enabled
- refresh configuration defaults to keep generated overrides aligned with the new baseline

## Testing
- pytest *(fails: environment lacks several gi repository stubs such as Graphene)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dd0137bc8328ae73613c0d59384d