### PR TITLE
Only add SSH keys to agent when requested by config

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -177,6 +177,8 @@ class Connection:
         # Track IdentityAgent directives so terminals can adjust askpass behaviour
         self.identity_agent_directive: str = ''
         self.identity_agent_disabled: bool = False
+        self.add_keys_to_agent_directive: str = ''
+        self.add_keys_to_agent_enabled: bool = False
         
         # Key selection mode: 0 try all, 1 specific key (IdentitiesOnly), 2 specific key (no IdentitiesOnly)
         try:
@@ -280,6 +282,7 @@ class Connection:
 
         # Reset IdentityAgent state before evaluating configuration
         self._update_identity_agent_state(None)
+        self._update_add_keys_to_agent_state(None)
 
         candidates: List[str] = []
         seen: Set[str] = set()
@@ -306,6 +309,9 @@ class Connection:
             if effective_cfg is not None:
                 self._update_identity_agent_state(
                     effective_cfg.get('identityagent')  # type: ignore[arg-type]
+                )
+                self._update_add_keys_to_agent_state(
+                    effective_cfg.get('addkeystoagent')  # type: ignore[arg-type]
                 )
             _add_candidate(keyfile_value)
             return candidates
@@ -341,6 +347,7 @@ class Connection:
 
         cfg = effective_cfg or {}
         self._update_identity_agent_state(cfg.get('identityagent'))
+        self._update_add_keys_to_agent_state(cfg.get('addkeystoagent'))
         cfg_ids = cfg.get('identityfile') if isinstance(cfg, dict) else None
         if isinstance(cfg_ids, list):
             for value in cfg_ids:
@@ -381,6 +388,36 @@ class Connection:
                 "IdentityAgent directive disables ssh-agent; forcing askpass for this connection"
             )
 
+    def _update_add_keys_to_agent_state(
+        self, directive: Optional[Union[str, List[str]]]
+    ) -> None:
+        """Update AddKeysToAgent directive tracking for the connection."""
+
+        directive_value = ''
+        enabled = False
+
+        if isinstance(directive, list):
+            values = [
+                str(entry).strip()
+                for entry in directive
+                if isinstance(entry, str) and str(entry).strip()
+            ]
+        elif isinstance(directive, str):
+            stripped = directive.strip()
+            values = [stripped] if stripped else []
+        else:
+            values = []
+
+        if values:
+            directive_value = values[-1]
+            lowered = directive_value.lower()
+            enabled = lowered in {'yes', 'confirm', 'ask'}
+
+        self.add_keys_to_agent_directive = directive_value
+        self.add_keys_to_agent_enabled = enabled
+        if enabled:
+            logger.debug("AddKeysToAgent enabled via directive: %s", directive_value)
+
     @property
     def source_file(self) -> str:
         """Return path to the config file where this host is defined."""
@@ -390,6 +427,7 @@ class Connection:
         """Prepare SSH command for later use (no preflight echo)."""
         try:
             self._update_identity_agent_state(None)
+            self._update_add_keys_to_agent_state(None)
             # Reset resolved identity cache on every connect preparation
             self.resolved_identity_files = []
 
@@ -508,6 +546,9 @@ class Connection:
 
 
             self._update_identity_agent_state(effective_cfg.get('identityagent'))
+            self._update_add_keys_to_agent_state(
+                effective_cfg.get('addkeystoagent')
+            )
 
             # Determine final parameters, falling back to resolved config when needed
             existing_hostname = self.hostname or ''
@@ -635,6 +676,7 @@ class Connection:
         """Prepare a minimal SSH command deferring to the user's SSH configuration."""
         try:
             self._update_identity_agent_state(None)
+            self._update_add_keys_to_agent_state(None)
             # Reset resolved identity cache when preparing native command
             self.resolved_identity_files = []
 
@@ -672,6 +714,9 @@ class Connection:
                 effective_cfg = {}
 
             self._update_identity_agent_state(effective_cfg.get('identityagent'))
+            self._update_add_keys_to_agent_state(
+                effective_cfg.get('addkeystoagent')
+            )
 
             try:
                 from .config import Config  # avoid circular import at top level

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1394,6 +1394,10 @@ class AsyncSFTPManager(GObject.GObject):
                     logger.debug(
                         "File manager: IdentityAgent disabled; skipping key preparation"
                     )
