### PR TITLE
Normalize key passphrase storage and add regression test

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -3338,15 +3338,16 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
 
         # Store key passphrase in secret storage if provided
         if keyfile_value and keyfile_value != "Select key file":
+            normalized_keyfile_value = os.path.realpath(os.path.expanduser(keyfile_value))
             try:
                 if hasattr(self, 'connection_manager') and self.connection_manager:
                     if hasattr(self.connection_manager, 'store_key_passphrase'):
                         if key_passphrase:
                             # Store new or modified passphrase (already verified above)
-                            self.connection_manager.store_key_passphrase(keyfile_value, key_passphrase)
+                            self.connection_manager.store_key_passphrase(normalized_keyfile_value, key_passphrase)
                         elif hasattr(self.connection_manager, 'delete_key_passphrase'):
                             # User cleared the field - remove stored passphrase
-                            self.connection_manager.delete_key_passphrase(keyfile_value)
+                            self.connection_manager.delete_key_passphrase(normalized_keyfile_value)
             except Exception as e:
                 logger.warning(f"Failed to store/delete key passphrase: {e}")
 

--- a/tests/test_askpass_utils.py
+++ b/tests/test_askpass_utils.py
@@ -1,0 +1,60 @@
+import os
+
+import pytest
+
+
+class DummySecretModule:
+    class SchemaAttributeType:
+        STRING = object()
+
+    class SchemaFlags:
+        NONE = 0
+
+    COLLECTION_DEFAULT = object()
+
+    class Schema:
+        @staticmethod
+        def new(*_args, **_kwargs):
+            return object()
+
+    store = {}
+
+    @classmethod
+    def password_store_sync(cls, _schema, attributes, _collection, _label, secret, _cancellable):
+        cls.store[attributes["key_path"]] = secret
+
+    @classmethod
+    def password_lookup_sync(cls, _schema, attributes, _cancellable):
+        return cls.store.get(attributes["key_path"])
+
+    @classmethod
+    def password_clear_sync(cls, _schema, attributes, _cancellable):
+        return 1 if cls.store.pop(attributes["key_path"], None) is not None else 0
+
+
+@pytest.fixture(autouse=True)
+def _reset_dummy_store():
+    DummySecretModule.store = {}
+    yield
+    DummySecretModule.store = {}
+
+
+def test_lookup_passphrase_handles_home_relative_alias(monkeypatch, tmp_path):
+    from sshpilot import askpass_utils
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    monkeypatch.setattr(askpass_utils, "Secret", DummySecretModule, raising=False)
+    monkeypatch.setattr(askpass_utils, "keyring", None, raising=False)
+    monkeypatch.setattr(askpass_utils, "is_macos", lambda: False, raising=False)
+    monkeypatch.setattr(askpass_utils, "_SCHEMA", None, raising=False)
+
+    key_path = "~/.ssh/example_key"
+    absolute_path = os.path.realpath(os.path.expanduser(key_path))
+
+    assert askpass_utils.store_passphrase(key_path, "super-secret")
+    assert DummySecretModule.store == {absolute_path: "super-secret"}
+
+    assert askpass_utils.lookup_passphrase(absolute_path) == "super-secret"
+    assert askpass_utils.lookup_passphrase(key_path) == "super-secret"


### PR DESCRIPTION
## Summary
- normalize askpass key path handling so storage and lookups share canonical and home-relative aliases, including the embedded askpass helper
- normalize the connection dialog key path before storing or clearing passphrases to reduce duplicate secrets
- add a regression test ensuring a passphrase saved for `~/.ssh/example_key` is found when looked up using its absolute path

## Testing
- pytest *(fails: environment lacks optional GTK/GI dependencies required by some tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e760fa85408328a95e543b328f58df