### PR TITLE
Wrap sidebar header in window handle

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1644,7 +1644,9 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         menu_button.set_menu_model(self.create_menu())
         header.append(menu_button)
 
-        sidebar_box.append(header)
+        header_handle = Gtk.WindowHandle()
+        header_handle.set_child(header)
+        sidebar_box.append(header_handle)
 
         # Search container
         search_container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)


### PR DESCRIPTION
## Summary
- wrap the sidebar header box in a Gtk.WindowHandle so the area becomes draggable without altering its layout

## Testing
- python3 -m py_compile sshpilot/window.py

------
https://chatgpt.com/codex/tasks/task_e_68ea7e06ff748328bc0c6de4a62d5291