### PR TITLE
Add Qt preview entrypoint and UI selector

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,8 +3,10 @@
 Simple runner for the simplified sshpilot package under new/
 """
 
-import sys
+import argparse
 import os
+import sys
+from typing import List, Tuple
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 PARENT = os.path.dirname(CURRENT_DIR)
@@ -16,8 +18,38 @@ sys.path.insert(0, PARENT)
 if os.path.isdir(SRC_DIR):
     sys.path.insert(0, SRC_DIR)
 
-from sshpilot.main import main
+
+def _parse_ui_choice(argv: List[str]) -> Tuple[str, List[str]]:
+    """Return the requested UI backend and the remaining arguments."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--ui",
+        choices=["gtk", "qt"],
+        help="Choose which UI backend to launch (experimental Qt preview available)",
+    )
+    args, remaining = parser.parse_known_args(argv)
+
+    env_choice = os.environ.get("SSHPILOT_UI", "").strip().lower() or None
+    choice = args.ui or env_choice or "gtk"
+    if choice not in {"gtk", "qt"}:
+        choice = "gtk"
+
+    return choice, remaining
+
+
+def main() -> int:
+    ui_choice, remaining = _parse_ui_choice(sys.argv[1:])
+    sys.argv = [sys.argv[0], *remaining]
+
+    if ui_choice == "qt":
+        from sshpilot_qt.app import main as qt_main
+
+        return qt_main()
+
+    from sshpilot.main import main as gtk_main
+
+    return gtk_main()
+
 
 if __name__ == '__main__':
     main()
-

--- a/src/sshpilot_qt/__init__.py
+++ b/src/sshpilot_qt/__init__.py
@@ -1,0 +1,1 @@
+"""Qt preview shell for sshPilot."""

