### PR TITLE
Stop overriding SSH retry and keepalive defaults

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1114,20 +1114,13 @@ class AsyncSFTPManager(GObject.GObject):
 
         def _coerce_int(value: Any, default: int) -> int:
             try:
-                return int(str(value))
+                coerced = int(str(value))
+                return coerced if coerced > 0 else default
             except (TypeError, ValueError):
                 return default
 
-        keepalive_interval = 0
-        keepalive_count_max = 0
-        keepalive_interval = max(
-            0,
-            _coerce_int(ssh_cfg.get("keepalive_interval", 60), 60),
-        )
-        keepalive_count_max = max(
-            0,
-            _coerce_int(ssh_cfg.get("keepalive_count_max", 3), 3),
-        )
+        keepalive_interval = max(0, _coerce_int(ssh_cfg.get("keepalive_interval"), 0))
+        keepalive_count_max = max(0, _coerce_int(ssh_cfg.get("keepalive_count_max"), 0))
 
         with self._lock:
             self._keepalive_interval = keepalive_interval

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -1062,27 +1062,55 @@ class PreferencesWindow(Gtk.Window):
 
 
             # Connect timeout
-            self.connect_timeout_row = Adw.SpinRow.new_with_range(1, 120, 1)
+            self.connect_timeout_row = Adw.SpinRow.new_with_range(0, 120, 1)
             self.connect_timeout_row.set_title("Connect Timeout (s)")
-            self.connect_timeout_row.set_value(self.config.get_setting('ssh.connection_timeout', 10))
+            connect_timeout_value = self.config.get_setting('ssh.connection_timeout', None)
+            try:
+                connect_timeout_value = int(connect_timeout_value)
+            except (TypeError, ValueError):
+                connect_timeout_value = 0
+            if connect_timeout_value < 0:
+                connect_timeout_value = 0
+            self.connect_timeout_row.set_value(connect_timeout_value)
             advanced_group.add(self.connect_timeout_row)
 
             # Connection attempts
-            self.connection_attempts_row = Adw.SpinRow.new_with_range(1, 10, 1)
+            self.connection_attempts_row = Adw.SpinRow.new_with_range(0, 10, 1)
             self.connection_attempts_row.set_title("Connection Attempts")
-            self.connection_attempts_row.set_value(self.config.get_setting('ssh.connection_attempts', 1))
+            connection_attempts_value = self.config.get_setting('ssh.connection_attempts', None)
+            try:
+                connection_attempts_value = int(connection_attempts_value)
+            except (TypeError, ValueError):
+                connection_attempts_value = 0
+            if connection_attempts_value < 0:
+                connection_attempts_value = 0
+            self.connection_attempts_row.set_value(connection_attempts_value)
             advanced_group.add(self.connection_attempts_row)
 
             # Keepalive interval
             self.keepalive_interval_row = Adw.SpinRow.new_with_range(0, 300, 5)
             self.keepalive_interval_row.set_title("ServerAlive Interval (s)")
-            self.keepalive_interval_row.set_value(self.config.get_setting('ssh.keepalive_interval', 30))
+            keepalive_interval_value = self.config.get_setting('ssh.keepalive_interval', None)
+            try:
+                keepalive_interval_value = int(keepalive_interval_value)
+            except (TypeError, ValueError):
+                keepalive_interval_value = 0
+            if keepalive_interval_value < 0:
+                keepalive_interval_value = 0
+            self.keepalive_interval_row.set_value(keepalive_interval_value)
             advanced_group.add(self.keepalive_interval_row)
 
             # Keepalive count max
-            self.keepalive_count_row = Adw.SpinRow.new_with_range(1, 10, 1)
+            self.keepalive_count_row = Adw.SpinRow.new_with_range(0, 10, 1)
             self.keepalive_count_row.set_title("ServerAlive CountMax")
