### PR TITLE
Honor AddKeysToAgent before adding SSH keys

### DIFF
--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -177,6 +177,9 @@ class Connection:
         # Track IdentityAgent directives so terminals can adjust askpass behaviour
         self.identity_agent_directive: str = ''
         self.identity_agent_disabled: bool = False
+
+        # Track AddKeysToAgent directives to control when keys are added to ssh-agent
+        self.add_keys_to_agent: bool = False
         
         # Key selection mode: 0 try all, 1 specific key (IdentitiesOnly), 2 specific key (no IdentitiesOnly)
         try:
@@ -278,8 +281,9 @@ class Connection:
     ) -> List[str]:
         """Return resolved identity file paths that exist on disk for this host."""
 
-        # Reset IdentityAgent state before evaluating configuration
+        # Reset IdentityAgent/AddKeysToAgent state before evaluating configuration
         self._update_identity_agent_state(None)
+        self._update_add_keys_to_agent_state(None)
 
         candidates: List[str] = []
         seen: Set[str] = set()
@@ -306,6 +310,9 @@ class Connection:
             if effective_cfg is not None:
                 self._update_identity_agent_state(
                     effective_cfg.get('identityagent')  # type: ignore[arg-type]
+                )
+                self._update_add_keys_to_agent_state(
+                    effective_cfg.get('addkeystoagent')  # type: ignore[arg-type]
                 )
             _add_candidate(keyfile_value)
             return candidates
@@ -341,6 +348,7 @@ class Connection:
 
         cfg = effective_cfg or {}
         self._update_identity_agent_state(cfg.get('identityagent'))
+        self._update_add_keys_to_agent_state(cfg.get('addkeystoagent'))
         cfg_ids = cfg.get('identityfile') if isinstance(cfg, dict) else None
         if isinstance(cfg_ids, list):
             for value in cfg_ids:
@@ -381,6 +389,31 @@ class Connection:
                 "IdentityAgent directive disables ssh-agent; forcing askpass for this connection"
             )
 
+    def _update_add_keys_to_agent_state(
+        self, directive: Optional[Union[str, List[str]]]
+    ) -> None:
+        """Update cached AddKeysToAgent directive state for the connection."""
+
+        enabled = False
+
+        if isinstance(directive, list):
+            values = [
+                str(entry).strip()
+                for entry in directive
+                if isinstance(entry, str) and str(entry).strip()
+            ]
+        elif isinstance(directive, str):
+            stripped = directive.strip()
+            values = [stripped] if stripped else []
+        else:
+            values = []
+
+        if values:
+            final_value = values[-1].lower()
+            enabled = final_value in {'yes', 'confirm', 'ask'}
+
+        self.add_keys_to_agent = enabled
+
     @property
     def source_file(self) -> str:
         """Return path to the config file where this host is defined."""
@@ -390,6 +423,7 @@ class Connection:
         """Prepare SSH command for later use (no preflight echo)."""
         try:
             self._update_identity_agent_state(None)
+            self._update_add_keys_to_agent_state(None)
             # Reset resolved identity cache on every connect preparation
             self.resolved_identity_files = []
 
@@ -508,6 +542,7 @@ class Connection:
 
 
             self._update_identity_agent_state(effective_cfg.get('identityagent'))
+            self._update_add_keys_to_agent_state(effective_cfg.get('addkeystoagent'))
 
             # Determine final parameters, falling back to resolved config when needed
             existing_hostname = self.hostname or ''
@@ -635,6 +670,7 @@ class Connection:
         """Prepare a minimal SSH command deferring to the user's SSH configuration."""
         try:
             self._update_identity_agent_state(None)
+            self._update_add_keys_to_agent_state(None)
             # Reset resolved identity cache when preparing native command
             self.resolved_identity_files = []
 
@@ -672,6 +708,7 @@ class Connection:
                 effective_cfg = {}
 
             self._update_identity_agent_state(effective_cfg.get('identityagent'))
+            self._update_add_keys_to_agent_state(effective_cfg.get('addkeystoagent'))
 
             try:
                 from .config import Config  # avoid circular import at top level

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -1374,9 +1374,13 @@ class AsyncSFTPManager(GObject.GObject):
             logger.debug("File manager: No connection object provided")
 
         identity_agent_disabled = False
