### PR TITLE
Add sorting to connection list

### DIFF
--- a/documentation/function-reference.md
+++ b/documentation/function-reference.md
@@ -40,6 +40,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`on_open_new_connection_tab_action(action, param=None)`** — Open a new tab for the selected connection via global shortcut (Ctrl/⌘+Alt+N).
 
+- **`on_sort_connections_action(action, param=None)`** — Apply a requested connection sort preset.
+
 - **`on_toggle_sidebar_action(action, param)`** — Handle sidebar toggle action (for keyboard shortcuts)
 
 
@@ -396,6 +398,10 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 ## Module: `sshpilot.connection_manager`
 
+### Functions
+
+- **`_ensure_event_loop()`** — Return the running asyncio event loop or create one if missing.
+
 ### Class: `Connection`
 
 - **`__init__(data)`** — Handles init.
@@ -438,6 +444,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`__init__(config, isolated_mode=False)`** — Handles init.
 
+- **`_ensure_config_parent_dir(path)`** — Normalize *path* and ensure its parent directory exists with secure permissions.
+
 - **`_ensure_secure_permissions(path, mode)`** — Best effort at applying restrictive permissions to files/directories.
 
 - **`_ensure_ssh_agent()`** — Ensure ssh-agent is running and export environment variables
@@ -449,6 +457,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`_get_active_connection_key(connection)`** — Return the dictionary key used to track active connection tasks.
 
 - **`_get_keyring_backend_name()`** — Return a descriptive name for the active keyring backend.
+
+- **`_normalize_path(path)`** — Expand user/env vars and return absolute, non-empty paths.
 
 - **`_post_init_slow_path()`** — Run slower initialization steps after UI is responsive.
 
@@ -507,6 +517,22 @@ This document enumerates the functions and methods available in the `sshpilot` p
 ### Class: `GLibEventLoopPolicy`
 
 - **`new_event_loop()`** — Handles new event loop.
+
+
+
+## Module: `sshpilot.connection_sort`
+
+### Functions
+
+- **`_name_key(connection)`** — Return a tuple used for alphabetical sorting.
+
+- **`_normalize_key(value)`** — Normalize a key so comparisons remain stable.
+
+- **`apply_connection_sort(group_manager, connections, preset_id)`** — Reorder connection lists managed by ``group_manager`` using ``preset_id``.
+
+### Class: `SortPreset`
+
+- **`__hash__()`** — Handles hash.
 
 
 
@@ -1962,6 +1988,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_prepare_key_for_native_mode()`** — Ensure explicit keys are unlocked when native SSH mode is active.
 
+- **`_refresh_connection_command()`** — Refresh the prepared SSH command using current preferences.
+
 - **`_relative_luminance(rgba)`** — Handles relative luminance.
 
 - **`_remove_custom_shortcut_controllers()`** — Detach any custom shortcut or scroll controllers from the VTE widget.
@@ -2168,6 +2196,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_build_shortcuts_window()`** — Builds shortcuts window.
 
+- **`_build_sort_split_button()`** — Builds sort split button.
+
 - **`_build_ssh_copy_id_argv(connection, ssh_key, force=False, known_hosts_path=None)`** — Construct argv for ssh-copy-id honoring saved UI auth preferences.
 
 - **`_cancel_broadcast_hide_timeout()`** — Cancel any pending hide timeout for the broadcast banner
@@ -2216,6 +2246,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_get_sidebar_width()`** — Returns sidebar width.
 
+- **`_get_sort_menu_model()`** — Returns sort menu model.
+
 - **`_get_target_connection_rows(prefer_context=False)`** — Return rows targeted by the current action, respecting context menus.
 
 - **`_get_target_connections(prefer_context=False)`** — Return connection objects targeted by the current action.
@@ -2228,6 +2260,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_install_sidebar_css()`** — Install sidebar focus CSS
 
+- **`_notify_sort_result(preset, changed)`** — Handles notify sort result.
+
 - **`_on_config_setting_changed(_config, key, value)`** — Synchronize runtime state when configuration values change.
 
 - **`_on_connection_list_key_pressed(controller, keyval, keycode, state)`** — Handle key presses in the connection list
@@ -2237,6 +2271,8 @@ This document enumerates the functions and methods available in the `sshpilot` p
 - **`_on_reconnect_response(dialog, response_id, connection)`** — Handle response from reconnect prompt
 
 - **`_on_search_entry_key_pressed(controller, keyval, keycode, state)`** — Handle key presses in search entry.
+
+- **`_on_sort_primary_clicked(*_args)`** — Handles sort primary clicked.
 
 - **`_on_ssh_config_editor_saved()`** — Handles ssh config editor saved.
 
