### PR TITLE
Add resize control channel for host agent

### DIFF
--- a/documentation/manual-qa.md
+++ b/documentation/manual-qa.md
@@ -18,3 +18,12 @@
 1. Multi-select two grouped connections.
 2. Open the context menu on one of the highlighted rows and choose **Ungroup**.
 3. Confirm that both connections return to the Ungrouped section.
+
+## Terminal resizing (Flatpak)
+
+### Verify agent-driven resize propagation
+1. Launch sshPilot from the Flatpak build and open a local shell (which uses the host agent).
+2. Run a full-screen terminal application such as `less /etc/hosts` or `htop`.
+3. Resize the sshPilot window horizontally and vertically.
+4. Confirm that the running application immediately adjusts to the new terminal dimensions without drawing artifacts.
+5. Repeat the resize in the opposite direction to ensure the agent continues to handle additional changes.


### PR DESCRIPTION
## Summary
- add a control file descriptor to the host-side agent so resize messages update the PTY and signal the shell
- plumb a control pipe through AgentClient and TerminalWidget to forward VTE dimension changes as JSON control messages
- document manual QA coverage to verify terminal applications resize correctly under Flatpak

## Testing
- pytest *(fails: requires system GTK/GI components in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d6a64c2c8328b09d987f9d7fad88