### PR TITLE
Fix Flatpak agent command quoting

### DIFF
--- a/sshpilot/agent_client.py
+++ b/sshpilot/agent_client.py
@@ -154,7 +154,7 @@ class AgentClient:
             logger.error("Agent script not found")
             return None
 
-        python_exec = shlex.quote(python_path or 'python3')
+        python_exec = python_path or 'python3'
         
         # Read and encode agent code
         try:
@@ -176,13 +176,21 @@ class AgentClient:
         
         if verbose:
             agent_args.append('--verbose')
-        
-        args_str = ' '.join(agent_args)
-        
-        # Create bash script that decodes and runs the agent
-        wrapper_script = (
-            f'''{python_exec} -c "import base64,sys;exec(base64.b64decode('${{SSHPILOT_AGENT}}').decode())" {args_str}'''
+
+        python_code = (
+            "import base64,os,sys;"
+            "exec(base64.b64decode(os.environ['SSHPILOT_AGENT']).decode('utf-8'))"
         )
+
+        wrapper_args = [
+            python_exec,
+            '-c',
+            python_code,
+            *agent_args,
+        ]
+
+        # Create bash script that decodes and runs the agent
+        wrapper_script = shlex.join(wrapper_args)
         
         # Store agent code in environment variable format
         self._agent_env = {'SSHPILOT_AGENT': agent_b64}

--- a/tests/test_agent_client_flatpak_command.py
+++ b/tests/test_agent_client_flatpak_command.py
@@ -1,0 +1,100 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+from sshpilot.agent_client import AgentClient
+
+
+def test_flatpak_agent_command_handles_cwd_with_spaces(tmp_path, monkeypatch):
+    client = AgentClient()
+
+    agent_script = tmp_path / "mock_agent.py"
+    agent_script.write_text(
+        textwrap.dedent(
+            """\
+            import os
+            import sys
+            from pathlib import Path
+
+            def main():
+                args = sys.argv[1:]
+                cwd_value = None
+                for index, value in enumerate(args):
+                    if value == '--cwd' and index + 1 < len(args):
+                        cwd_value = args[index + 1]
+                        break
+
+                output_path = Path(os.environ['SSHPILOT_TEST_OUTPUT'])
+                output_path.write_text(cwd_value or '')
+
+            if __name__ == '__main__':
+                main()
+            """
+        )
+    )
+
+    monkeypatch.setattr(
+        client,
+        'find_agent',
+        lambda: (sys.executable, str(agent_script)),
+    )
+
+    flatpak_spawn = tmp_path / "flatpak-spawn"
+    flatpak_spawn.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os
+            import subprocess
+            import sys
+
+            def main():
+                args = sys.argv[1:]
+                env = os.environ.copy()
+                index = 0
+
+                while index < len(args):
+                    value = args[index]
+                    if value == '--host':
+                        index += 1
+                        continue
+
+                    if value.startswith('--env='):
+                        key, val = value[6:].split('=', 1)
+                        env[key] = val
+                        index += 1
+                        continue
+
+                    break
+
+                cmd = args[index:]
+                subprocess.run(cmd, check=True, env=env)
+
+            if __name__ == '__main__':
+                main()
+            """
+        )
+    )
+    flatpak_spawn.chmod(0o755)
+
+    monkeypatch.setenv('PATH', f"{tmp_path}:{os.environ.get('PATH', '')}")
+
+    cwd_path = tmp_path / "dir with spaces"
+    output_path = tmp_path / "result.txt"
+
+    cmd = client._build_flatpak_agent_command(
+        rows=24,
+        cols=80,
+        cwd=str(cwd_path),
+        verbose=False,
+    )
+
+    assert cmd is not None
+
+    run_env = os.environ.copy()
+    run_env['SSHPILOT_TEST_OUTPUT'] = str(output_path)
+
+    subprocess.run(cmd, check=True, env=run_env)
+
+    assert output_path.read_text() == str(cwd_path)


### PR DESCRIPTION
## Summary
- update the Flatpak agent wrapper to build the bash command with proper shell quoting so arguments survive spaces and special characters
- add a regression test that exercises `_build_flatpak_agent_command` with a working directory containing spaces and ensures the generated command runs the agent

## Testing
- pytest tests/test_agent_client_flatpak_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e6d6b356208328828c908e031306c6