### PR TITLE
Create .ssh directory on new server

### DIFF
--- a/tests/test_ssh_directory_creation.py
+++ b/tests/test_ssh_directory_creation.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from sshpilot.connection_manager import Connection, ConnectionManager
+
+
+def test_update_connection_creates_ssh_directory(tmp_path):
+    """Saving a new connection should create the SSH directory when missing."""
+    ssh_dir = tmp_path / "custom_ssh"
+    config_path = ssh_dir / "config"
+    known_hosts_path = ssh_dir / "known_hosts"
+
+    manager = ConnectionManager.__new__(ConnectionManager)
+    manager.connections = []
+    manager.rules = []
+    manager.isolated_mode = False
+    manager.ssh_config_path = str(config_path)
+    manager.known_hosts_path = str(known_hosts_path)
+    manager.emit = lambda *args, **kwargs: None
+    manager.store_password = lambda *args, **kwargs: True
+    manager.delete_password = lambda *args, **kwargs: True
+
+    connection_data = {
+        "nickname": "demo",
+        "hostname": "example.com",
+        "username": "alice",
+        "port": 22,
+        "auth_method": 0,
+        "keyfile": "",
+        "password": "",
+        "forwarding_rules": [],
+    }
+
+    connection = Connection(connection_data)
+    manager.connections.append(connection)
+
+    assert not ssh_dir.exists()
+
+    manager.update_connection(connection, dict(connection_data))
+
+    assert ssh_dir.exists()
+    assert config_path.exists()
+    contents = Path(config_path).read_text()
+    assert "Host demo" in contents


### PR DESCRIPTION
Automatically create missing `~/.ssh` directories and config files with secure permissions to ensure new server connections can be added successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-3979bb76-2223-4edf-8f4a-29817e073a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3979bb76-2223-4edf-8f4a-29817e073a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

