### PR TITLE
Fix invalid css column-gap property

### DIFF
--- a/sshpilot/tui/app.py
+++ b/sshpilot/tui/app.py
@@ -167,15 +167,15 @@ class SshPilotTuiApp(App[None]):
         layout: vertical;
     }
 
-    HelpScreen {
-        align: center middle;
-    }
+      HelpScreen {
+          align: center middle;
+      }
 
-    #body {
-        height: 1fr;
-        padding: 1 2;
-        column-gap: 2;
-    }
+      #body {
+          height: 1fr;
+          padding: 1 2;
+          gap: 2;
+      }
 
     #list-panel, #details-panel {
         height: 1fr;


### PR DESCRIPTION
Replace unsupported `column-gap` with `gap` in the TUI stylesheet to fix CSS parsing errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb2beb76-f8d1-4075-8cd0-d1eff7fa2827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb2beb76-f8d1-4075-8cd0-d1eff7fa2827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

