### PR TITLE
Add terminal search overlay with VTE integration

### DIFF
--- a/documentation/keyboard-shortcuts.md
+++ b/documentation/keyboard-shortcuts.md
@@ -57,6 +57,10 @@ SSH Pilot is designed for efficient keyboard navigation. This guide covers all a
 
 | Action | Linux/Windows | macOS | Description |
 |--------|---------------|-------|-------------|
+| **Search Terminal** | `Ctrl+F` | `Cmd+F` | Show the in-terminal search banner |
+| **Find Next Match** | `Ctrl+G` or `Enter` | `Cmd+G` or `Enter` | Jump to the next highlighted search result |
+| **Find Previous Match** | `Ctrl+Shift+G` or `Shift+Enter` | `Cmd+Shift+G` or `Shift+Enter` | Jump to the previous highlighted search result |
+| **Dismiss Terminal Search** | `Escape` | `Escape` | Hide the terminal search banner |
 | **Copy** | `Ctrl+Shift+C` | `Cmd+C` | Copy selected text |
 | **Paste** | `Ctrl+Shift+V` | `Cmd+V` | Paste text |
 | **Select All** | `Ctrl+Shift+A` | `Cmd+A` | Select all terminal text |


### PR DESCRIPTION
## Summary
- add a banner-styled search revealer with entry and navigation controls to terminal overlays
- implement shared VTE-backed search helpers and shortcut handling for Ctrl/Cmd+F/G navigation
- document the new terminal search shortcuts in the keyboard reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e377cb78d88328804f833a03f5919a