### PR TITLE
Fix macOS preferences title bar duplication

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -596,22 +596,27 @@ class PreferencesWindow(Gtk.Window):
         self.header_bar.set_title_widget(self.header_title_label)
 
         self.header_controls = None
-        try:
-            self.header_controls = Gtk.WindowControls.new(Gtk.PackType.END)
-        except AttributeError:
-            logger.debug("Gtk.WindowControls unavailable; skipping window buttons")
+        if not is_macos():
+            try:
+                self.header_controls = Gtk.WindowControls.new(Gtk.PackType.END)
+            except AttributeError:
+                logger.debug("Gtk.WindowControls unavailable; skipping window buttons")
         if self.header_controls:
             self.header_bar.pack_end(self.header_controls)
             self.header_bar.set_show_title_buttons(False)
         else:
             self.header_bar.set_show_title_buttons(True)
 
-        window_handle = Gtk.WindowHandle()
-        window_handle.set_child(self.header_bar)
-
         self.content_toolbar_view = Adw.ToolbarView()
-        self.content_toolbar_view.add_top_bar(window_handle)
-        self.content_toolbar_view.set_content(content_scroller)
+        if is_macos():
+            # Use the headerbar as the window titlebar on macOS to avoid a double title bar
+            self.set_titlebar(self.header_bar)
+            self.content_toolbar_view.set_content(content_scroller)
+        else:
+            window_handle = Gtk.WindowHandle()
+            window_handle.set_child(self.header_bar)
+            self.content_toolbar_view.add_top_bar(window_handle)
+            self.content_toolbar_view.set_content(content_scroller)
 
         content_page = Adw.NavigationPage.new(self.content_toolbar_view, "Preferences")
         self.navigation_split_view.set_content(content_page)


### PR DESCRIPTION
## Summary
- use the preferences header bar as the macOS titlebar to avoid double title bars
- keep custom window controls only on non-macOS platforms

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693038c972d883298284d96e771a5e9f)