### PR TITLE
Disable key passphrase entry when auto-selecting keys

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -1006,6 +1006,8 @@ class ConnectionDialog(Adw.Window):
             if hasattr(self, 'key_only_row'):
                 self.key_only_row.set_visible(use_specific)
                 self.key_only_row.set_sensitive(use_specific)
+            if hasattr(self, 'key_passphrase_row'):
+                self.key_passphrase_row.set_sensitive(use_specific)
 
             if use_specific:
                 key_path = getattr(self, '_selected_keyfile_path', None)
@@ -2232,7 +2234,11 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         self.key_passphrase_row = Adw.PasswordEntryRow(title=_("Key Passphrase"))
         self.key_passphrase_row.set_show_apply_button(False)
         auth_group.add(self.key_passphrase_row)
-        
+        try:
+            self.on_key_select_changed(self.key_select_row, None)
+        except Exception:
+            pass
+
         # Password
         self.password_row = Adw.PasswordEntryRow(title=_("Password (optional)"))
         self.password_row.set_show_apply_button(False)


### PR DESCRIPTION
## Summary
- disable the key passphrase entry when automatic key selection is active in the connection dialog
- re-run the key selection change handler after creating the passphrase row so the initial sensitivity matches the selected mode

## Testing
- pytest *(fails: missing GI Graphene / optional modules in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a0d8fc4c83288b6a70c6901e1d8c