### PR TITLE
Create tui version of sshpilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - File management using SFTP
 - Organize servers in groups
 - Option to use the built-in terminal or your favorite one
+- Built-in terminal user interface (`sshpilot-tui`) for headless workflows
 - Broadcast commands to all open tabs
 - Full support for Local, Remote and Dynamic port forwarding 
 - SCP support for quickly uploading or downloading files to/from remote servers
@@ -171,6 +172,23 @@ python3 run.py --verbose
 `
 
 
+
+## Terminal UI
+
+The same connection database is available in a keyboard-driven terminal UI, ideal for servers and headless environments.
+
+```
+sshpilot-tui             # read ~/.ssh/config and launch from your terminal
+sshpilot-tui --isolated  # use sshPilot's managed ssh_config/known_hosts
+```
+
+Key bindings:
+- Arrow keys / `j` `k`, `PgUp`/`PgDn`, `Home`/`End` for navigation
+- `/` toggles live filtering, `r` reloads `~/.ssh/config`
+- `Enter` or `c` opens the highlighted host and streams the session in-place
+- `?` shows the built-in cheat sheet, `q` quits
+
+The TUI shares the same SSH option builder as the GTK app, so port forwarding, advanced flags, identities, and remote/local commands behave exactly the same.
 
 ## Runtime Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,13 @@ dependencies = [
     "psutil>=5.9.0",
 ]
 
+[project.scripts]
+sshpilot = "sshpilot.main:main"
+sshpilot-tui = "sshpilot.tui.app:main"
+
+[project.gui-scripts]
+sshpilot = "sshpilot.main:main"
+
 [tool.setuptools.packages.find]
 where = ["", "src"]
 include = ["sshpilot*", "sshpilot_dnd*"]

--- a/sshpilot/tui/__init__.py
+++ b/sshpilot/tui/__init__.py
@@ -1,0 +1,9 @@
+"""
+Terminal UI package for sshPilot.
+
+This module exposes the public entry point for running the curses-based TUI.
+"""
+
+from .app import main
+
+__all__ = ["main"]

--- a/sshpilot/tui/app.py
+++ b/sshpilot/tui/app.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import argparse
+import curses
+import locale
+import logging
+import shlex
+import subprocess
+import time
+from typing import List, Optional, Sequence
+
+from sshpilot.config import Config
+from sshpilot.connection_manager import ConnectionManager
+from sshpilot.tui.command_builder import build_ssh_command
+
+LOG = logging.getLogger(__name__)
+
+
+class SshPilotTuiApp:
+    """
+    Curses-based interface for browsing and launching sshPilot connections.
+    """
+
+    def __init__(self, *, isolated_mode: bool = False):
+        self.isolated_mode = isolated_mode
+        self.config = Config()
+        self.connection_manager = ConnectionManager(self.config, isolated_mode=isolated_mode)
+        try:
+            self.connection_manager._post_init_slow_path()
+        except Exception:
+            LOG.debug("Post init slow path failed", exc_info=True)
+
+        self.connections = []
+        self.filtered_connections: List = []
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.filter_text = ""
+        self.mode = "navigate"
+        self.show_help = False
+        self.status_message = ""
+        self.status_error = False
+        self.status_expiry: Optional[float] = None
+        self.visible_list_rows = 1
+        self.screen = None
+
+        self.reload_connections(initial=True)
+
+    # ------------------------------------------------------------------ helpers
+    def reload_connections(self, *, initial: bool = False):
+        self.connection_manager.load_ssh_config()
+        self.connections = sorted(
+            list(self.connection_manager.connections),
+            key=lambda c: (str(getattr(c, "nickname", "") or "").lower(), str(getattr(c, "hostname", "") or "").lower()),
+        )
+        self.apply_filter()
+        if not initial:
+            self.set_status(f"Loaded {len(self.connections)} connection(s)")
+
+    def apply_filter(self):
+        if not self.filter_text:
+            self.filtered_connections = list(self.connections)
+        else:
+            needle = self.filter_text.lower()
+            self.filtered_connections = [
+                conn
+                for conn in self.connections
+                if self._matches(conn, needle)
+            ]
+        if self.filtered_connections:
+            self.selected_index = max(0, min(self.selected_index, len(self.filtered_connections) - 1))
+        else:
+            self.selected_index = 0
+        self.scroll_offset = 0
+
+    @staticmethod
+    def _matches(connection, needle: str) -> bool:
+        fields = [
+            getattr(connection, "nickname", ""),
+            getattr(connection, "hostname", ""),
+            getattr(connection, "host", ""),
+            getattr(connection, "username", ""),
+            getattr(connection, "source", ""),
+        ]
+        for field in fields:
+            if field and needle in str(field).lower():
+                return True
+        return False
+
+    def set_status(self, message: str, *, error: bool = False, persist: bool = False):
+        self.status_message = message
+        self.status_error = error
+        self.status_expiry = None if persist else (time.time() + 6)
+
+    def clear_status_if_needed(self):
+        if self.status_message and self.status_expiry and time.time() > self.status_expiry:
+            self.status_message = ""
+            self.status_expiry = None
+
+    def get_selected_connection(self):
+        if not self.filtered_connections:
+            return None
+        try:
+            return self.filtered_connections[self.selected_index]
+        except IndexError:
+            return None
+
+    # ------------------------------------------------------------------- curses
+    def run(self):
+        locale.setlocale(locale.LC_ALL, "")
+        curses.wrapper(self._curses_main)
+
+    def _curses_main(self, stdscr):
+        self.screen = stdscr
+        try:
+            curses.start_color()
+            curses.use_default_colors()
+        except curses.error:
+            pass
+        curses.noecho()
+        curses.cbreak()
+        stdscr.keypad(True)
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            pass
+        self._init_colors()
+        try:
+            self._main_loop()
+        finally:
+            try:
+                curses.curs_set(1)
+            except curses.error:
+                pass
+            curses.echo()
+            curses.nocbreak()
+            stdscr.keypad(False)
+
+    def _init_colors(self):
+        try:
+            curses.init_pair(1, curses.COLOR_BLACK, curses.COLOR_CYAN)
+            curses.init_pair(2, curses.COLOR_CYAN, -1)
+            curses.init_pair(3, curses.COLOR_RED, -1)
+            curses.init_pair(4, curses.COLOR_GREEN, -1)
+        except Exception:
+            pass
+
+    def _main_loop(self):
+        while True:
+            self.clear_status_if_needed()
+            self._draw()
+            key = self.screen.getch()
+            if key == -1:
+                continue
+            if self.show_help:
+                if key in (ord("?"), 27, curses.KEY_EXIT, ord("q")):
+                    self.show_help = False
+                continue
+            if self.mode == "filter":
+                if self._handle_filter_key(key):
+                    break
+                continue
+            if self._handle_nav_key(key):
+                break
+
+    # ------------------------------------------------------------------ drawing
+    def _draw(self):
+        self.screen.erase()
+        height, width = self.screen.getmaxyx()
+        if height < 10 or width < 60:
+            self.screen.addstr(0, 0, "Window too small for sshpilot-tui (min 60x10)")
+            self.screen.refresh()
+            return
+
+        if self.show_help:
+            self._draw_help(height, width)
+            self.screen.refresh()
+            return
+
+        title = f"sshPilot TUI — {len(self.filtered_connections)} of {len(self.connections)} connections"
+        mode_suffix = " FILTER" if self.mode == "filter" else ""
+        self.screen.addnstr(0, 0, title + mode_suffix, width)
+
+        filter_line = f"/ {self.filter_text}" if self.mode == "filter" else f"Filter: {self.filter_text or '(none)'}"
+        self.screen.addnstr(1, 0, filter_line.ljust(width), width)
+        if self.mode == "filter":
+            cursor_col = min(2 + len(self.filter_text), width - 1)
+            self.screen.move(1, cursor_col)
+
+        header = "{:<28} {:<20} {:<12} {:>5}".format("Nickname", "Host/Hostname", "User", "Port")
+        header_attr = curses.color_pair(2) | curses.A_BOLD if curses.has_colors() else curses.A_BOLD
+        self.screen.addnstr(2, 0, header.ljust(width), width, header_attr)
+
+        list_start = 3
+        status_row = height - 1
+        detail_height = max(3, min(6, height // 3))
+        detail_start = max(list_start + 1, status_row - detail_height)
+        list_height = max(1, detail_start - list_start)
+        self.visible_list_rows = list_height
+        self._ensure_visible(list_height)
+
+        for row_idx in range(list_height):
+            conn_idx = self.scroll_offset + row_idx
+            screen_row = list_start + row_idx
+            if conn_idx >= len(self.filtered_connections):
+                self.screen.addnstr(screen_row, 0, "".ljust(width), width)
+                continue
+            conn = self.filtered_connections[conn_idx]
+            nickname = getattr(conn, "nickname", "") or "(unnamed)"
+            host = getattr(conn, "hostname", "") or getattr(conn, "host", "") or "?"
+            user = getattr(conn, "username", "") or "-"
+            port = getattr(conn, "port", 22)
+            line = "{:<28} {:<20} {:<12} {:>5}".format(nickname[:28], host[:20], user[:12], str(port))
+            if conn_idx == self.selected_index:
+                attr = curses.color_pair(1) | curses.A_BOLD if curses.has_colors() else curses.A_REVERSE
+                self.screen.addnstr(screen_row, 0, line.ljust(width), width, attr)
+            else:
+                self.screen.addnstr(screen_row, 0, line.ljust(width), width)
+
+        self._draw_details(detail_start, status_row - 1, width)
+        self._draw_status(status_row, width)
+        self.screen.refresh()
+
+    def _draw_details(self, start_row: int, end_row: int, width: int):
+        conn = self.get_selected_connection()
+        if not conn:
+            message = "No connections available" if not self.connections else "No matches for current filter"
+            self._draw_wrapped(start_row, end_row, width, message)
+            return
+
+        host_fn = getattr(conn, "get_effective_host", None)
+        effective_host = host_fn() if callable(host_fn) else (getattr(conn, "hostname", "") or getattr(conn, "host", ""))
+        source = getattr(conn, "source", "") or "ssh config"
+        identity = getattr(conn, "keyfile", "") or "default"
+        remote_cmd = getattr(conn, "remote_command", "") or ""
+        data = getattr(conn, "data", None)
+        if not remote_cmd and isinstance(data, dict):
+            remote_cmd = data.get("remote_command", "") or ""
+        details = [
+            f"Nickname : {getattr(conn, 'nickname', '')}",
+            f"Target   : {effective_host} (user: {getattr(conn, 'username', '') or '-'})",
+            f"Port     : {getattr(conn, 'port', 22)}    Key: {identity}",
+            f"Source   : {source}",
+        ]
+        if remote_cmd:
+            details.append(f"Remote cmd: {remote_cmd}")
+
+        self._draw_wrapped(start_row, end_row, width, "\n".join(details))
+
+    def _draw_wrapped(self, start_row: int, end_row: int, width: int, text: str):
+        lines = []
+        for paragraph in text.split("\n"):
+            while paragraph:
+                lines.append(paragraph[: width - 1])
+                paragraph = paragraph[width - 1 :]
+        lines = lines[: max(0, end_row - start_row + 1)]
+        for idx, line in enumerate(lines):
+            self.screen.addnstr(start_row + idx, 0, line.ljust(width), width)
+
+    def _draw_status(self, row: int, width: int):
+        if self.status_message:
+            attr = curses.color_pair(3) if self.status_error and curses.has_colors() else 0
+            msg = self.status_message
+        else:
+            attr = curses.color_pair(4) if curses.has_colors() else 0
+            msg = "Enter: connect  /: filter  r: reload  ?: help  q: quit"
+        self.screen.addnstr(row, 0, msg.ljust(width), width, attr)
+
+    def _draw_help(self, height: int, width: int):
+        help_lines = [
+            "sshPilot TUI — key bindings",
+            "",
+            "Arrow keys / j k : Navigate",
+            "PgUp / PgDn      : Scroll a page",
+            "Home / End       : Jump to start or end",
+            "Enter / c        : Connect to highlighted host",
+            "r                : Reload SSH config",
+            "/                : Filter connections",
+            "Esc              : Cancel filter / exit help",
+            "q                : Quit",
+            "",
+            "Press ? again or Esc to return",
+        ]
+        start_row = max(0, (height - len(help_lines)) // 2)
+        for idx, line in enumerate(help_lines):
+            centered = line.center(width)
+            self.screen.addnstr(start_row + idx, 0, centered[:width], width, curses.A_BOLD if idx == 0 else 0)
+
+    # --------------------------------------------------------------- key input
+    def _handle_filter_key(self, key: int) -> bool:
+        if key in (curses.KEY_ENTER, 10, 13):
+            self.mode = "navigate"
+            curses.curs_set(0)
+            self.apply_filter()
+            return False
+        if key in (27, curses.KEY_EXIT):
+            self.mode = "navigate"
+            curses.curs_set(0)
+            self.filter_text = ""
+            self.apply_filter()
+            return False
+        if key in (curses.KEY_BACKSPACE, 127, 8):
+            self.filter_text = self.filter_text[:-1]
+            self.apply_filter()
+            return False
+        if 32 <= key <= 126:
+            self.filter_text += chr(key)
+            self.apply_filter()
+            return False
+        return False
+
+    def _handle_nav_key(self, key: int) -> bool:
+        if key in (ord("q"), 27):
+            return True
+        if key in (curses.KEY_DOWN, ord("j")):
+            self._move_selection(1)
+        elif key in (curses.KEY_UP, ord("k")):
+            self._move_selection(-1)
+        elif key in (curses.KEY_NPAGE,):
+            self._move_selection(self.visible_list_rows)
+        elif key in (curses.KEY_PPAGE,):
+            self._move_selection(-self.visible_list_rows)
+        elif key in (curses.KEY_HOME,):
+            self.selected_index = 0
+        elif key in (curses.KEY_END,):
+            if self.filtered_connections:
+                self.selected_index = len(self.filtered_connections) - 1
+        elif key in (10, 13, ord("c")):
+            self._connect_selected()
+        elif key in (ord("r"), curses.KEY_F5):
+            self.reload_connections()
+        elif key == ord("/"):
+            self.mode = "filter"
+            curses.curs_set(1)
+        elif key in (ord("?"), curses.KEY_F1):
+            self.show_help = True
+        return False
+
+    def _move_selection(self, delta: int):
+        if not self.filtered_connections:
+            return
+        self.selected_index = min(max(0, self.selected_index + delta), len(self.filtered_connections) - 1)
+        self._ensure_visible(self.visible_list_rows)
+
+    def _ensure_visible(self, list_height: int):
+        if not list_height:
+            list_height = 1
+        max_index = len(self.filtered_connections) - 1
+        if self.selected_index > max_index:
+            self.selected_index = max_index
+        if self.selected_index < 0:
+            self.selected_index = 0
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + list_height:
+            self.scroll_offset = self.selected_index - list_height + 1
+        max_offset = max(0, len(self.filtered_connections) - list_height)
+        if self.scroll_offset > max_offset:
+            self.scroll_offset = max_offset
+
+    # ------------------------------------------------------------- connections
+    def _connect_selected(self):
+        conn = self.get_selected_connection()
+        if not conn:
+            self.set_status("No connection selected", error=True)
+            return
+        try:
+            cmd = build_ssh_command(conn, self.config, known_hosts_path=self.connection_manager.known_hosts_path)
+        except Exception as exc:
+            LOG.exception("Failed to build SSH command")
+            self.set_status(f"Failed to prepare SSH command: {exc}", error=True)
+            return
+
+        display_cmd = " ".join(shlex.quote(part) for part in cmd)
+        self.set_status(f"Connecting with: {display_cmd}", persist=True)
+        self._suspend_curses()
+        try:
+            proc = subprocess.run(cmd)
+            rc = proc.returncode
+        except FileNotFoundError:
+            rc = -1
+            print("ssh executable was not found on PATH.")
+        except Exception as exc:
+            rc = -1
+            print(f"Connection failed: {exc}")
+        finally:
+            self._resume_curses()
+        if rc == 0:
+            self.set_status("SSH session ended", error=False)
+        else:
+            self.set_status(f"SSH exited with code {rc}", error=True)
+
+    def _suspend_curses(self):
+        curses.def_prog_mode()
+        curses.endwin()
+
+    def _resume_curses(self):
+        curses.reset_prog_mode()
+        curses.curs_set(0)
+        if self.screen:
+            self.screen.refresh()
+
+
+def parse_args(argv: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser(description="sshPilot terminal UI")
+    parser.add_argument(
+        "--isolated",
+        action="store_true",
+        help="Use the isolated sshPilot SSH config stored under ~/.config/sshpilot",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        help="Python logging level (default: WARNING)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None):
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.WARNING),
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )
+    app = SshPilotTuiApp(isolated_mode=args.isolated)
+    try:
+        app.run()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+__all__ = ["main", "SshPilotTuiApp"]

--- a/sshpilot/tui/command_builder.py
+++ b/sshpilot/tui/command_builder.py
@@ -1,0 +1,166 @@
+"""
+Helpers for preparing SSH commands for the TUI.
+
+The curses interface needs to run regular ``ssh`` commands that faithfully
+mirror the options configured inside the main GTK application.  This module
+reuses the option generation logic from :mod:`sshpilot.ssh_utils` and adds a
+lightweight layer to decide which host to target, how to deal with quick
+connect commands and how to append remote or local commands.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from typing import Iterable, List, Optional
+
+from sshpilot.ssh_utils import build_connection_ssh_options
+
+
+def _first_non_empty(values: Iterable[str]) -> str:
+    for value in values:
+        if value:
+            return value
+    return ""
+
+
+def _format_host_for_tunnel(host: Optional[str]) -> str:
+    host = (host or "").strip()
+    if not host:
+        return ""
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        return f"[{host}]"
+    return host
+
+
+def build_ssh_command(connection, config, *, known_hosts_path: Optional[str] = None) -> List[str]:
+    """
+    Return the argv list for launching SSH for *connection*.
+
+    Args:
+        connection: ``sshpilot.connection_manager.Connection`` instance.
+        config: Shared :class:`sshpilot.config.Config` used for preference lookup.
+        known_hosts_path: Optional override for ``UserKnownHostsFile`` (used in
+            isolated mode).
+    """
+
+    quick_cmd = (getattr(connection, "quick_connect_command", "") or "").strip()
+    if quick_cmd:
+        try:
+            return shlex.split(quick_cmd)
+        except ValueError as exc:
+            raise ValueError("Quick connect command cannot be parsed") from exc
+
+    cmd: List[str] = ["ssh"]
+
+    options = build_connection_ssh_options(connection, config=config)
+    if options:
+        cmd.extend(options)
+
+    if known_hosts_path:
+        abs_path = os.path.abspath(os.path.expanduser(known_hosts_path))
+        cmd.extend(["-o", f"UserKnownHostsFile={abs_path}"])
+
+    port = getattr(connection, "port", 22) or 22
+    try:
+        port_int = int(port)
+    except (TypeError, ValueError):
+        port_int = 22
+    if port_int != 22:
+        cmd.extend(["-p", str(port_int)])
+
+    local_cmd = _extract_string(connection, "local_command")
+    if local_cmd:
+        cmd.extend(["-o", "PermitLocalCommand=yes", "-o", f"LocalCommand={local_cmd}"])
+
+    remote_cmd = _extract_string(connection, "remote_command")
+    x11_enabled = bool(getattr(connection, "x11_forwarding", False))
+    if x11_enabled and "-X" not in cmd:
+        cmd.append("-X")
+
+    cmd.extend(_build_forwarding_args(connection))
+
+    host_label = ""
+    if hasattr(connection, "resolve_host_identifier"):
+        try:
+            host_label = connection.resolve_host_identifier() or ""
+        except Exception:
+            host_label = ""
+    if not host_label:
+        host_label = _first_non_empty(
+            (
+                getattr(connection, "hostname", ""),
+                getattr(connection, "host", ""),
+                getattr(connection, "nickname", ""),
+            )
+        )
+    host_label = host_label.strip()
+    if not host_label:
+        raise ValueError("Connection is missing a target host")
+
+    username = (getattr(connection, "username", "") or "").strip()
+    if username:
+        target = f"{username}@{host_label}"
+    else:
+        target = host_label
+
+    if remote_cmd:
+        cmd.extend(["-t", "-t"])
+
+    cmd.append(target)
+
+    if remote_cmd:
+        needs_exec_tail = "exec $SHELL" not in remote_cmd
+        final_remote = remote_cmd if not needs_exec_tail else f"{remote_cmd} ; exec $SHELL -l"
+        cmd.append(final_remote)
+
+    return cmd
+
+
+def _extract_string(connection, field: str) -> str:
+    value = getattr(connection, field, None)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+
+    data = getattr(connection, "data", None)
+    if isinstance(data, dict):
+        candidate = data.get(field)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
+def _build_forwarding_args(connection) -> List[str]:
+    forwarding_rules = getattr(connection, "forwarding_rules", []) or []
+    if not isinstance(forwarding_rules, list):
+        return []
+
+    args: List[str] = []
+
+    for rule in forwarding_rules:
+        if not isinstance(rule, dict):
+            continue
+        if not rule.get("enabled", True):
+            continue
+        rule_type = rule.get("type", "local")
+        listen_addr = _format_host_for_tunnel(rule.get("listen_addr") or "localhost")
+        listen_port = rule.get("listen_port")
+        remote_host = _format_host_for_tunnel(rule.get("remote_host") or rule.get("local_host") or "localhost")
+        remote_port = rule.get("remote_port") or rule.get("local_port")
+
+        if rule_type == "dynamic":
+            if listen_port:
+                args.extend(["-D", f"{listen_addr}:{listen_port}"])
+        elif rule_type == "remote":
+            if listen_port and remote_port:
+                remote_target = f"{remote_host}:{remote_port}"
+                args.extend(["-R", f"{listen_addr}:{listen_port}:{remote_target}"])
+        else:  # treat everything else as local forwarding
+            if listen_port and remote_port:
+                remote_target = f"{remote_host}:{remote_port}"
+                args.extend(["-L", f"{listen_addr}:{listen_port}:{remote_target}"])
+
+    return args
+
+
+__all__ = ["build_ssh_command"]

--- a/tests/test_tui_command_builder.py
+++ b/tests/test_tui_command_builder.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+from sshpilot.tui.command_builder import build_ssh_command
+
+
+class DummyConfig:
+    """Minimal config stub for command_builder tests."""
+
+    def get_ssh_config(self):
+        return {
+            "connection_timeout": 5,
+            "auto_add_host_keys": True,
+            "batch_mode": False,
+            "compression": False,
+        }
+
+
+def _make_connection(**overrides):
+    defaults = {
+        "nickname": "web",
+        "hostname": "web.internal",
+        "host": "web",
+        "username": "deploy",
+        "port": 2222,
+        "keyfile": "",
+        "certificate": "",
+        "forwarding_rules": [],
+        "data": {},
+        "quick_connect_command": "",
+        "remote_command": "",
+        "local_command": "",
+        "x11_forwarding": False,
+        "auth_method": 0,
+        "key_select_mode": 0,
+        "password": "",
+        "extra_ssh_config": "",
+    }
+    defaults.update(overrides)
+    conn = SimpleNamespace(**defaults)
+
+    def _resolver():
+        return getattr(conn, "hostname", "") or getattr(conn, "host", "") or getattr(conn, "nickname", "")
+
+    conn.resolve_host_identifier = _resolver
+    return conn
+
+
+def test_build_basic_command_uses_username_and_port():
+    conn = _make_connection()
+    cmd = build_ssh_command(conn, DummyConfig())
+
+    assert cmd[0] == "ssh"
+    assert cmd[-1] == "deploy@web.internal"
+    assert "-p" in cmd
+    port_index = cmd.index("-p")
+    assert cmd[port_index + 1] == "2222"
+
+
+def test_quick_connect_command_is_respected():
+    conn = _make_connection(quick_connect_command="ssh -p 44 other-host")
+    cmd = build_ssh_command(conn, DummyConfig())
+    assert cmd == ["ssh", "-p", "44", "other-host"]
+
+
+def test_remote_command_requests_tty():
+    conn = _make_connection(remote_command="uptime")
+    cmd = build_ssh_command(conn, DummyConfig())
+    host_index = cmd.index("deploy@web.internal")
+    assert cmd[host_index - 2 : host_index] == ["-t", "-t"]
+    assert cmd[-1].startswith("uptime")
+
+
+def test_forwarding_rules_are_translated():
+    forwarding_rules = [
+        {
+            "type": "local",
+            "listen_addr": "127.0.0.1",
+            "listen_port": 8080,
+            "remote_host": "db.local",
+            "remote_port": 5432,
+            "enabled": True,
+        },
+        {
+            "type": "dynamic",
+            "listen_addr": "localhost",
+            "listen_port": 1080,
+            "enabled": True,
+        },
+        {
+            "type": "remote",
+            "listen_addr": "0.0.0.0",
+            "listen_port": 2222,
+            "local_host": "localhost",
+            "local_port": 22,
+            "enabled": True,
+        },
+    ]
+    conn = _make_connection(forwarding_rules=forwarding_rules)
+    cmd = build_ssh_command(conn, DummyConfig())
+
+    assert any(arg == "127.0.0.1:8080:db.local:5432" for arg in cmd)
+    assert any(arg == "localhost:1080" for arg in cmd)
+    assert any(arg == "0.0.0.0:2222:localhost:22" for arg in cmd)


### PR DESCRIPTION
Add a curses-based Terminal User Interface (TUI) for sshPilot to enable keyboard-driven connection management in headless environments.

The TUI reuses the existing SSH command building logic from the GTK application to ensure consistent behavior for connection options, port forwarding, and remote commands. It also handles suspending and resuming the curses environment to allow SSH sessions to run directly in the terminal.

---
<a href="https://cursor.com/background-agent?bcId=bc-c88ae24a-bae5-49b7-8301-2f5bb12afab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c88ae24a-bae5-49b7-8301-2f5bb12afab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

