### PR TITLE
Support forced askpass for SCP downloads

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -2144,7 +2144,7 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_resolve_ssh_copy_id_askpass_env(connection, ssh_key, connection_manager)`** — Return askpass environment and force status for ssh-copy-id launches.
 
-- **`download_file(host, user, remote_file, local_path, recursive=False, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None, saved_passphrase=None, keyfile=None, key_mode=None)`** — Download a remote file (or directory when ``recursive``) via SCP.
+- **`download_file(host, user, remote_file, local_path, recursive=False, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None, saved_passphrase=None, keyfile=None, key_mode=None, force_passphrase_env=False)`** — Download a remote file (or directory when ``recursive``) via SCP.
 
 - **`list_remote_files(host, user, remote_path, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None)`** — List remote files via SSH for the provided path.
 


### PR DESCRIPTION
## Summary
- add a flag to force the SCP askpass environment when key-based auth is needed without a saved passphrase
- ensure the download dialog computes the new flag when the identity agent is disabled
- extend documentation and tests to cover the new behaviour

## Testing
- pytest tests/test_window_scp_args.py

------
https://chatgpt.com/codex/tasks/task_e_68ea5f9e82688328a4f95aaae7c86bec