+                elif not getattr(connection, "add_keys_to_agent_enabled", False):
+                    logger.debug(
+                        "File manager: AddKeysToAgent not enabled; skipping key preparation"
+                    )
                 elif (
                     self._connection_manager is not None
                     and hasattr(self._connection_manager, "prepare_key_for_connection")
@@ -1401,9 +1405,13 @@ class AsyncSFTPManager(GObject.GObject):
                     try:
                         key_prepared = self._connection_manager.prepare_key_for_connection(keyfile)
                         if key_prepared:
-                            logger.debug("Successfully prepared key for file manager: %s", keyfile)
+                            logger.debug(
+                                "Successfully prepared key for file manager: %s", keyfile
+                            )
                         else:
-                            logger.warning("Failed to prepare key for file manager: %s", keyfile)
+                            logger.warning(
+                                "Failed to prepare key for file manager: %s", keyfile
+                            )
                     except Exception as exc:  # pragma: no cover - defensive
                         logger.warning("Error preparing key for file manager %s: %s", keyfile, exc)
                         key_prepared = False

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -878,6 +878,10 @@ class TerminalWidget(Gtk.Box):
             logger.debug("IdentityAgent disabled; skipping native key preload")
             return
 
+        if not getattr(connection, 'add_keys_to_agent_enabled', False):
+            logger.debug("AddKeysToAgent not enabled; skipping native key preload")
+            return
+
         manager = getattr(self, 'connection_manager', None)
         if not manager or not hasattr(manager, 'prepare_key_for_connection'):
             return
@@ -1258,6 +1262,10 @@ class TerminalWidget(Gtk.Box):
                         if getattr(self.connection, 'identity_agent_disabled', False):
                             logger.debug(
                                 "IdentityAgent disabled; skipping key preparation before connection"
+                            )
+                        elif not getattr(self.connection, 'add_keys_to_agent_enabled', False):
+                            logger.debug(
+                                "AddKeysToAgent not enabled; skipping key preparation before connection"
                             )
                         else:
                             try:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -165,6 +165,7 @@ class SCPConnectionProfile:
     keyfile_ok: bool
     keyfile_expanded: str
     identity_agent_disabled: bool = False
+    add_keys_to_agent_enabled: bool = False
 
 
 def _quote_remote_path_for_shell(path: str) -> str:
@@ -5252,6 +5253,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         identity_agent_disabled = bool(
             getattr(connection, 'identity_agent_disabled', False)
         )
+
+        add_keys_to_agent_enabled = bool(
+            getattr(connection, 'add_keys_to_agent_enabled', False)
+        )
         
         # Also check if 'identityagent none' is in the SSH options
         if not identity_agent_disabled and ssh_options:
@@ -5277,6 +5282,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             keyfile_ok=keyfile_ok,
             keyfile_expanded=expanded_keyfile if keyfile_ok else '',
             identity_agent_disabled=identity_agent_disabled,
+            add_keys_to_agent_enabled=add_keys_to_agent_enabled,
         )
 
     def _prompt_scp_download(self, connection):
@@ -6808,6 +6814,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     if profile.identity_agent_disabled:
                         logger.debug(
                             "SCP: IdentityAgent disabled; skipping key preload"
+                        )
+                    elif not profile.add_keys_to_agent_enabled:
+                        logger.debug(
+                            "SCP: AddKeysToAgent not enabled; skipping key preload"
                         )
                     else:
                         self.connection_manager.prepare_key_for_connection(

--- a/tests/test_terminal_askpass.py
+++ b/tests/test_terminal_askpass.py
@@ -307,6 +307,7 @@ def test_prepare_key_skipped_when_identity_agent_disabled(tmp_path):
         key_select_mode=1,
         keyfile=str(key_path),
         identity_agent_disabled=True,
+        add_keys_to_agent_enabled=True,
     )
 
     terminal.connection = connection
@@ -316,6 +317,11 @@ def test_prepare_key_skipped_when_identity_agent_disabled(tmp_path):
     assert prepare_calls == []
 
     connection.identity_agent_disabled = False
+    connection.add_keys_to_agent_enabled = False
+    terminal._prepare_key_for_native_mode()
+    assert prepare_calls == []
+
+    connection.add_keys_to_agent_enabled = True
     terminal._prepare_key_for_native_mode()
     assert prepare_calls == [str(key_path)]
 

--- a/tests/test_terminal_pass_through.py
+++ b/tests/test_terminal_pass_through.py
@@ -92,7 +92,9 @@ def test_prepare_key_native_mode_falls_back(monkeypatch, tmp_path, caplog):
             return False
 
     terminal.connection_manager = DummyManager()
-    terminal.connection = types.SimpleNamespace(key_select_mode=0)
+    terminal.connection = types.SimpleNamespace(
+        key_select_mode=0, add_keys_to_agent_enabled=True
+    )
     terminal._resolve_native_identity_candidates = lambda: [
         str(first_key),
         str(second_key),


### PR DESCRIPTION
## Summary
- track the AddKeysToAgent directive and only preload keys when the SSH config opts in
- apply the opt-in check across terminal, SCP, and file manager key preparation logic
- extend tests to cover the new AddKeysToAgent requirement

## Testing
- pytest tests/test_terminal_pass_through.py::test_prepare_key_native_mode_falls_back tests/test_terminal_askpass.py::test_prepare_key_skipped_when_identity_agent_disabled tests/test_window_scp_args.py::test_build_scp_argv_only_prepares_keys_when_enabled


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936f1106034832986f0562ee0cdf757)