@@ -2316,11 +2352,15 @@ This document enumerates the functions and methods available in the `sshpilot` p
 
 - **`_track_internal_file_manager_window(window, widget=None)`** — Keep a reference to in-app file manager controllers to prevent GC.
 
+- **`_update_sort_button_content()`** — Updates sort button content.
+
 - **`_update_tab_button_visibility()`** — Update TabButton visibility based on number of tabs
 
 - **`_update_tab_titles()`** — Update tab titles
 
 - **`add_connection_row(connection, indent_level=0)`** — Add a connection row to the list with optional indentation
+
+- **`apply_connection_sort_preset(preset_id)`** — Handles apply connection sort preset.
 
 - **`create_menu()`** — Create application menu
 

--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -197,6 +197,19 @@ class WindowActions:
         except Exception as e:
             logger.error(f"Failed to open in system terminal: {e}")
 
+    def on_sort_connections_action(self, action, param=None):
+        """Apply a requested connection sort preset."""
+        try:
+            preset_id = param.get_string() if param is not None else None
+        except AttributeError:
+            preset_id = None
+
+        if not preset_id:
+            return
+
+        if hasattr(self, 'apply_connection_sort_preset'):
+            self.apply_connection_sort_preset(preset_id)
+
     def on_broadcast_command_action(self, action, param=None):
         """Handle broadcast command action - shows dialog to input command"""
         try:
@@ -834,6 +847,10 @@ def register_window_actions(window):
         window.open_in_system_terminal_action = Gio.SimpleAction.new('open-in-system-terminal', None)
         window.open_in_system_terminal_action.connect('activate', window.on_open_in_system_terminal_action)
         window.add_action(window.open_in_system_terminal_action)
+
+    window.sort_connections_action = Gio.SimpleAction.new('sort-connections', GLib.VariantType.new('s'))
+    window.sort_connections_action.connect('activate', window.on_sort_connections_action)
+    window.add_action(window.sort_connections_action)
 
     # Action for broadcasting commands to all SSH terminals
     window.broadcast_command_action = Gio.SimpleAction.new('broadcast-command', None)

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -176,6 +176,7 @@ class Config(GObject.Object):
                 'group_color_display': 'fill',
                 'use_group_color_in_tab': False,
                 'use_group_color_in_terminal': False,
