### PR TITLE
Expose terminal search shortcut

### DIFF
--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -130,6 +130,7 @@ class SshPilotApplication(Adw.Application):
             self.create_action('open-new-connection-tab', self.on_open_new_connection_tab, ['<Meta><Alt>n'])
             self.create_action('toggle-list', self.on_toggle_list, ['<Meta>l'])
             self.create_action('search', self.on_search, ['<Meta>f'])
+            self.create_action('terminal-search', self.on_terminal_search, ['<Meta><Shift>f'])
             self.create_action('new-key', self.on_new_key, ['<Meta><Shift>k'])
             self.create_action('edit-ssh-config', self.on_edit_ssh_config, ['<Meta><Shift>e'])
             if not should_hide_file_manager_options():
@@ -142,6 +143,7 @@ class SshPilotApplication(Adw.Application):
             self.create_action('open-new-connection-tab', self.on_open_new_connection_tab, ['<primary><alt>n'])
             self.create_action('toggle-list', self.on_toggle_list, ['<primary>l'])
             self.create_action('search', self.on_search, ['<primary>f'])
+            self.create_action('terminal-search', self.on_terminal_search, ['<primary><shift>f'])
             self.create_action('new-key', self.on_new_key, ['<primary><shift>k'])
             self.create_action('edit-ssh-config', self.on_edit_ssh_config, ['<primary><shift>e'])
             if not should_hide_file_manager_options():
@@ -504,6 +506,16 @@ class SshPilotApplication(Adw.Application):
         logging.debug("Local terminal action triggered")
         if self.props.active_window:
             self.props.active_window.terminal_manager.show_local_terminal()
+
+    def on_terminal_search(self, action, param):
+        """Toggle the search overlay for the active terminal."""
+        window = self.props.active_window
+        if not window:
+            return
+
+        handler = getattr(window, 'toggle_terminal_search_overlay', None)
+        if callable(handler):
+            handler(select_all=True)
 
     def on_preferences(self, action, param):
         """Handle preferences action"""

--- a/sshpilot/shortcut_editor.py
+++ b/sshpilot/shortcut_editor.py
@@ -50,6 +50,7 @@ ACTION_LABELS: Dict[str, str] = {
     'open-new-connection-tab': _('Open New Connection Tab'),
     'toggle-list': _('Focus Connection List'),
     'search': _('Search Connections'),
+    'terminal-search': _('Search in Terminal'),
     'new-key': _('Copy Key to Server'),
     'manage-files': _('Manage Files'),
     'edit-ssh-config': _('SSH Config Editor'),
@@ -266,7 +267,7 @@ class ShortcutsPreferencesPage(PreferencesPageBase):
             'edit-ssh-config',
             'quick-connect',
         ]
-        terminal_actions = ['local-terminal', 'broadcast-command']
+        terminal_actions = ['local-terminal', 'terminal-search', 'broadcast-command']
         tab_actions = ['tab-next', 'tab-prev', 'tab-close', 'tab-overview']
 
         for name in self._action_names:


### PR DESCRIPTION
## Summary
- register a terminal-search action with platform-specific accelerators and route it to the active terminal
- show the terminal search binding in the shortcut editor and keyboard shortcut window alongside other terminal actions

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e496684a188328a729d91ba8f12f56