### PR TITLE
Check for ssh directory

### DIFF
--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -1,12 +1,21 @@
 """Platform-related utility functions."""
 
+import logging
 import os
 import platform
+from pathlib import Path
 
 from gi.repository import GLib
 
 APP_ID = "io.github.mfat.sshpilot"
 APP_NAME = "sshpilot"
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_path(path: str) -> str:
+    """Expand user references and return an absolute path."""
+    return os.path.abspath(os.path.expanduser(path))
 
 
 def is_macos() -> bool:
@@ -34,10 +43,33 @@ def get_ssh_dir() -> str:
 
     By default this uses GLib's concept of the home directory and appends
     ``.ssh``. The location can be overridden by setting the
-    ``SSHPILOT_SSH_DIR`` environment variable.
+    ``SSHPILOT_SSH_DIR`` environment variable. When GLib cannot determine
+    the home directory (returns an empty string), we fall back to Python's
+    ``expanduser``/``Path.home`` heuristics to ensure the returned path is
+    absolute and points to the real home directory rather than the current
+    working directory.
     """
     override = os.environ.get("SSHPILOT_SSH_DIR")
     if override:
-        return os.path.expanduser(override)
-    return os.path.join(GLib.get_home_dir(), ".ssh")
+        return _normalize_path(override)
+
+    home_dir = GLib.get_home_dir()
+    if not home_dir or not str(home_dir).strip():
+        expanded = os.path.expanduser("~")
+        if expanded and expanded != "~":
+            home_dir = expanded
+        else:
+            try:
+                home_dir = str(Path.home())
+            except Exception:
+                home_dir = ""
+
+    if not home_dir or not str(home_dir).strip():
+        logger.warning(
+            "Unable to determine the user's home directory via GLib; "
+            "falling back to the current working directory for SSH data."
+        )
+        home_dir = os.getcwd()
+
+    return _normalize_path(os.path.join(home_dir, ".ssh"))
 

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -64,5 +64,19 @@ def test_get_ssh_dir_override(monkeypatch, tmp_path):
         lambda: "ignored",
         raising=False,
     )
-    assert platform_utils.get_ssh_dir() == str(override)
+    expected = os.path.abspath(str(override))
+    assert platform_utils.get_ssh_dir() == expected
+
+
+def test_get_ssh_dir_glib_empty_falls_back_to_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("SSHPILOT_SSH_DIR", raising=False)
+    monkeypatch.setattr(
+        platform_utils.GLib,
+        "get_home_dir",
+        lambda: "",
+        raising=False,
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    expected = os.path.join(str(tmp_path), ".ssh")
+    assert platform_utils.get_ssh_dir() == expected
 


### PR DESCRIPTION
Harden `get_ssh_dir()` to ensure configuration is always saved in the correct user's SSH directory.

The previous implementation of `get_ssh_dir()` could return an empty or incorrect home directory if GLib failed, leading to configuration not being saved or being saved in the current working directory instead of the user's actual `~/.ssh` directory. This change adds robust fallback mechanisms and path normalization.

---
<a href="https://cursor.com/background-agent?bcId=bc-10e52145-7126-4b75-a8e7-6fec021a758b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10e52145-7126-4b75-a8e7-6fec021a758b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

