### PR TITLE
Investigate sshpilot issue 765

### DIFF
--- a/packaging/fedora/rpm.spec
+++ b/packaging/fedora/rpm.spec
@@ -11,6 +11,9 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  desktop-file-utils
 
+# Exclude automatic Python ABI dependency to allow compatibility across Python 3.x versions
+%global __requires_exclude ^python\\(abi\\)
+
 Requires:       python3
 Requires:       python3-gobject
 Requires:       gtk4 >= 4.6


### PR DESCRIPTION
Exclude automatic Python ABI dependency in RPM spec file to fix installation failures on Fedora 43 due to Python 3.14 incompatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-0de144fb-de8d-4844-ba94-5d7db6ee0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0de144fb-de8d-4844-ba94-5d7db6ee0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

