### PR TITLE
Propagate ProxyJump timeouts in the file manager

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -954,6 +954,7 @@ class AsyncSFTPManager(GObject.GObject):
         resolved_host: str,
         resolved_port: int,
         base_username: str,
+        connect_timeout: Optional[int] = None,
     ) -> Tuple[Any, List[paramiko.SSHClient]]:
         """Create a socket by chaining SSH connections through jump hosts."""
 
@@ -1461,6 +1462,7 @@ class AsyncSFTPManager(GObject.GObject):
                     resolved_host=resolved_host,
                     resolved_port=resolved_port,
                     base_username=resolved_username,
+                    connect_timeout=connect_timeout,
                 )
                 logger.debug(
                     "File manager: using Paramiko ProxyJump chain via %s",

--- a/tests/test_file_manager_auth.py
+++ b/tests/test_file_manager_auth.py
@@ -347,6 +347,50 @@ def test_async_sftp_manager_builds_proxy_jump_chain(monkeypatch):
     assert proxy_channel.closed
 
 
+def test_async_sftp_manager_proxy_jump_timeout(monkeypatch):
+    module = _load_file_manager_module(monkeypatch)
+
+    module._fake_ssh_config.config_map.update(
+        {
+            "Router": {"hostname": "router.internal", "user": "gateway", "port": "2201"},
+        }
+    )
+
+    connection = types.SimpleNamespace(
+        hostname="example.com",
+        host="example.com",
+        username="alice",
+        auth_method=0,
+        key_select_mode=0,
+        proxy_jump=["Router"],
+    )
+
+    manager = module.AsyncSFTPManager(
+        "example.com",
+        "alice",
+        port=2222,
+        connection=connection,
+        connection_manager=None,
+        ssh_config={
+            "auto_add_host_keys": True,
+            "connection_timeout": 19,
+            "file_manager": {"sftp_connect_timeout": 25},
+        },
+    )
+
+    manager._connect_impl()
+
+    assert len(DummyClient.instances) == 2
+    target_client = DummyClient.instances[0]
+    jump_client = DummyClient.instances[1]
+
+    jump_kwargs = jump_client.connect_calls[-1]
+    assert jump_kwargs.get("timeout") == 25
+
+    target_kwargs = target_client.connect_calls[-1]
+    assert target_kwargs.get("timeout") == 25
+
+
 def test_async_sftp_manager_uses_effective_host_settings(monkeypatch):
     module = _load_file_manager_module(monkeypatch)
 


### PR DESCRIPTION
## Summary
- add an explicit connect_timeout parameter when creating ProxyJump sockets
- propagate the computed timeout through ProxyJump hops and the final SFTP connection
- cover ProxyJump timeout propagation with a dedicated unit test

## Testing
- pytest tests/test_file_manager_auth.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0eac1de6c83289c8f99f415d43054