### PR TITLE
Include appstream metadata in packages

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -118,6 +118,8 @@ jobs:
             echo -e "\tcp -a sshpilot/vendor/pyxtermjs/LICENSE \$(CURDIR)/debian/sshpilot/usr/lib/python3/dist-packages/sshpilot/vendor/pyxtermjs/ 2>/dev/null || true"
             echo -e "\t# Install desktop file and icon"
             echo -e "\tinstall -D -m 644 io.github.mfat.sshpilot.desktop \$(CURDIR)/debian/sshpilot/usr/share/applications/io.github.mfat.sshpilot.desktop"
+            echo -e "\t# Install appstream metadata"
+            echo -e "\tinstall -D -m 644 io.github.mfat.sshpilot.metainfo.xml \$(CURDIR)/debian/sshpilot/usr/share/metainfo/io.github.mfat.sshpilot.metainfo.xml"
             echo -e "\tinstall -D -m 644 sshpilot/resources/sshpilot.svg \$(CURDIR)/debian/sshpilot/usr/share/pixmaps/io.github.mfat.sshpilot.svg"
             echo "override_dh_auto_test:"
             echo -e "\t# Skip tests for now (can be enabled later)"
@@ -173,6 +175,7 @@ jobs:
           ls -la run.py || echo "run.py missing"
           ls -la sshpilot/ || echo "sshpilot/ missing"
           ls -la io.github.mfat.sshpilot.desktop || echo "desktop file missing"
+          ls -la io.github.mfat.sshpilot.metainfo.xml || echo "metainfo file missing"
           ls -la sshpilot/resources/sshpilot.svg || echo "icon missing"
           
           echo "=== Debian packaging files created ==="

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -79,6 +79,7 @@ jobs:
           BuildArch:      noarch
           BuildRequires:  python3-devel
           BuildRequires:  desktop-file-utils
+          BuildRequires:  appstream
           
           # Exclude automatic Python ABI dependency to allow compatibility across Python 3.x versions
           %global __requires_exclude ^python\\(abi\\)
@@ -98,7 +99,7 @@ jobs:
           Requires:       sshpass
           Requires:       openssh-askpass
           Requires:       webkitgtk6.0
-          
+
           %description
           SSH Pilot is a user-friendly SSH connection manager featuring built-in tabbed terminal, remote file management, key transfer, port forwarding and more. It's an alternative to Putty, Termius and Mobaxterm.
           
@@ -124,7 +125,7 @@ jobs:
           cp -a sshpilot/vendor/pyxtermjs/*.py %{buildroot}%{_datadir}/sshpilot/sshpilot/vendor/pyxtermjs/
           cp -a sshpilot/vendor/pyxtermjs/*.html %{buildroot}%{_datadir}/sshpilot/sshpilot/vendor/pyxtermjs/ 2>/dev/null || true
           cp -a sshpilot/vendor/pyxtermjs/LICENSE %{buildroot}%{_datadir}/sshpilot/sshpilot/vendor/pyxtermjs/ 2>/dev/null || true
-          
+
           # Create wrapper script that sets PYTHONPATH
           cat > sshpilot-wrapper << 'WRAPPER_EOF'
           #!/usr/bin/env python3
@@ -138,14 +139,16 @@ jobs:
           
           # Install the wrapper as the main executable
           install -D -m 755 sshpilot-wrapper %{buildroot}%{_bindir}/sshpilot
-          
-          # Install desktop file and icon
+
+          # Install desktop file, appstream metadata and icon
           install -D -m 644 io.github.mfat.sshpilot.desktop %{buildroot}%{_datadir}/applications/io.github.mfat.sshpilot.desktop
+          install -D -m 644 io.github.mfat.sshpilot.metainfo.xml %{buildroot}%{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml
           install -D -m 644 sshpilot/resources/sshpilot.svg %{buildroot}%{_datadir}/pixmaps/io.github.mfat.sshpilot.svg
-          
+
           %check
           # Validate desktop file
           desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.mfat.sshpilot.desktop || true
+          appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml || true
           
           %files
           %license LICENSE*
@@ -153,6 +156,7 @@ jobs:
           %{_bindir}/sshpilot
           %{_datadir}/sshpilot/
           %{_datadir}/applications/io.github.mfat.sshpilot.desktop
+          %{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml
           %{_datadir}/pixmaps/io.github.mfat.sshpilot.svg
           
           %changelog
@@ -166,6 +170,7 @@ jobs:
           ls -la run.py || echo "run.py missing"
           ls -la sshpilot/ || echo "sshpilot/ missing"
           ls -la io.github.mfat.sshpilot.desktop || echo "desktop file missing"
+          ls -la io.github.mfat.sshpilot.metainfo.xml || echo "metainfo file missing"
           ls -la sshpilot/resources/sshpilot.svg || echo "icon missing"
           ls -la sshpilot/vendor/pyxtermjs/ || echo "vendor/pyxtermjs/ missing"
           

--- a/packaging/fedora/rpm.spec
+++ b/packaging/fedora/rpm.spec
@@ -12,6 +12,7 @@ Source0:        https://github.com/mfat/sshpilot/archive/refs/tags/v%{version}.t
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  desktop-file-utils
+BuildRequires:  appstream
 
 # Exclude automatic Python ABI dependency to allow compatibility across Python 3.x versions
 %global __requires_exclude ^python\\(abi\\)
@@ -69,11 +70,13 @@ cp -a sshpilot/vendor/pyxtermjs/LICENSE %{buildroot}%{python3_sitelib}/sshpilot/
 
 # Install desktop file and icon
 install -D -m 644 io.github.mfat.sshpilot.desktop %{buildroot}%{_datadir}/applications/io.github.mfat.sshpilot.desktop
+install -D -m 644 io.github.mfat.sshpilot.metainfo.xml %{buildroot}%{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml
 install -D -m 644 sshpilot/resources/sshpilot.svg %{buildroot}%{_datadir}/pixmaps/io.github.mfat.sshpilot.svg
 
 %check
 # Validate desktop file
 desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.mfat.sshpilot.desktop || true
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml || true
 
 %files
 %license LICENSE*
@@ -81,6 +84,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.mfat.sshpil
 %{_bindir}/sshpilot
 %{python3_sitelib}/sshpilot/
 %{_datadir}/applications/io.github.mfat.sshpilot.desktop
+%{_metainfodir}/io.github.mfat.sshpilot.metainfo.xml
 %{_datadir}/pixmaps/io.github.mfat.sshpilot.svg
 
 %changelog


### PR DESCRIPTION
## Summary
- install the AppStream metainfo.xml during Debian package creation
- include AppStream metadata and validation in RPM workflow-generated spec
- update fedora rpm.spec to ship the metainfo file with appstream validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6937c81ae6a88329a7e988a1843b9046)