### PR TITLE
Load passphrase when selecting specific key

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -1006,6 +1006,27 @@ class ConnectionDialog(Adw.Window):
             if hasattr(self, 'key_only_row'):
                 self.key_only_row.set_visible(use_specific)
                 self.key_only_row.set_sensitive(use_specific)
+
+            if use_specific:
+                key_path = getattr(self, '_selected_keyfile_path', None)
+                if not key_path:
+                    try:
+                        selected = self.key_dropdown.get_selected() if hasattr(self, 'key_dropdown') else -1
+                    except Exception:
+                        selected = -1
+                    if (
+                        hasattr(self, '_key_paths')
+                        and hasattr(self, 'key_dropdown')
+                        and 0 <= selected < len(self._key_paths)
+                    ):
+                        candidate_path = self._key_paths[selected]
+                        if candidate_path and candidate_path != "__BROWSE__":
+                            key_path = candidate_path
+                if key_path:
+                    self._update_passphrase_for_key(key_path)
+            else:
+                if hasattr(self, 'key_passphrase_row'):
+                    self.key_passphrase_row.set_text("")
         except Exception:
             pass
         


### PR DESCRIPTION
## Summary
- ensure selecting "Use a specific key" immediately loads the stored passphrase for the chosen key
- clear the passphrase field when returning to automatic key selection to avoid stale credentials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e338b1bc04832895e041faa048729b