### PR TITLE
Ensure key prep runs for default key selection

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -758,26 +758,29 @@ class TerminalWidget(Gtk.Box):
                     except Exception:
                         pass
 
+                    keyfile_value = getattr(self.connection, 'keyfile', '') or ''
+                    has_explicit_key = bool(
+                        keyfile_value
+                        and not str(keyfile_value).startswith('Select key file')
+                        and os.path.isfile(keyfile_value)
+                    )
+
+                    if has_explicit_key and hasattr(self, 'connection_manager') and self.connection_manager:
+                        try:
+                            if hasattr(self.connection_manager, 'prepare_key_for_connection'):
+                                key_prepared = self.connection_manager.prepare_key_for_connection(keyfile_value)
+                                if key_prepared:
+                                    logger.debug(f"Key prepared for connection: {keyfile_value}")
+                                else:
+                                    logger.warning(f"Failed to prepare key for connection: {keyfile_value}")
+                        except Exception as e:
+                            logger.warning(f"Error preparing key for connection: {e}")
+
                     # Only add specific key when a dedicated key mode is selected
-                    if key_select_mode in (1, 2) and hasattr(self.connection, 'keyfile') and self.connection.keyfile and \
-                       os.path.isfile(self.connection.keyfile) and \
-                       not self.connection.keyfile.startswith('Select key file'):
-
-                        # Prepare key for connection (add to ssh-agent if needed)
-                        if hasattr(self, 'connection_manager') and self.connection_manager:
-                            try:
-                                if hasattr(self.connection_manager, 'prepare_key_for_connection'):
-                                    key_prepared = self.connection_manager.prepare_key_for_connection(self.connection.keyfile)
-                                    if key_prepared:
-                                        logger.debug(f"Key prepared for connection: {self.connection.keyfile}")
-                                    else:
-                                        logger.warning(f"Failed to prepare key for connection: {self.connection.keyfile}")
-                            except Exception as e:
-                                logger.warning(f"Error preparing key for connection: {e}")
-
-                        if self.connection.keyfile not in ssh_cmd:
-                            ssh_cmd.extend(['-i', self.connection.keyfile])
-                        logger.debug(f"Using SSH key: {self.connection.keyfile}")
+                    if has_explicit_key and key_select_mode in (1, 2):
+                        if keyfile_value not in ssh_cmd:
+                            ssh_cmd.extend(['-i', keyfile_value])
+                        logger.debug(f"Using SSH key: {keyfile_value}")
                         if key_select_mode == 1:
                             ensure_option('IdentitiesOnly=yes')
 


### PR DESCRIPTION
## Summary
- always call the connection manager to prepare an explicit keyfile even when using the default key selection mode
- keep `IdentitiesOnly` handling scoped to dedicated key selection while logging the default-mode behavior
- cover the new behavior with a terminal widget test that stubs the connection manager

## Testing
- pytest *(fails: missing optional GTK/Graphene bindings in the test environment)*
- pytest tests/test_proxy_directives.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b2f7a47883288ef065af779a3ef7