### PR TITLE
Adjust file manager toggle visibility on macOS

### DIFF
--- a/tests/test_preferences_file_manager_toggle.py
+++ b/tests/test_preferences_file_manager_toggle.py
@@ -1,0 +1,19 @@
+def test_force_internal_toggle_hidden_on_macos(monkeypatch):
+    from sshpilot import preferences
+
+    monkeypatch.setattr(preferences, "is_macos", lambda: True)
+    monkeypatch.setattr(preferences, "has_native_gvfs_support", lambda: True)
+
+    assert preferences.should_show_force_internal_file_manager_toggle() is False
+
+
+def test_force_internal_toggle_requires_gvfs_support(monkeypatch):
+    from sshpilot import preferences
+
+    monkeypatch.setattr(preferences, "is_macos", lambda: False)
+    monkeypatch.setattr(preferences, "has_native_gvfs_support", lambda: True)
+
+    assert preferences.should_show_force_internal_file_manager_toggle() is True
+
+    monkeypatch.setattr(preferences, "has_native_gvfs_support", lambda: False)
+    assert preferences.should_show_force_internal_file_manager_toggle() is False


### PR DESCRIPTION
## Summary
- add a helper to decide when the "force internal" toggle should be visible
- only build the toggle when native GVFS support is present so macOS only sees the external-window switch
- add tests covering the helper logic for macOS vs. GVFS availability

## Testing
- pytest *(fails: missing Graphene / GTK symbols in test stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d0e6b7bc8328a4bfe4401877b480