-            self.keepalive_count_row.set_value(self.config.get_setting('ssh.keepalive_count_max', 3))
+            keepalive_count_value = self.config.get_setting('ssh.keepalive_count_max', None)
+            try:
+                keepalive_count_value = int(keepalive_count_value)
+            except (TypeError, ValueError):
+                keepalive_count_value = 0
+            if keepalive_count_value < 0:
+                keepalive_count_value = 0
+            self.keepalive_count_row.set_value(keepalive_count_value)
             advanced_group.add(self.keepalive_count_row)
 
             # Strict host key checking
@@ -1755,16 +1783,32 @@ class PreferencesWindow(Gtk.Window):
                 if self.parent_window and hasattr(self.parent_window, 'connection_manager'):
                     self.parent_window.connection_manager.native_connect_enabled = native_value
             if hasattr(self, 'connect_timeout_row'):
-                connect_timeout = int(self.connect_timeout_row.get_value())
+                connect_timeout_value = int(self.connect_timeout_row.get_value())
+                if connect_timeout_value <= 0:
+                    connect_timeout = None
+                else:
+                    connect_timeout = connect_timeout_value
                 self.config.set_setting('ssh.connection_timeout', connect_timeout)
             if hasattr(self, 'connection_attempts_row'):
-                connection_attempts = int(self.connection_attempts_row.get_value())
+                connection_attempts_value = int(self.connection_attempts_row.get_value())
+                if connection_attempts_value <= 0:
+                    connection_attempts = None
+                else:
+                    connection_attempts = connection_attempts_value
                 self.config.set_setting('ssh.connection_attempts', connection_attempts)
             if hasattr(self, 'keepalive_interval_row'):
-                keepalive_interval = int(self.keepalive_interval_row.get_value())
+                keepalive_interval_value = int(self.keepalive_interval_row.get_value())
+                if keepalive_interval_value <= 0:
+                    keepalive_interval = None
+                else:
+                    keepalive_interval = keepalive_interval_value
                 self.config.set_setting('ssh.keepalive_interval', keepalive_interval)
             if hasattr(self, 'keepalive_count_row'):
-                keepalive_count = int(self.keepalive_count_row.get_value())
+                keepalive_count_value = int(self.keepalive_count_row.get_value())
+                if keepalive_count_value <= 0:
+                    keepalive_count = None
+                else:
+                    keepalive_count = keepalive_count_value
                 self.config.set_setting('ssh.keepalive_count_max', keepalive_count)
             if hasattr(self, 'strict_host_row'):
                 options = ["accept-new", "yes", "no", "ask"]
@@ -1843,17 +1887,17 @@ class PreferencesWindow(Gtk.Window):
             defaults = self.config.get_default_config().get('ssh', {})
 
             if hasattr(self, 'connect_timeout_row'):
-                self.config.set_setting('ssh.connection_timeout', defaults.get('connection_timeout'))
-                self.connect_timeout_row.set_value(int(defaults.get('connection_timeout', 30)))
+                self.config.set_setting('ssh.connection_timeout', None)
+                self.connect_timeout_row.set_value(0)
             if hasattr(self, 'connection_attempts_row'):
-                self.config.set_setting('ssh.connection_attempts', defaults.get('connection_attempts'))
-                self.connection_attempts_row.set_value(int(defaults.get('connection_attempts', 1)))
+                self.config.set_setting('ssh.connection_attempts', None)
+                self.connection_attempts_row.set_value(0)
             if hasattr(self, 'keepalive_interval_row'):
-                self.config.set_setting('ssh.keepalive_interval', defaults.get('keepalive_interval'))
-                self.keepalive_interval_row.set_value(int(defaults.get('keepalive_interval', 60)))
+                self.config.set_setting('ssh.keepalive_interval', None)
+                self.keepalive_interval_row.set_value(0)
             if hasattr(self, 'keepalive_count_row'):