+        add_keys_to_agent = False
         if connection is not None:
             identity_agent_disabled = bool(
                 getattr(connection, "identity_agent_disabled", False)
+            )
+            add_keys_to_agent = bool(
+                getattr(connection, "add_keys_to_agent", False)
             )
 
         if (
@@ -1393,6 +1397,10 @@ class AsyncSFTPManager(GObject.GObject):
                 if identity_agent_disabled:
                     logger.debug(
                         "File manager: IdentityAgent disabled; skipping key preparation"
+                    )
+                elif not add_keys_to_agent:
+                    logger.debug(
+                        "File manager: AddKeysToAgent not enabled; skipping key preparation"
                     )
                 elif (
                     self._connection_manager is not None

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -878,6 +878,10 @@ class TerminalWidget(Gtk.Box):
             logger.debug("IdentityAgent disabled; skipping native key preload")
             return
 
+        if not getattr(connection, 'add_keys_to_agent', False):
+            logger.debug("AddKeysToAgent not enabled; skipping native key preload")
+            return
+
         manager = getattr(self, 'connection_manager', None)
         if not manager or not hasattr(manager, 'prepare_key_for_connection'):
             return

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -165,6 +165,7 @@ class SCPConnectionProfile:
     keyfile_ok: bool
     keyfile_expanded: str
     identity_agent_disabled: bool = False
+    add_keys_to_agent: bool = False
 
 
 def _quote_remote_path_for_shell(path: str) -> str:
@@ -349,7 +350,7 @@ def list_remote_files(
     
     # Set up askpass environment if we have a keyfile (askpass will handle passphrase retrieval/prompting)
     # Check if askpass is already set up (inherited from caller)
-    has_inherited_askpass = bool(inherit_env and inherit_env.get('SSH_ASKPASS_REQUIRE'))
+    has_inherited_askpass = False
     
     # Set up askpass if we have a keyfile and not using password auth
     # The askpass script will retrieve from storage or show GUI dialog if needed
@@ -500,7 +501,15 @@ def download_file(
     ssh_extra_opts: List[str] = list(extra_ssh_opts or [])
     
     # Check if the inherited environment has askpass configured (e.g., when identity agent is disabled)
-    has_inherited_askpass = bool(inherit_env and inherit_env.get('SSH_ASKPASS_REQUIRE'))
+    has_inherited_askpass = False
+
+    # Always ensure explicit key options are present when a keyfile is provided
+    if keyfile:
+        if '-i' not in ssh_extra_opts:
+            ssh_extra_opts.extend(['-i', keyfile])
+
+        if key_mode == 1 and 'IdentitiesOnly=yes' not in ' '.join(ssh_extra_opts):
+            ssh_extra_opts.extend(['-o', 'IdentitiesOnly=yes'])
 
     # Set up askpass if we have a keyfile and not using password auth
     # The askpass script will retrieve from storage or show GUI dialog if needed
@@ -522,12 +531,6 @@ def download_file(
             except Exception:
                 logger.debug('SCP: Unable to initialize askpass environment', exc_info=True)
 
-        if keyfile and '-i' not in ssh_extra_opts:
-            ssh_extra_opts.extend(['-i', keyfile])
-
-        if key_mode == 1 and 'IdentitiesOnly=yes' not in ' '.join(ssh_extra_opts):
-            ssh_extra_opts.extend(['-o', 'IdentitiesOnly=yes'])
-
         if get_scp_ssh_options is not None:
             try:
                 passphrase_opts = list(get_scp_ssh_options())
@@ -545,8 +548,12 @@ def download_file(
                         break
                 if not already:
                     ssh_extra_opts.extend([flag, value])
-    elif not has_inherited_askpass:
+        else:
+            if 'PreferredAuthentications=publickey' not in ' '.join(ssh_extra_opts):
+                ssh_extra_opts.extend(['-o', 'PreferredAuthentications=publickey'])
+    elif not has_inherited_askpass or not keyfile:
         # Only remove askpass environment if it wasn't inherited (e.g., when identity agent is disabled)
+        # Always clear when no keyfile is in use to match default SSH prompting behaviour
         env.pop('SSH_ASKPASS', None)
         env.pop('SSH_ASKPASS_REQUIRE', None)
 
@@ -5252,6 +5259,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         identity_agent_disabled = bool(
             getattr(connection, 'identity_agent_disabled', False)
         )
+
+        add_keys_to_agent = bool(
+            getattr(connection, 'add_keys_to_agent', False)
+        )
         
         # Also check if 'identityagent none' is in the SSH options
         if not identity_agent_disabled and ssh_options:
@@ -5277,6 +5288,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             keyfile_ok=keyfile_ok,
             keyfile_expanded=expanded_keyfile if keyfile_ok else '',
             identity_agent_disabled=identity_agent_disabled,
+            add_keys_to_agent=add_keys_to_agent,
         )
 
     def _prompt_scp_download(self, connection):
@@ -6808,6 +6820,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     if profile.identity_agent_disabled:
                         logger.debug(
                             "SCP: IdentityAgent disabled; skipping key preload"
+                        )
+                    elif not profile.add_keys_to_agent:
+                        logger.debug(
+                            "SCP: AddKeysToAgent not enabled; skipping key preload"
                         )
                     else:
                         self.connection_manager.prepare_key_for_connection(

--- a/tests/test_terminal_askpass.py
+++ b/tests/test_terminal_askpass.py
@@ -7,14 +7,36 @@ class DummyVte:
         self.last_env_list = None
         self.spawn_calls = []
 
-    def spawn_async(self, *args):
-        # env_list is the 4th positional argument
-        if len(args) >= 4:
-            self.last_env_list = list(args[3]) if args[3] is not None else None
+    def spawn_async(self, *args, **kwargs):
+        env_list = None
+        if 'env' in kwargs and isinstance(kwargs.get('env'), dict):
+            env_items = kwargs.get('env') or {}
+            env_list = [f"{k}={v}" for k, v in env_items.items()]
+        elif 'envv' in kwargs:
+            env_list = kwargs.get('envv')
+        elif len(args) >= 4:
+            env_list = args[3]
+        if env_list is not None:
+            self.last_env_list = list(env_list)
         self.spawn_calls.append(args)
         return None
 
     def grab_focus(self):
+        return None
+
+
+class DummyBackend:
+    def __init__(self, vte):
+        self.vte = vte
+        self.widget = vte
+
+    def spawn_async(self, *args, **kwargs):
+        return self.vte.spawn_async(*args, **kwargs)
+
+    def grab_focus(self):
+        return None
+
+    def feed(self, *_args, **_kwargs):
         return None
 
 
@@ -140,6 +162,7 @@ def test_forced_askpass_without_passphrase(monkeypatch, caplog):
     terminal._set_connecting_overlay_visible = lambda *a, **k: None
     terminal._set_disconnected_banner_visible = lambda *a, **k: None
     terminal.emit = lambda *a, **k: None
+    terminal.backend = DummyBackend(terminal.vte)
     terminal.session_id = "session-123"
     terminal.is_connected = False
     terminal._is_quitting = False
@@ -267,6 +290,7 @@ def test_forced_askpass_with_resolved_identity_passphrase(monkeypatch, caplog):
     terminal._set_connecting_overlay_visible = lambda *a, **k: None
     terminal._set_disconnected_banner_visible = lambda *a, **k: None
     terminal.emit = lambda *a, **k: None
+    terminal.backend = DummyBackend(terminal.vte)
     terminal.session_id = "session-456"
     terminal.is_connected = False
     terminal._is_quitting = False
@@ -307,6 +331,7 @@ def test_prepare_key_skipped_when_identity_agent_disabled(tmp_path):
         key_select_mode=1,
         keyfile=str(key_path),
         identity_agent_disabled=True,
+        add_keys_to_agent=True,
     )
 
     terminal.connection = connection
@@ -417,6 +442,7 @@ def test_identity_agent_disabled_with_key_auth_uses_forced_askpass(monkeypatch, 
     terminal._set_connecting_overlay_visible = lambda *a, **k: None
     terminal._set_disconnected_banner_visible = lambda *a, **k: None
     terminal.emit = lambda *a, **k: None
+    terminal.backend = DummyBackend(terminal.vte)
     terminal.session_id = "session-forced"
     terminal.is_connected = False
     terminal._is_quitting = False

--- a/tests/test_terminal_pass_through.py
+++ b/tests/test_terminal_pass_through.py
@@ -92,7 +92,10 @@ def test_prepare_key_native_mode_falls_back(monkeypatch, tmp_path, caplog):
             return False
 
     terminal.connection_manager = DummyManager()
-    terminal.connection = types.SimpleNamespace(key_select_mode=0)
+    terminal.connection = types.SimpleNamespace(
+        key_select_mode=0,
+        add_keys_to_agent=True,
+    )
     terminal._resolve_native_identity_candidates = lambda: [
         str(first_key),
         str(second_key),

--- a/tests/test_window_scp_args.py
+++ b/tests/test_window_scp_args.py
@@ -58,6 +58,7 @@ def _build_args(monkeypatch, tmp_path, key_mode):
         key_select_mode=key_mode,
         auth_method=2,
         port=22,
+        add_keys_to_agent=True,
     )
 
     dummy_window = _DummyWindow()
@@ -103,6 +104,7 @@ def test_build_scp_argv_skips_key_prep_when_identity_agent_disabled(monkeypatch,
         auth_method=2,
         port=22,
         identity_agent_disabled=True,
+        add_keys_to_agent=True,
     )
 
     dummy_window = _DummyWindow()


### PR DESCRIPTION
## Summary
- respect AddKeysToAgent directives before preloading keys into ssh-agent and propagate the flag to terminal and SCP flows
- tighten askpass/SCP option handling to keep behavior consistent with default SSH expectations
- update tests and supporting helpers for the new key-loading rules

## Testing
- pytest tests/test_terminal_pass_through.py tests/test_terminal_askpass.py tests/test_window_scp_args.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936f1106034832986f0562ee0cdf757)