### PR TITLE
Ensure macOS uses in-app file manager for SFTP

### DIFF
--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple, Callable, Any
 
 from gi.repository import Gtk, Adw, Gio, GLib, Gdk
 
-from .platform_utils import is_flatpak
+from .platform_utils import is_flatpak, is_macos
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +134,8 @@ def _should_use_in_app_file_manager() -> bool:
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Failed to read file manager preference: %s", exc)
     if is_flatpak():
+        return True
+    if is_macos():
         return True
     if os.environ.get("SSHPILOT_DISABLE_GVFS") == "1":
         return True

--- a/tests/test_sftp_utils_in_app_manager.py
+++ b/tests/test_sftp_utils_in_app_manager.py
@@ -327,3 +327,22 @@ def test_gvfs_supports_sftp_false_when_gio_missing(monkeypatch):
     sftp_utils = import_sftp_utils(monkeypatch)
     monkeypatch.setattr(sftp_utils.shutil, "which", lambda *_args, **_kwargs: None)
     assert not sftp_utils._gvfs_supports_sftp()
+
+
+def test_should_use_in_app_manager_when_macos(monkeypatch):
+    sftp_utils = import_sftp_utils(monkeypatch)
+    monkeypatch.delenv("SSHPILOT_FORCE_IN_APP_FILE_MANAGER", raising=False)
+    monkeypatch.delenv("SSHPILOT_DISABLE_GVFS", raising=False)
+    monkeypatch.setattr(sftp_utils, "is_flatpak", lambda: False)
+    monkeypatch.setattr(sftp_utils, "is_macos", lambda: True)
+
+    gvfs_called = {"value": False}
+
+    def fake_gvfs_support():
+        gvfs_called["value"] = True
+        return True
+
+    monkeypatch.setattr(sftp_utils, "_gvfs_supports_sftp", fake_gvfs_support)
+
+    assert sftp_utils._should_use_in_app_file_manager()
+    assert not gvfs_called["value"]


### PR DESCRIPTION
## Summary
- ensure the in-app file manager is always chosen on macOS before GVFS heuristics run
- add a regression test confirming macOS short-circuits the GVFS detection logic

## Testing
- pytest tests/test_sftp_utils_in_app_manager.py


------
https://chatgpt.com/codex/tasks/task_e_68e8d0e519c08328b8eb74811dd13600