### PR TITLE
Simplify accent color override handling

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -1167,8 +1167,6 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`on_accent_color_changed(color_button)`** — Handle accent color change
 
-- **`on_app_color_changed(color_button)`** — Handle app color change
-
 - **`on_close_request(*args)`** — Persist settings when the preferences window closes
 
 - **`on_color_scheme_changed(combo_row, param)`** — Handle terminal color scheme change
@@ -1187,9 +1185,7 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`on_reset_advanced_ssh(*args)`** — Reset only advanced SSH keys to defaults and update UI.
 
-- **`on_reset_colors_clicked(button)`** — Reset color overrides to default
-
-- **`on_sidebar_color_changed(color_button)`** — Handle sidebar color change
+- **`on_reset_colors_clicked(button)`** — Reset accent color override to default
 
 - **`on_startup_behavior_changed(radio_button, *args)`** — Handle startup behavior radio button change
 


### PR DESCRIPTION
## Summary
- remove the app and sidebar color override controls so the preferences dialog only manages the accent override
- streamline accent override CSS application in both the preferences dialog and application startup
- update the function reference documentation to reflect the accent-only override behavior

## Testing
- pytest *(fails: ImportError: cannot import name 'Graphene' from 'gi.repository' and other GI-related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a2eb54208328a682b9d80bb5fef5