### PR TITLE
Run yui version

### DIFF
--- a/sshpilot/tui/__init__.py
+++ b/sshpilot/tui/__init__.py
@@ -2,8 +2,21 @@
 Terminal UI package for sshPilot.
 
 This module exposes the public entry point for running the curses-based TUI.
+The actual TUI implementation lives in ``sshpilot.tui.app``. We import it
+lazily so that running ``python -m sshpilot.tui.app`` does not emit the
+``RuntimeWarning`` that occurs when the module is imported twice before being
+executed.
 """
 
-from .app import main
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["main"]
+
+
+def main(*args: Any, **kwargs: Any) -> Any:
+    """Entry point used by ``sshpilot-tui`` console script."""
+    from .app import main as _app_main
+
+    return _app_main(*args, **kwargs)


### PR DESCRIPTION
Make `sshpilot.tui.app` import lazy in `sshpilot.tui.__init__.py` to prevent `RuntimeWarning` when running `python3 -m sshpilot.tui.app`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4722f913-f736-4156-b791-e2c37f606756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4722f913-f736-4156-b791-e2c37f606756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

