### PR TITLE
Allow toggling the terminal search overlay

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -2269,7 +2269,10 @@ class TerminalWidget(Gtk.Box):
             meta = bool(state & Gdk.ModifierType.META_MASK)
 
             if keyval in (Gdk.KEY_f, Gdk.KEY_F) and (primary or meta):
-                self._show_search_overlay(select_all=True)
+                if hasattr(self, 'search_revealer') and self.search_revealer.get_reveal_child():
+                    self._hide_search_overlay()
+                else:
+                    self._show_search_overlay(select_all=True)
                 return True
 
             if keyval in (Gdk.KEY_g, Gdk.KEY_G) and (primary or meta):
@@ -3126,6 +3129,10 @@ class TerminalWidget(Gtk.Box):
                     self._on_search_previous()
                 else:
                     self._on_search_next()
+                return True
+
+            if keyval in (Gdk.KEY_f, Gdk.KEY_F) and (primary or meta):
+                self._hide_search_overlay()
                 return True
 
             if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter) and shift:


### PR DESCRIPTION
## Summary
- toggle the terminal search overlay when Ctrl/Command+F is pressed repeatedly
- let the focused search entry handle Ctrl/Command+F to close the overlay

## Testing
- pytest *(fails: missing optional gi bindings and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3830e446c8328a7456f57c09746e4