### PR TITLE
Add appstream package to RPM workflow dependencies

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -28,6 +28,7 @@ jobs:
             python3 \
             python3-devel \
             desktop-file-utils \
+            appstream \
             appstream-glib \
             git \
             which


### PR DESCRIPTION
## Summary
- install the appstream package in the RPM GitHub Actions job to satisfy BuildRequires for appstream-util checks

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6937cc51dbd08329b46bb9737fe71392)