### PR TITLE
Sanitize Flatpak environment variables for host shell spawns

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -31,6 +31,31 @@ from gi.repository import Gtk, GObject, GLib, Vte, Pango, Gdk, Gio, Adw
 
 logger = logging.getLogger(__name__)
 
+_FLATPAK_SANDBOX_ENV_BLOCKLIST = (
+    "XDG_DATA_HOME",
+    "XDG_DATA_DIRS",
+)
+
+
+def _sanitize_flatpak_environment(env: dict) -> dict:
+    """Return a copy of *env* without sandbox-only Flatpak values."""
+
+    sanitized_env = dict(env)
+
+    removed_keys = []
+    for key in _FLATPAK_SANDBOX_ENV_BLOCKLIST:
+        if key in sanitized_env:
+            removed_keys.append(key)
+            sanitized_env.pop(key, None)
+
+    if removed_keys:
+        logger.debug(
+            "Removing Flatpak sandbox variables before host spawn: %s",
+            ", ".join(removed_keys),
+        )
+
+    return sanitized_env
+
 class SSHProcessManager:
     """Manages SSH processes and ensures proper cleanup"""
     _instance = None
@@ -2028,6 +2053,9 @@ class TerminalWidget(Gtk.Box):
         This is the fallback when agent is not available.
         """
         env = os.environ.copy()
+
+        if is_flatpak():
+            env = _sanitize_flatpak_environment(env)
 
         # Determine the user's preferred shell
         shell = None

--- a/tests/test_terminal_flatpak_env.py
+++ b/tests/test_terminal_flatpak_env.py
@@ -1,0 +1,25 @@
+"""Tests for Flatpak environment handling in TerminalWidget."""
+
+from sshpilot.terminal import _sanitize_flatpak_environment
+
+
+def test_sanitize_flatpak_environment_removes_flatpak_values():
+    original_env = {
+        "LANG": "en_US.UTF-8",
+        "TERM": "xterm-256color",
+        "PATH": "/usr/bin:/bin",
+        "XDG_DATA_HOME": "/app/data",
+        "XDG_DATA_DIRS": "/app/share:/usr/share",
+    }
+
+    sanitized = _sanitize_flatpak_environment(original_env)
+
+    assert "XDG_DATA_HOME" not in sanitized
+    assert "XDG_DATA_DIRS" not in sanitized
+    assert sanitized["LANG"] == original_env["LANG"]
+    assert sanitized["TERM"] == original_env["TERM"]
+    assert sanitized["PATH"] == original_env["PATH"]
+
+    # Ensure the original dictionary is untouched
+    assert original_env["XDG_DATA_HOME"] == "/app/data"
+    assert original_env["XDG_DATA_DIRS"] == "/app/share:/usr/share"


### PR DESCRIPTION
## Summary
- strip Flatpak sandbox XDG_* variables before spawning the host shell to avoid warnings while keeping critical values intact
- add a regression test covering the Flatpak environment sanitiser

## Testing
- pytest tests/test_terminal_flatpak_env.py

------
https://chatgpt.com/codex/tasks/task_e_68e6c5611fc08328a945160de1dedae7