### PR TITLE
Add built-in SFTP file manager preferences

### DIFF
--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -20,6 +20,9 @@ class DummyConfig:
             'file_manager': {
                 'force_internal': False,
                 'open_externally': False,
+                'sftp_keepalive_interval': 30,
+                'sftp_keepalive_count_max': 5,
+                'sftp_connect_timeout': 20,
             },
         }
 
@@ -33,6 +36,27 @@ class DummyConfig:
         return {
             'ssh': dict(self.default_config['ssh']),
             'file_manager': dict(self.default_config['file_manager']),
+        }
+
+    def get_file_manager_config(self):
+        defaults = self.default_config['file_manager']
+
+        def _bool(setting_key, default):
+            return bool(self.settings.get(setting_key, default))
+
+        def _int(setting_key, default):
+            value = self.settings.get(setting_key, default)
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return int(default)
+
+        return {
+            'force_internal': _bool('file_manager.force_internal', defaults['force_internal']),
+            'open_externally': _bool('file_manager.open_externally', defaults['open_externally']),
+            'sftp_keepalive_interval': _int('file_manager.sftp_keepalive_interval', defaults['sftp_keepalive_interval']),
+            'sftp_keepalive_count_max': _int('file_manager.sftp_keepalive_count_max', defaults['sftp_keepalive_count_max']),
+            'sftp_connect_timeout': _int('file_manager.sftp_connect_timeout', defaults['sftp_connect_timeout']),
         }
 
 
@@ -85,6 +109,9 @@ def _build_preferences(**values):
     prefs.debug_enabled_row = values.get('debug_enabled_row', DummySwitchRow(True))
     prefs.force_internal_file_manager_row = values.get('force_internal_file_manager_row', None)
     prefs.open_file_manager_externally_row = values.get('open_file_manager_externally_row', None)
+    prefs.sftp_keepalive_interval_row = values.get('sftp_keepalive_interval_row', DummySpinRow(30))
+    prefs.sftp_keepalive_count_row = values.get('sftp_keepalive_count_row', DummySpinRow(5))
+    prefs.sftp_connect_timeout_row = values.get('sftp_connect_timeout_row', DummySpinRow(20))
     return prefs
 
 


### PR DESCRIPTION
## Summary
- add defaults and accessors for SFTP keepalive and timeout settings in the configuration layer
- surface built-in SFTP keepalive and timeout controls in the preferences dialog with clear messaging
- honor the new settings inside the file manager connection logic and update supporting tests

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0e5c05a5c8328a91be0f315d5fc6a