### PR TITLE
Fix hidden request access button on flatpak light mode

### DIFF
--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -2576,6 +2576,9 @@ class FilePane(Gtk.Box):
             content.set_icon_name("folder-open-symbolic")
             content.set_label("Request Access")
             request_access_button.set_child(content)
+            # Ensure the button uses the suggested-action styling with visible background
+            request_access_button.set_has_frame(True)
+            request_access_button.remove_css_class("flat")
             request_access_button.add_css_class("suggested-action")
             # Store reference to the button so we can hide it later
             self._request_access_button = request_access_button


### PR DESCRIPTION
Restore the frame and remove the `flat` CSS class from the "Request Access" button to make it visible in light mode on Flatpak.

The button was inheriting a generic flat action-bar look, which made it invisible on light themes. By restoring the frame and removing the `flat` class, it now correctly uses the Adwaita “suggested action” styling with a visible background.

---
<a href="https://cursor.com/background-agent?bcId=bc-a025ae9b-f58a-4330-9dd3-e67f27db2bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a025ae9b-f58a-4330-9dd3-e67f27db2bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

