### PR TITLE
Place terminal search overlay in overlay stack

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -396,11 +396,15 @@ class TerminalWidget(Gtk.Box):
 
         self.overlay.add_overlay(self.connecting_bg)
         self.overlay.add_overlay(self.connecting_box)
+        self.overlay.add_overlay(self.search_revealer)
+        try:
+            self.overlay.set_measure_overlay(self.search_revealer, True)
+        except AttributeError:
+            pass
 
         self.terminal_stack = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.terminal_stack.set_hexpand(True)
         self.terminal_stack.set_vexpand(True)
-        self.terminal_stack.append(self.search_revealer)
         self.terminal_stack.append(self.overlay)
 
         # Disconnected banner with reconnect button at the bottom (separate panel below terminal)


### PR DESCRIPTION
## Summary
- add the terminal search revealer to the overlay stack so it opens in the top banner area
- ensure the overlay measures the search revealer so it spans the terminal width

## Testing
- pytest *(fails: missing GTK/Graphene dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e53f00ddd48328bebc2b472cb14c51