+                'connection_sort_last': 'name-asc',
             },
             'welcome': {
                 'background_color': None,  # None for default, or CSS string for custom
@@ -974,6 +975,11 @@ class Config(GObject.Object):
             updated = True
         elif not isinstance(ui_cfg['use_group_color_in_terminal'], bool):
             ui_cfg['use_group_color_in_terminal'] = bool(ui_cfg['use_group_color_in_terminal'])
+            updated = True
+
+        sort_last = ui_cfg.get('connection_sort_last')
+        if not isinstance(sort_last, str):
+            ui_cfg['connection_sort_last'] = 'name-asc'
             updated = True
 
         ssh_cfg = config.get('ssh')

--- a/sshpilot/connection_sort.py
+++ b/sshpilot/connection_sort.py
@@ -1,0 +1,124 @@
+"""Helpers for sorting connections across groups and the root list."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Sequence, Tuple
+
+from gettext import gettext as _
+
+
+@dataclass(frozen=True)
+class SortPreset:
+    """Describes a connection sorting preset."""
+
+    preset_id: str
+    title: str
+    description: str
+    icon_name: str
+    reverse: bool = False
+
+    def __hash__(self) -> int:  # pragma: no cover - required for dataclass
+        return hash(self.preset_id)
+
+
+def _name_key(connection) -> Tuple[str, str, str]:
+    """Return a tuple used for alphabetical sorting."""
+    nickname = str(getattr(connection, "nickname", "") or "")
+    hostname = str(getattr(connection, "hostname", "") or "")
+    alias = str(getattr(connection, "host", "") or "")
+    primary = nickname or alias or hostname
+    return (primary.casefold(), alias.casefold(), hostname.casefold())
+
+
+DEFAULT_CONNECTION_SORT = "name-asc"
+
+CONNECTION_SORT_PRESETS: Dict[str, SortPreset] = {
+    "name-asc": SortPreset(
+        preset_id="name-asc",
+        title=_("Name (A-Z)"),
+        description=_("Sort connections alphabetically by nickname"),
+        icon_name="view-sort-ascending-symbolic",
+        reverse=False,
+    ),
+    "name-desc": SortPreset(
+        preset_id="name-desc",
+        title=_("Name (Z-A)"),
+        description=_("Sort connections alphabetically by nickname in reverse"),
+        icon_name="view-sort-descending-symbolic",
+        reverse=True,
+    ),
+}
+
+
+def _normalize_key(value: Optional[Sequence[str]]) -> Tuple:
+    """Normalize a key so comparisons remain stable."""
+    if value is None:
+        return ("",)
+
+    if isinstance(value, tuple):
+        items = value
+    elif isinstance(value, list):
+        items = tuple(value)
+    else:
+        items = (value,)
+
+    normalized = []
+    for item in items:
+        if isinstance(item, str):
+            normalized.append(item.casefold())
+        elif item is None:
+            normalized.append("")
+        else:
+            normalized.append(item)
+    return tuple(normalized)
+
+
+def apply_connection_sort(group_manager, connections: Iterable, preset_id: str) -> bool:
+    """
+    Reorder connection lists managed by ``group_manager`` using ``preset_id``.
+
+    Returns ``True`` when any ordering changed and persists the new order.
+    """
+
+    preset = CONNECTION_SORT_PRESETS.get(preset_id)
+    if not preset:
+        return False
+
+    lookup = {
+        getattr(conn, "nickname", None): conn
+        for conn in connections
+        if getattr(conn, "nickname", None)
+    }
+
+    def _decorated_key(nickname: str) -> Tuple:
+        connection = lookup.get(nickname)
+        if not connection:
+            fallback = nickname.casefold()
+            return (True, (fallback,), fallback)
+        raw_key = _name_key(connection)
+        normalized = _normalize_key(raw_key)
+        return (False, normalized, nickname.casefold())
+
+    changed = False
+
+    # Sort ungrouped/root connections
+    root_connections = getattr(group_manager, "root_connections", [])
+    sorted_root = sorted(root_connections, key=_decorated_key, reverse=preset.reverse)
+    if list(root_connections) != sorted_root:
+        group_manager.root_connections = sorted_root
+        changed = True
+
+    # Sort per-group lists
+    groups = getattr(group_manager, "groups", {})
+    for group in groups.values():
+        conn_list = list(group.get("connections", []))
+        sorted_list = sorted(conn_list, key=_decorated_key, reverse=preset.reverse)
+        if conn_list != sorted_list:
+            group["connections"] = sorted_list
+            changed = True
+
+    if changed and hasattr(group_manager, "_save_groups"):
+        group_manager._save_groups()
+
+    return changed

--- a/tests/test_connection_sort.py
+++ b/tests/test_connection_sort.py
@@ -1,0 +1,72 @@
+"""Tests for connection sorting helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sshpilot.connection_sort import apply_connection_sort
+from sshpilot.groups import GroupManager
+
+
+class DummyConfig:
+    """Minimal config shim for GroupManager."""
+
+    def __init__(self):
+        self._settings = {}
+
+    def get_setting(self, key: str, default: Any = None):
+        return self._settings.get(key, default)
+
+    def set_setting(self, key: str, value: Any):
+        self._settings[key] = value
+
+
+class DummyConnection:
+    def __init__(self, nickname: str, hostname: str = "", host: str = ""):
+        self.nickname = nickname
+        self.hostname = hostname
+        self.host = host or nickname
+
+
+def _build_manager() -> GroupManager:
+    config = DummyConfig()
+    manager = GroupManager(config)
+    manager._save_groups = lambda: None  # type: ignore[attr-defined]
+    return manager
+
+
+def test_apply_connection_sort_changes_orders_and_is_idempotent():
+    manager = _build_manager()
+    manager.root_connections = ["beta", "alpha"]
+    manager.groups = {
+        "grp": {
+            "id": "grp",
+            "name": "Group 1",
+            "parent_id": None,
+            "children": [],
+            "connections": ["delta", "gamma"],
+            "expanded": True,
+            "order": 0,
+            "color": None,
+        }
+    }
+
+    connections = [
+        DummyConnection("alpha", hostname="a.example", host="alpha"),
+        DummyConnection("beta", hostname="b.example", host="beta"),
+        DummyConnection("gamma", hostname="c.example", host="gamma"),
+        DummyConnection("delta", hostname="d.example", host="delta"),
+    ]
+
+    changed = apply_connection_sort(manager, connections, "name-asc")
+    assert changed is True
+    assert manager.root_connections == ["alpha", "beta"]
+    assert manager.groups["grp"]["connections"] == ["delta", "gamma"]
+
+    changed_again = apply_connection_sort(manager, connections, "name-asc")
+    assert changed_again is False
+
+    changed_desc = apply_connection_sort(manager, connections, "name-desc")
+    assert changed_desc is True
+    assert manager.root_connections == ["beta", "alpha"]
+    assert manager.groups["grp"]["connections"] == ["gamma", "delta"]


### PR DESCRIPTION
Add connection list sorting functionality with a GNOME HIG-compliant `Adw.SplitButton` to improve user organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-50b59594-b7d0-4984-a113-16c99ab7cecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50b59594-b7d0-4984-a113-16c99ab7cecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

