### PR TITLE
Fix AppStream metainfo screenshot defaults

### DIFF
--- a/io.github.mfat.sshpilot.metainfo.xml
+++ b/io.github.mfat.sshpilot.metainfo.xml
@@ -145,19 +145,19 @@
       <image>https://raw.githubusercontent.com/mfat/sshpilot/c8b8a73186c217a670c4dce8722b79ec3141ba01/screenshots/start-page.png</image>
       <caption>Start Page</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://raw.githubusercontent.com/mfat/sshpilot/6ef5e5bc618ab6dc563a47aa4470b576d9b25ac8/screenshots/main.png</image>
       <caption>Terminal</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://raw.githubusercontent.com/mfat/sshpilot/524e9a0d1405d968a6e6e88d31b31b0a480589ab/screenshots/file-manager.png</image>
       <caption>SFTP File Manager</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://raw.githubusercontent.com/mfat/sshpilot/38e1a8a/screenshots/tab-overview.png</image>
       <caption>Tab Overview</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://raw.githubusercontent.com/mfat/sshpilot/38e1a8a/screenshots/ssh-copy-id.png</image>
       <caption>ssh-copy-id Window</caption>
     </screenshot>


### PR DESCRIPTION
## Summary
- ensure the AppStream metadata defines only one default screenshot
- keep additional screenshots without the default flag to satisfy validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6937ccf249408329b722fd4631f7607a)