-                self.config.set_setting('ssh.keepalive_count_max', defaults.get('keepalive_count_max'))
-                self.keepalive_count_row.set_value(int(defaults.get('keepalive_count_max', 3)))
+                self.config.set_setting('ssh.keepalive_count_max', None)
+                self.keepalive_count_row.set_value(0)
             if hasattr(self, 'strict_host_row'):
                 try:
                     self.strict_host_row.set_selected(["accept-new", "yes", "no", "ask"].index('accept-new'))

--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -301,8 +301,6 @@ def _verify_ssh_connection(user: str, host: str, port: Optional[int]) -> bool:
     ssh_cmd = [
         "ssh",
         "-o",
-        "ConnectTimeout=10",
-        "-o",
         "StrictHostKeyChecking=accept-new",
     ]
 
@@ -871,7 +869,7 @@ def _try_command_line_mount(
         sshfs_cmd.extend(
             [
                 "-o",
-                "reconnect,ServerAliveInterval=15,ServerAliveCountMax=3",
+                "reconnect",
                 f"{user}@{host}:/",
                 mount_point,
             ]

--- a/sshpilot/ssh_password_exec.py
+++ b/sshpilot/ssh_password_exec.py
@@ -44,8 +44,6 @@ def run_ssh_with_password(host: str, user: str, password: str, *,
         ssh_opts += ["-o", "PreferredAuthentications=password"]
     ssh_opts += [
         "-o", "NumberOfPasswordPrompts=1",
-        "-o", "ServerAliveInterval=30",
-        "-o", "ServerAliveCountMax=3",
     ]
     if known_hosts_path:
         ssh_opts += ["-o", f"UserKnownHostsFile={known_hosts_path}",

--- a/sshpilot/ssh_utils.py
+++ b/sshpilot/ssh_utils.py
@@ -44,7 +44,10 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
 
     def _coerce_int(value, default=None):
         try:
-            return int(str(value))
+            coerced = int(str(value))
+            if coerced <= 0:
+                return default
+            return coerced
         except (TypeError, ValueError):
             return default
 

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -643,7 +643,10 @@ class TerminalWidget(Gtk.Box):
 
                 def _coerce_int(value, default=None):
                     try:
-                        return int(str(value))
+                        coerced = int(str(value))
+                        if coerced <= 0:
+                            return default
+                        return coerced
                     except (TypeError, ValueError):
                         return default
 

--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -9,16 +9,13 @@ class DummyConfig:
         self.settings = {}
         self.default_config = {
             'ssh': {
-                'connection_timeout': 30,
-                'connection_attempts': 1,
-                'keepalive_interval': 60,
-                'keepalive_count_max': 3,
                 'auto_add_host_keys': True,
                 'batch_mode': False,
                 'compression': False,
                 'verbosity': 0,
                 'debug_enabled': False,
                 'ssh_overrides': [],
+                'strict_host_key_checking': 'accept-new',
             },
             'file_manager': {
                 'force_internal': False,
@@ -117,10 +114,6 @@ def test_apply_default_clears_overrides():
     prefs._apply_default_advanced_settings()
 
     assert prefs.config.settings['ssh.ssh_overrides'] == [
-        '-o', 'ConnectTimeout=30',
-        '-o', 'ConnectionAttempts=1',
-        '-o', 'ServerAliveInterval=60',
-        '-o', 'ServerAliveCountMax=3',
         '-o', 'StrictHostKeyChecking=accept-new',
     ]
 


### PR DESCRIPTION
## Summary
- remove baked-in SSH retry/keepalive defaults from the config and preference reset paths while keeping StrictHostKeyChecking on accept-new
- treat advanced SSH spin boxes as optional so saved commands only include connect/keepalive options when explicitly configured
- drop hard-coded keepalive/timeout flags from connection helpers (ssh, sshfs, sftp, sshpass) and update tests for the slimmer default override set

## Testing
- pytest *(fails: requires GI Graphene bindings and related components in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e07cce1483288a95f12e432d01af