### PR TITLE
Handle forced askpass passphrase candidates

### DIFF
--- a/tests/test_terminal_askpass.py
+++ b/tests/test_terminal_askpass.py
@@ -162,6 +162,132 @@ def test_forced_askpass_without_passphrase(monkeypatch, caplog):
     assert "allowing interactive prompt" in caplog.text
 
 
+def test_forced_askpass_with_resolved_identity_passphrase(monkeypatch, caplog):
+    terminal_mod = importlib.import_module("sshpilot.terminal")
+    askpass_mod = importlib.import_module("sshpilot.askpass_utils")
+
+    monkeypatch.setattr(
+        terminal_mod,
+        "Vte",
+        types.SimpleNamespace(
+            Pty=types.SimpleNamespace(new_sync=lambda *a, **k: object()),
+            PtyFlags=types.SimpleNamespace(DEFAULT=0),
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(terminal_mod, "GLib", _DummyGLib, raising=False)
+    monkeypatch.setattr(
+        terminal_mod.Adw,
+        "Application",
+        types.SimpleNamespace(get_default=lambda: None),
+        raising=False,
+    )
+
+    monkeypatch.delenv("SSH_ASKPASS_REQUIRE", raising=False)
+    monkeypatch.delenv("SSH_ASKPASS", raising=False)
+
+    lookup_calls = []
+    manager_calls = []
+
+    def fake_forced_env():
+        return {
+            "SSH_ASKPASS": "/tmp/helper",
+            "SSH_ASKPASS_REQUIRE": "force",
+            "DISPLAY": ":1",
+        }
+
+    resolved_key_path = "/tmp/resolved-key"
+
+    def fake_lookup(key_path):
+        lookup_calls.append(key_path)
+        if key_path == resolved_key_path:
+            return "secret"
+        return ""
+
+    monkeypatch.setattr(
+        askpass_mod,
+        "get_ssh_env_with_forced_askpass",
+        fake_forced_env,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        askpass_mod,
+        "lookup_passphrase",
+        fake_lookup,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        terminal_mod,
+        "lookup_passphrase",
+        fake_lookup,
+        raising=False,
+    )
+
+    terminal_cls = terminal_mod.TerminalWidget
+    terminal = terminal_cls.__new__(terminal_cls)
+
+    terminal.connection = types.SimpleNamespace(
+        ssh_cmd=None,
+        auth_method=2,
+        password=None,
+        key_passphrase="",
+        keyfile="",
+        key_select_mode=0,
+        identity_agent_disabled=True,
+        quick_connect_command="",
+        data={},
+        forwarding_rules=[],
+        hostname="example.com",
+        username="demo",
+        port=22,
+        pubkey_auth_no=False,
+        remote_command="",
+        local_command="",
+        extra_ssh_config="",
+        resolved_identity_files=[resolved_key_path],
+    )
+
+    def fake_get_key_passphrase(path):
+        manager_calls.append(path)
+        return None
+
+    terminal.connection_manager = types.SimpleNamespace(
+        native_connect_enabled=False,
+        get_password=lambda *a, **k: None,
+        known_hosts_path="",
+        prepare_key_for_connection=lambda *a, **k: True,
+        get_key_passphrase=fake_get_key_passphrase,
+        update_connection_status=lambda *a, **k: None,
+    )
+
+    terminal.config = types.SimpleNamespace(get_ssh_config=lambda: {})
+    terminal.vte = DummyVte()
+    terminal._enable_askpass_log_forwarding = lambda *a, **k: None
+    terminal.apply_theme = lambda *a, **k: None
+    terminal._set_connecting_overlay_visible = lambda *a, **k: None
+    terminal._set_disconnected_banner_visible = lambda *a, **k: None
+    terminal.emit = lambda *a, **k: None
+    terminal.session_id = "session-456"
+    terminal.is_connected = False
+    terminal._is_quitting = False
+    terminal._resolve_native_identity_candidates = lambda: []
+
+    caplog.set_level(logging.DEBUG)
+
+    terminal._setup_ssh_terminal()
+
+    assert lookup_calls == [resolved_key_path]
+    assert manager_calls == []
+
+    assert terminal.vte.last_env_list is not None
+    env_dict = dict(item.split("=", 1) for item in terminal.vte.last_env_list)
+
+    assert env_dict["SSH_ASKPASS"] == "/tmp/helper"
+    assert env_dict["SSH_ASKPASS_REQUIRE"] == "force"
+
+    assert "allowing interactive prompt" not in caplog.text
+
+
 def test_prepare_key_skipped_when_identity_agent_disabled(tmp_path):
     terminal_mod = importlib.import_module("sshpilot.terminal")
 


### PR DESCRIPTION
## Summary
- iterate through all available identity file candidates before clearing SSH_ASKPASS_REQUIRE when forcing askpass
- retain forced askpass usage when a stored passphrase is found via lookup or connection manager sources
- add a regression test covering passphrase retrieval via resolved identity files

## Testing
- pytest tests/test_terminal_askpass.py

------
https://chatgpt.com/codex/tasks/task_e_68ea027e1a108328a472020b79aecb9e