--- a/src/sshpilot_qt/app.py
+++ b/src/sshpilot_qt/app.py
@@ -1,0 +1,115 @@
+"""Entry point for the Qt preview application."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+try:
+    from PyQt6.QtCore import QCoreApplication
+    from PyQt6.QtGui import QIcon
+    from PyQt6.QtWidgets import QApplication
+except ImportError as exc:  # pragma: no cover - PyQt may not be installed in CI
+    raise SystemExit(
+        "PyQt6 is required for the Qt preview. Please install PyQt6 before continuing."
+    ) from exc
+
+from sshpilot import __version__
+from sshpilot.platform_utils import get_data_dir
+
+from .main_window import MainWindow
+from .resources import load_icon
+
+LOGGER = logging.getLogger(__name__)
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Mirror the GTK logging strategy for the Qt entrypoint."""
+    log_dir = get_data_dir()
+    os.makedirs(log_dir, exist_ok=True)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    file_handler = RotatingFileHandler(
+        os.path.join(log_dir, "sshpilot.log"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        encoding="utf-8",
+    )
+    console_handler = logging.StreamHandler()
+
+    logging.getLogger().handlers.clear()
+    root = logging.getLogger()
+    root.addHandler(file_handler)
+    root.addHandler(console_handler)
+
+    level = logging.DEBUG if verbose else logging.INFO
+    file_handler.setFormatter(formatter)
+    console_handler.setFormatter(formatter)
+    file_handler.setLevel(level)
+    console_handler.setLevel(level)
+    root.setLevel(level)
+
+
+def load_config() -> Optional[object]:
+    try:
+        from sshpilot.config import Config
+    except Exception as exc:  # pragma: no cover - config is optional here
+        LOGGER.warning("Could not load configuration backend: %s", exc)
+        return None
+
+    try:
+        return Config()
+    except Exception as exc:  # pragma: no cover - best-effort load
+        LOGGER.warning("Config initialization failed: %s", exc)
+        return None
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="sshPilot Qt preview")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--isolated",
+        action="store_true",
+        help="Placeholder flag for parity with the GTK entrypoint",
+    )
+    parser.add_argument(
+        "--native-connect",
+        action="store_true",
+        help="Reserved for future parity with GTK backend",
+    )
+    return parser.parse_args(argv)
+
+
+def bootstrap(argv: Optional[list[str]] = None) -> QApplication:
+    args = parse_args(argv)
+    setup_logging(verbose=args.verbose)
+
+    QCoreApplication.setOrganizationName("mFat")
+    QCoreApplication.setApplicationName("sshPilot")
+    QCoreApplication.setApplicationVersion(__version__)
+
+    app = QApplication(sys.argv if argv is None else [sys.argv[0], *argv])
+
+    icon = load_icon("sshpilot.png")
+    if icon and isinstance(icon, QIcon):
+        app.setWindowIcon(icon)
+
+    return app
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    app = bootstrap(argv)
+    window = MainWindow(config=load_config())
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sshpilot_qt/main_window.py
+++ b/src/sshpilot_qt/main_window.py
@@ -1,0 +1,84 @@
+"""Qt main window shell for the sshPilot preview UI."""
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QCloseEvent
+from PyQt6.QtWidgets import (
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QSizePolicy,
+    QStatusBar,
+    QVBoxLayout,
+    QWidget,
+    QHBoxLayout,
+    QTextEdit,
+)
+
+from .resources import load_icon, load_stylesheet
+
+
+class MainWindow(QMainWindow):
+    """Placeholder Qt main window with provisional panes."""
+
+    def __init__(self, config: Optional[object] = None, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.config = config
+        self.setWindowTitle("sshPilot (Qt Preview)")
+        self.setMinimumSize(900, 600)
+
+        app_icon = load_icon("sshpilot.png")
+        if app_icon:
+            self.setWindowIcon(app_icon)
+
+        self._build_layout()
+        self._apply_style_overrides()
+
+    def _build_layout(self) -> None:
+        central = QWidget(self)
+        root_layout = QHBoxLayout(central)
+        root_layout.setContentsMargins(12, 12, 12, 12)
+        root_layout.setSpacing(12)
+
+        # Connections list placeholder
+        self.connections = QListWidget(central)
+        self.connections.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+        self.connections.setMaximumWidth(280)
+        self.connections.addItem(QListWidgetItem("Example Host"))
+        self.connections.addItem(QListWidgetItem("Staging Bastion"))
+        self.connections.addItem(QListWidgetItem("Production"))
+        root_layout.addWidget(self.connections)
+
+        # Details / terminal placeholder
+        detail_container = QWidget(central)
+        detail_layout = QVBoxLayout(detail_container)
+        detail_layout.setSpacing(8)
+
+        self.detail_label = QLabel("Connection details and terminal preview", detail_container)
+        self.detail_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        detail_layout.addWidget(self.detail_label)
+
+        self.terminal_placeholder = QTextEdit(detail_container)
+        self.terminal_placeholder.setReadOnly(True)
+        self.terminal_placeholder.setPlaceholderText("Terminal output will appear here")
+        self.terminal_placeholder.setMinimumHeight(200)
+        detail_layout.addWidget(self.terminal_placeholder, stretch=1)
+
+        root_layout.addWidget(detail_container, stretch=1)
+        self.setCentralWidget(central)
+
+        status_bar = QStatusBar(self)
+        status_bar.showMessage("Disconnected")
+        self.setStatusBar(status_bar)
+
+    def _apply_style_overrides(self) -> None:
+        stylesheet = load_stylesheet("qt-preview.css")
+        if stylesheet:
+            self.setStyleSheet(stylesheet)
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # pragma: no cover - UI hook
+        event.accept()
+        super().closeEvent(event)

--- a/src/sshpilot_qt/resources.py
+++ b/src/sshpilot_qt/resources.py
@@ -1,0 +1,57 @@
+"""Helpers for loading icons and styles for the Qt preview."""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+try:  # Optional dependency: PyQt6
+    from PyQt6.QtGui import QIcon
+except ImportError:  # pragma: no cover - PyQt may not be installed in CI
+    QIcon = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _resource_roots() -> Iterable[Path]:
+    """Return possible base paths that contain shipped assets."""
+    here = Path(__file__).resolve().parent
+    yield here / ".." / "sshpilot" / "resources"
+    yield Path.cwd() / "sshpilot" / "resources"
+
+
+def resolve_asset_path(*parts: str) -> Optional[str]:
+    """Return the first existing asset path for the requested file."""
+    relative = Path(*parts)
+    for root in _resource_roots():
+        candidate = (root / relative).resolve()
+        if candidate.exists():
+            return str(candidate)
+    LOGGER.warning("Asset not found: %s", relative)
+    return None
+
+
+def load_icon(name: str) -> Optional["QIcon"]:
+    """Load an icon from shipped assets if PyQt6 is available."""
+    if QIcon is None:
+        LOGGER.debug("PyQt6 is not available; skipping icon load for %s", name)
+        return None
+
+    icon_path = resolve_asset_path("icons", name) or resolve_asset_path(name)
+    if icon_path:
+        return QIcon(icon_path)
+    return None
+
+
+def load_stylesheet(name: str) -> str:
+    """Load a stylesheet from disk if present."""
+    stylesheet_path = resolve_asset_path(name)
+    if stylesheet_path is None:
+        return ""
+
+    try:
+        return Path(stylesheet_path).read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - filesystem errors are non-critical
+        LOGGER.warning("Failed to read stylesheet %s: %s", stylesheet_path, exc)
+        return ""


### PR DESCRIPTION
## Summary
- add a Qt preview application entrypoint with logging and config loading
- implement a placeholder Qt main window shell and resource loader for icons/styles
- allow selecting the Qt or GTK backend via --ui flag or SSHPILOT_UI environment variable

## Testing
- not run (Qt dependencies not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69383db4312083298a813c609ab17240)