### PR TITLE
Respect IdentityAgent=none when preloading SSH keys

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1249,13 +1249,28 @@ class AsyncSFTPManager(GObject.GObject):
         else:
             logger.debug("File manager: No connection object provided")
 
-        if connection is not None and key_mode in (1, 2) and keyfile and os.path.isfile(keyfile):
+        identity_agent_disabled = False
+        if connection is not None:
+            identity_agent_disabled = bool(
+                getattr(connection, "identity_agent_disabled", False)
+            )
+
+        if (
+            connection is not None
+            and key_mode in (1, 2)
+            and keyfile
+            and os.path.isfile(keyfile)
+        ):
                 key_filename = keyfile
                 look_for_keys = False
                 logger.debug("File manager: Using specific key file: %s", keyfile)
                 # Prepare key for connection (add to ssh-agent if needed)
                 key_prepared = False
-                if (
+                if identity_agent_disabled:
+                    logger.debug(
+                        "File manager: IdentityAgent disabled; skipping key preparation"
+                    )
+                elif (
                     self._connection_manager is not None
                     and hasattr(self._connection_manager, "prepare_key_for_connection")
                 ):

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -607,6 +607,10 @@ class TerminalWidget(Gtk.Box):
         if not connection:
             return
 
+        if getattr(connection, 'identity_agent_disabled', False):
+            logger.debug("IdentityAgent disabled; skipping native key preload")
+            return
+
         manager = getattr(self, 'connection_manager', None)
         if not manager or not hasattr(manager, 'prepare_key_for_connection'):
             return
@@ -942,15 +946,20 @@ class TerminalWidget(Gtk.Box):
                     )
 
                     if has_explicit_key and hasattr(self, 'connection_manager') and self.connection_manager:
-                        try:
-                            if hasattr(self.connection_manager, 'prepare_key_for_connection'):
-                                key_prepared = self.connection_manager.prepare_key_for_connection(keyfile_value)
-                                if key_prepared:
-                                    logger.debug(f"Key prepared for connection: {keyfile_value}")
-                                else:
-                                    logger.warning(f"Failed to prepare key for connection: {keyfile_value}")
-                        except Exception as e:
-                            logger.warning(f"Error preparing key for connection: {e}")
+                        if getattr(self.connection, 'identity_agent_disabled', False):
+                            logger.debug(
+                                "IdentityAgent disabled; skipping key preparation before connection"
+                            )
+                        else:
+                            try:
+                                if hasattr(self.connection_manager, 'prepare_key_for_connection'):
+                                    key_prepared = self.connection_manager.prepare_key_for_connection(keyfile_value)
+                                    if key_prepared:
+                                        logger.debug(f"Key prepared for connection: {keyfile_value}")
+                                    else:
+                                        logger.warning(f"Failed to prepare key for connection: {keyfile_value}")
+                            except Exception as e:
+                                logger.warning(f"Error preparing key for connection: {e}")
 
                     # Only add specific key when a dedicated key mode is selected
                     if has_explicit_key and key_select_mode in (1, 2):


### PR DESCRIPTION
## Summary
- skip preloading keys in the terminal when IdentityAgent disables ssh-agent usage
- propagate the identity_agent_disabled flag through SCP/file manager helpers to suppress key preparation
- extend askpass and SCP argument tests to cover IdentityAgent=none scenarios

## Testing
- pytest tests/test_terminal_askpass.py tests/test_window_scp_args.py

------
https://chatgpt.com/codex/tasks/task_e_68e9fc4976588328a280792bc5f0501e