### PR TITLE
Default to welcome screen on startup

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -754,12 +754,12 @@ class PreferencesWindow(Gtk.Window):
             # Make them behave like radio buttons
             self.welcome_startup_radio.set_group(self.terminal_startup_radio)
 
-            # Set current preference (default to terminal)
-            startup_behavior = self.config.get_setting('app-startup-behavior', 'terminal')
-            if startup_behavior == 'welcome':
-                self.welcome_startup_radio.set_active(True)
-            else:
+            # Set current preference (default to welcome/start page)
+            startup_behavior = self.config.get_setting('app-startup-behavior', 'welcome')
+            if startup_behavior == 'terminal':
                 self.terminal_startup_radio.set_active(True)
+            else:
+                self.welcome_startup_radio.set_active(True)
 
             # Connect radio button changes
             self.terminal_startup_radio.connect('toggled', self.on_startup_behavior_changed)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -240,20 +240,14 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
         # Check startup behavior setting and show appropriate view
         try:
-            startup_behavior = self.config.get_setting('app-startup-behavior', 'terminal')
+            startup_behavior = self.config.get_setting('app-startup-behavior', 'welcome')
         except Exception as e:
             logger.error(f"Error handling startup behavior: {e}")
-            startup_behavior = 'terminal'
+            startup_behavior = 'welcome'
 
         # On startup, focus the appropriate widget based on preference
-        if startup_behavior == 'welcome':
-            # Delay focus to ensure the UI is fully set up
-            try:
-                GLib.timeout_add(100, self._focus_connection_list_first_row)
-            except Exception:
-                pass
-        else:
-            # Default to terminal behavior for unknown preferences
+        if startup_behavior == 'terminal':
+            # Show terminal when explicitly requested
             try:
                 GLib.idle_add(self.terminal_manager.show_local_terminal)
             except Exception as e:
@@ -276,6 +270,12 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
 
             # Queue terminal focus operation to avoid race conditions
             self._queue_focus_operation(_focus_terminal_when_ready)
+        else:
+            # Delay focus to ensure the UI is fully set up
+            try:
+                GLib.timeout_add(100, self._focus_connection_list_first_row)
+            except Exception:
+                pass
 
         # Mark startup as complete after a short delay to allow all initialization to finish
         GLib.timeout_add(500, self._on_startup_complete)

--- a/tests/test_startup_behavior.py
+++ b/tests/test_startup_behavior.py
@@ -1,0 +1,122 @@
+import sys
+import types
+
+
+def _ensure_cairo_stub():
+    if 'cairo' not in sys.modules:
+        sys.modules['cairo'] = types.SimpleNamespace()
+
+
+def _setup_glib_stub(window_module, calls, monkeypatch):
+    """Install GLib stubs that track idle and timeout usage."""
+
+    def idle_add(callback, *args, **kwargs):
+        calls.setdefault('idle', []).append(callback)
+        if callable(callback):
+            callback(*args, **kwargs)
+        return 0
+
+    def timeout_add(interval, callback, *args, **kwargs):
+        calls.setdefault('timeout', []).append(interval)
+        if callable(callback):
+            callback(*args, **kwargs)
+        return 0
+
+    monkeypatch.setattr(window_module.GLib, 'idle_add', idle_add, raising=False)
+    monkeypatch.setattr(window_module.GLib, 'timeout_add', timeout_add, raising=False)
+
+
+def _build_main_window(window_module, startup_value, calls):
+    window = window_module.MainWindow.__new__(window_module.MainWindow)
+    window._startup_tasks_scheduled = False
+    window._pending_focus_operations = []
+    window._startup_complete = False
+    window._install_sidebar_css = lambda: None
+    window._queue_focus_operation = lambda func: calls.setdefault('queued', []).append(func)
+    window._on_startup_complete = lambda: calls.setdefault('startup_complete', []).append(True) or False
+    window._focus_connection_list_first_row = lambda: calls.setdefault('welcome_focus', []).append(True)
+
+    class StubConfig:
+        def get_setting(self, key, default=None):
+            if key == 'app-startup-behavior':
+                return startup_value if startup_value is not None else default
+            return default
+
+    window.config = StubConfig()
+
+    window.terminal_manager = types.SimpleNamespace(
+        show_local_terminal=lambda: calls.setdefault('terminal_shown', []).append(True)
+    )
+
+    terminal_widget = types.SimpleNamespace(
+        vte=types.SimpleNamespace(
+            grab_focus=lambda: calls.setdefault('terminal_focused', []).append(True)
+        )
+    )
+    page = types.SimpleNamespace(get_child=lambda: terminal_widget)
+    window.tab_view = types.SimpleNamespace(get_selected_page=lambda: page)
+
+    return window
+
+
+def test_startup_defaults_to_welcome(monkeypatch):
+    _ensure_cairo_stub()
+    from sshpilot import window as window_module
+
+    calls = {}
+    _setup_glib_stub(window_module, calls, monkeypatch)
+    main_window = _build_main_window(window_module, startup_value=None, calls=calls)
+
+    main_window._schedule_startup_tasks()
+
+    assert 'terminal_shown' not in calls
+    assert calls.get('welcome_focus') == [True]
+    assert 100 in calls.get('timeout', [])
+    assert calls.get('idle', []) == []
+
+
+def test_startup_honors_terminal_preference(monkeypatch):
+    _ensure_cairo_stub()
+    from sshpilot import window as window_module
+
+    calls = {}
+    _setup_glib_stub(window_module, calls, monkeypatch)
+    main_window = _build_main_window(window_module, startup_value='terminal', calls=calls)
+
+    main_window._schedule_startup_tasks()
+
+    assert calls.get('terminal_shown') == [True]
+    assert calls.get('idle')
+    assert 100 not in calls.get('timeout', [])
+    assert calls.get('queued') and callable(calls['queued'][0])
+
+
+def test_preferences_toggle_persists_choice():
+    from sshpilot import preferences
+
+    class StubConfig:
+        def __init__(self):
+            self.saved = []
+
+        def set_setting(self, key, value):
+            self.saved.append((key, value))
+
+    class StubRadio:
+        def __init__(self, active):
+            self._active = active
+
+        def get_active(self):
+            return self._active
+
+    prefs = preferences.PreferencesWindow.__new__(preferences.PreferencesWindow)
+    prefs.config = StubConfig()
+
+    prefs.terminal_startup_radio = StubRadio(active=True)
+    preferences.PreferencesWindow.on_startup_behavior_changed(prefs, None)
+    assert prefs.config.saved[-1] == ('app-startup-behavior', 'terminal')
+
+    prefs.terminal_startup_radio = StubRadio(active=False)
+    preferences.PreferencesWindow.on_startup_behavior_changed(prefs, None)
+    assert prefs.config.saved[-1] == ('app-startup-behavior', 'welcome')
+
+


### PR DESCRIPTION
## Summary
- default the startup behavior to the welcome screen when no preference is stored
- align the preferences UI so the welcome option is active by default
- add regression tests covering welcome defaults and preference persistence

## Testing
- pytest tests/test_startup_behavior.py

------
https://chatgpt.com/codex/tasks/task_e_68e112ebbd80832894646be02d7ff5e0