### PR TITLE
Fix terminal text selection highlight with group color

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1892,9 +1892,13 @@ class TerminalWidget(Gtk.Box):
             if use_group_color and override_rgba is not None:
                 bg_color = self._clone_rgba(override_rgba)  # Use exact group color
                 fg_color = self._get_contrast_color(bg_color)
-                highlight_bg = self._clone_rgba(override_rgba)
+
+                contrast_for_bg = self._get_contrast_color(bg_color)
+                mix_ratio = 0.35 if self._relative_luminance(bg_color) < 0.5 else 0.25
+                highlight_bg = self._mix_rgba(bg_color, contrast_for_bg, mix_ratio)
+                highlight_bg.alpha = 1.0
                 highlight_fg = self._get_contrast_color(highlight_bg)
-                cursor_color = self._clone_rgba(highlight_fg)
+                cursor_color = self._clone_rgba(fg_color)
 
 
             # Prepare palette colors (16 ANSI colors)


### PR DESCRIPTION
Ensure terminal text selection is visible and highlighted when group colors are used for the background.

The previous implementation resulted in invisible text selection when a group color was applied to the terminal background. This PR derives the selection tint by blending the group color with its contrast color and reuses the terminal foreground for the cursor, ensuring proper visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae8fff7b-5f84-4f0f-95a2-ab5965407114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae8fff7b-5f84-4f0f-95a2-ab5965407114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

