### PR TITLE
Ensure fallback spinner hide restores terminal focus

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1467,6 +1467,13 @@ class TerminalWidget(Gtk.Box):
             self.emit('connection-established')
             self._set_connecting_overlay_visible(False)
             try:
+                if getattr(self, 'vte', None):
+                    self.vte.grab_focus()
+                    if hasattr(self.vte, 'set_cursor_blink_mode'):
+                        self.vte.set_cursor_blink_mode(Vte.CursorBlinkMode.ON)
+            except Exception as e:
+                logger.debug(f"Failed to refocus terminal after fallback: {e}")
+            try:
                 self._set_disconnected_banner_visible(False)
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- refocus the VTE widget after the fallback spinner hide path completes
- reassert cursor blink mode so terminals regain a blinking cursor when the fallback runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6bbac8e108328951ad9ae0e343099