### PR TITLE
Ensure settings reconnect honors native SSH mode

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -8400,7 +8400,16 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             # options resolved via ssh -G are honored for the reconnect.
             try:
                 loop = asyncio.get_event_loop()
-                connect_coro = connection.connect()
+                cm = getattr(self, 'connection_manager', None)
+                app = self.get_application() if hasattr(self, 'get_application') else None
+                use_native = bool(getattr(cm, 'native_connect_enabled', False))
+                if not use_native and app is not None and hasattr(app, 'native_connect_enabled'):
+                    use_native = bool(app.native_connect_enabled)
+
+                if use_native and hasattr(connection, 'native_connect'):
+                    connect_coro = connection.native_connect()
+                else:
+                    connect_coro = connection.connect()
                 if loop.is_running():
                     future = asyncio.run_coroutine_threadsafe(connect_coro, loop)
                     future.result()


### PR DESCRIPTION
## Summary
- update the settings-change reconnect path to reuse native SSH connection preparation when enabled
- ensure reconnections after configuration changes follow the same native-vs-legacy logic as initial connects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea461084e48328ad37b098c49f8578