### PR TITLE
Respect IdentityAgent when applying BatchMode options

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Optional, Any, Tuple, Union, Set
 from .ssh_config_utils import resolve_ssh_config_files, get_effective_ssh_config
 from .platform_utils import is_macos, get_config_dir, get_ssh_dir
 from .key_utils import _is_private_key
+from .ssh_utils import remove_batchmode_yes_options
 
 try:
     import gi
@@ -420,8 +421,7 @@ class Connection:
                 has_saved_password = False
             using_password = password_auth_selected or has_saved_password
 
-            if batch_mode and not using_password:
-                ssh_cmd.extend(['-o', 'BatchMode=yes'])
+            should_enable_batch_mode = batch_mode and not using_password
             if connect_timeout is not None:
                 ssh_cmd.extend(['-o', f'ConnectTimeout={connect_timeout}'])
             if connection_attempts is not None:
@@ -483,6 +483,11 @@ class Connection:
 
 
             self._update_identity_agent_state(effective_cfg.get('identityagent'))
+
+            if self.identity_agent_disabled:
+                ssh_cmd = remove_batchmode_yes_options(ssh_cmd)
+            elif should_enable_batch_mode:
+                ssh_cmd.extend(['-o', 'BatchMode=yes'])
 
             # Determine final parameters, falling back to resolved config when needed
             existing_hostname = self.hostname or ''

--- a/tests/test_connection_batchmode.py
+++ b/tests/test_connection_batchmode.py
@@ -1,0 +1,53 @@
+import asyncio
+import importlib
+
+
+def test_connection_batchmode_removed_when_identity_agent_none(monkeypatch):
+    manager_mod = importlib.import_module("sshpilot.connection_manager")
+
+    class DummyConfig:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def get_ssh_config(self):
+            return {"batch_mode": True}
+
+    monkeypatch.setattr(manager_mod, "Config", DummyConfig, raising=False)
+
+    def fake_effective_config(_alias, config_file=None):
+        return {"identityagent": "none"}
+
+    monkeypatch.setattr(
+        manager_mod,
+        "get_effective_ssh_config",
+        fake_effective_config,
+        raising=False,
+    )
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        connection = manager_mod.Connection(
+            {
+                "hostname": "example.com",
+                "username": "demo",
+                "port": 22,
+            }
+        )
+
+        # Avoid file lookups for config overrides during the test
+        connection._resolve_config_override_path = lambda: None
+
+        result = loop.run_until_complete(connection.connect())
+    finally:
+        try:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except Exception:
+            pass
+        asyncio.set_event_loop(None)
+        loop.close()
+
+    assert result is True
+    assert connection.identity_agent_disabled is True
+    assert 'BatchMode=yes' not in connection.ssh_cmd


### PR DESCRIPTION
## Summary
- ensure Connection.connect removes BatchMode when IdentityAgent disables the agent and defer adding it until after identity resolution
- reuse a shared helper to strip BatchMode=yes and guard TerminalWidget and SSH helper option assembly when agents are disabled
- add regression tests covering BatchMode removal for identity-agent-disabled connections

## Testing
- pytest tests/test_connection_batchmode.py tests/test_terminal_askpass.py::test_identity_agent_disabled_skips_batchmode

------
https://chatgpt.com/codex/tasks/task_e_68ea3deb58548328b91f0c41ef96f0fb