### PR TITLE
Preload first matching native key in SSH terminal

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -360,6 +360,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_resolve_config_override_path()`** — Return an absolute path to the SSH config override, if any.
 
+- **`collect_identity_file_candidates(effective_cfg=None)`** — Return resolved identity file paths that exist on disk for this host.
+
 - **`_update_properties_from_data(data)`** — Update instance properties from data dictionary
 
 - **`connect()`** — Prepare SSH command for later use (no preflight echo).


### PR DESCRIPTION
## Summary
- cache resolved identity files on Connection objects and expose a helper to enumerate them
- preload the first available identity when native SSH runs in automatic key-selection mode
- document the new helper in the function reference

## Testing
- pytest *(fails: ImportError: cannot import name 'Graphene' from 'gi.repository')*


------
https://chatgpt.com/codex/tasks/task_e_68e2c561be7c83288a2e4104e3280a7b