### PR TITLE
Handle forced askpass for remote listings

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -2146,7 +2146,7 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`download_file(host, user, remote_file, local_path, recursive=False, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None, saved_passphrase=None, keyfile=None, key_mode=None, force_passphrase_env=False)`** — Download a remote file (or directory when ``recursive``) via SCP.
 
-- **`list_remote_files(host, user, remote_path, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None)`** — List remote files via SSH for the provided path.
+- **`list_remote_files(host, user, remote_path, port=22, password=None, known_hosts_path=None, extra_ssh_opts=None, use_publickey=False, inherit_env=None, force_passphrase_env=False)`** — List remote files via SSH for the provided path.
 
 - **`maybe_set_native_controls(header_bar, value=False)`** — Safely set native controls on header bar, with fallback for older GTK versions.
 


### PR DESCRIPTION
## Summary
- add a `force_passphrase_env` option to `list_remote_files` that merges forced askpass env vars and SSH options when needed
- propagate the forced passphrase flag from the SCP download prompt so listings mirror download behavior
- cover the new behavior with a unit test ensuring the forced askpass environment and SSH options are preserved

## Testing
- pytest tests/test_window_scp_args.py

------
https://chatgpt.com/codex/tasks/task_e_68ea63998fc88328a72a0040a78af397