### PR TITLE
Add initial Qt UI scaffolding

### DIFF
--- a/src/sshpilot_qt/connection_editor.py
+++ b/src/sshpilot_qt/connection_editor.py
@@ -1,0 +1,158 @@
+"""Qt dialog for creating and editing SSH connections."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from PyQt6.QtGui import QIntValidator
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from sshpilot.connection_manager import Connection, ConnectionManager
+
+
+class ConnectionEditorDialog(QDialog):
+    """Edit or create connections using Qt widgets."""
+
+    def __init__(
+        self,
+        manager: ConnectionManager,
+        *,
+        connection: Optional[Connection] = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.manager = manager
+        self.connection = connection
+        self.setWindowTitle("Edit Connection" if connection else "New Connection")
+        self.setModal(True)
+
+        self.nickname = QLineEdit(self)
+        self.hostname = QLineEdit(self)
+        self.username = QLineEdit(self)
+        self.port = QLineEdit(self)
+        self.port.setValidator(QIntValidator(1, 65535, self))
+        self.private_key = QLineEdit(self)
+        self.certificate = QLineEdit(self)
+        self.quick_command = QLineEdit(self)
+        self.password = QLineEdit(self)
+        self.password.setEchoMode(QLineEdit.EchoMode.Password)
+        self.group = QLineEdit(self)
+        self.forward_agent = QCheckBox("Forward SSH agent", self)
+
+        self._build_form()
+        self._populate_from_connection()
+
+    def _build_form(self):
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        form.addRow("Nickname", self.nickname)
+        form.addRow("Hostname", self.hostname)
+        form.addRow("Username", self.username)
+        form.addRow("Port", self.port)
+        form.addRow("Group", self.group)
+
+        key_row = QHBoxLayout()
+        key_row.addWidget(self.private_key)
+        key_button = QPushButton("Browse…", self)
+        key_button.clicked.connect(self._select_keyfile)
+        key_row.addWidget(key_button)
+        form.addRow("Private key", key_row)
+
+        cert_row = QHBoxLayout()
+        cert_row.addWidget(self.certificate)
+        cert_button = QPushButton("Browse…", self)
+        cert_button.clicked.connect(self._select_certificate)
+        cert_row.addWidget(cert_button)
+        form.addRow("Certificate", cert_row)
+
+        form.addRow("Quick connect", self.quick_command)
+        form.addRow("Password", self.password)
+        form.addRow("Agent forwarding", self.forward_agent)
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel, self)
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+
+    def _populate_from_connection(self):
+        if not self.connection:
+            return
+        self.nickname.setText(getattr(self.connection, "nickname", ""))
+        self.hostname.setText(getattr(self.connection, "hostname", ""))
+        self.username.setText(getattr(self.connection, "username", ""))
+        self.port.setText(str(getattr(self.connection, "port", 22)))
+        self.private_key.setText(getattr(self.connection, "keyfile", ""))
+        self.certificate.setText(getattr(self.connection, "certificate", ""))
+        self.quick_command.setText(getattr(self.connection, "quick_connect_command", ""))
+        self.forward_agent.setChecked(bool(getattr(self.connection, "forward_agent", False)))
+        data = getattr(self.connection, "data", {}) or {}
+        if isinstance(data, dict):
+            self.group.setText(str(data.get("group", "")))
+            self.password.setText(str(data.get("password", "")))
+
+    def _select_keyfile(self):
+        filename, _ = QFileDialog.getOpenFileName(self, "Select private key")
+        if filename:
+            self.private_key.setText(filename)
+
+    def _select_certificate(self):
+        filename, _ = QFileDialog.getOpenFileName(self, "Select certificate")
+        if filename:
+            self.certificate.setText(filename)
+
+    def _validate(self) -> Optional[str]:
+        if not self.nickname.text().strip():
+            return "Nickname is required."
+        if not self.hostname.text().strip():
+            return "Hostname is required."
+        if self.port.text().strip() and not self.port.hasAcceptableInput():
+            return "Port must be between 1 and 65535."
+        return None
+
+    def _collect_payload(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "nickname": self.nickname.text().strip(),
+            "hostname": self.hostname.text().strip(),
+            "username": self.username.text().strip(),
+            "port": int(self.port.text()) if self.port.text().strip() else 22,
+            "keyfile": self.private_key.text().strip(),
+            "certificate": self.certificate.text().strip(),
+            "quick_connect_command": self.quick_command.text().strip(),
+            "forward_agent": self.forward_agent.isChecked(),
+        }
+        password = self.password.text()
+        group_name = self.group.text().strip()
+        if password:
+            payload["password"] = password
+        if group_name:
+            payload.setdefault("group", group_name)
+        return payload
+
+    def _on_accept(self):
+        error = self._validate()
+        if error:
+            QMessageBox.critical(self, "Invalid connection", error)
+            return
+
+        payload = self._collect_payload()
+        if self.connection:
+            self.manager.update_connection(self.connection, payload)
+        else:
+            new_connection = Connection(payload)
+            self.manager.connections.append(new_connection)
+            self.manager.update_ssh_config_file(new_connection, payload, payload.get("nickname"))
+            self.manager.emit("connection-added", new_connection)
+        self.accept()

--- a/src/sshpilot_qt/connections_view.py
+++ b/src/sshpilot_qt/connections_view.py
@@ -1,0 +1,225 @@
+"""Qt-based connection list with filtering, grouping, and context menus."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+from PyQt6.QtCore import QAbstractListModel, QModelIndex, Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QListView,
+    QLineEdit,
+    QMenu,
+    QSizePolicy,
+    QTreeView,
+    QVBoxLayout,
+    QWidget,
+)
+
+from sshpilot.connection_manager import Connection
+
+
+@dataclass
+class _ConnectionRow:
+    connection: Optional[Connection]
+    group: str = ""
+    is_header: bool = False
+
+
+class ConnectionListModel(QAbstractListModel):
+    """List model that supports grouping and search filtering."""
+
+    ConnectionRole = Qt.ItemDataRole.UserRole + 1
+    GroupRole = Qt.ItemDataRole.UserRole + 2
+    HeaderRole = Qt.ItemDataRole.UserRole + 3
+
+    def __init__(self, connections: Optional[List[Connection]] = None):
+        super().__init__()
+        self._all_connections: List[Connection] = connections or []
+        self._rows: List[_ConnectionRow] = []
+        self._filter_text: str = ""
+        self._grouping_enabled = False
+        self._default_group_name = "Ungrouped"
+        self._refresh_rows()
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N802
+        if parent.isValid():
+            return 0
+        return len(self._rows)
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):  # noqa: D401, N802
+        if not index.isValid() or index.row() >= len(self._rows):
+            return None
+
+        row = self._rows[index.row()]
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
+            if row.is_header:
+                return row.group
+            if row.connection is None:
+                return ""
+            nickname = getattr(row.connection, "nickname", "")
+            host = row.connection.get_effective_host() if hasattr(row.connection, "get_effective_host") else ""
+            username = getattr(row.connection, "username", "")
+            if username and host:
+                return f"{nickname} ({username}@{host})"
+            if host:
+                return f"{nickname} ({host})"
+            return nickname
+        if role == Qt.ItemDataRole.ToolTipRole and row.connection is not None:
+            host = row.connection.get_effective_host() if hasattr(row.connection, "get_effective_host") else ""
+            return f"{row.connection.nickname}\nHost: {host}\nPort: {getattr(row.connection, 'port', '')}"
+        if role == self.ConnectionRole:
+            return row.connection
+        if role == self.GroupRole:
+            return row.group
+        if role == self.HeaderRole:
+            return row.is_header
+        return None
+
+    def flags(self, index: QModelIndex):  # noqa: D401
+        base = super().flags(index)
+        if not index.isValid():
+            return base
+        if self._rows[index.row()].is_header:
+            return Qt.ItemFlag.ItemIsEnabled
+        return base | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled
+
+    def set_connections(self, connections: List[Connection]):
+        self.beginResetModel()
+        self._all_connections = connections
+        self._refresh_rows()
+        self.endResetModel()
+
+    def set_filter_text(self, text: str):
+        normalized = text.lower().strip()
+        if normalized == self._filter_text:
+            return
+        self.beginResetModel()
+        self._filter_text = normalized
+        self._refresh_rows()
+        self.endResetModel()
+
+    def set_grouping_enabled(self, enabled: bool):
+        if self._grouping_enabled == enabled:
+            return
+        self.beginResetModel()
+        self._grouping_enabled = enabled
+        self._refresh_rows()
+        self.endResetModel()
+
+    def connection_at(self, index: QModelIndex) -> Optional[Connection]:
+        if not index.isValid():
+            return None
+        row = self._rows[index.row()]
+        return None if row.is_header else row.connection
+
+    def _refresh_rows(self):
+        self._rows = []
+        filtered = [conn for conn in self._all_connections if self._accepts_connection(conn)]
+        if not self._grouping_enabled:
+            self._rows = [_ConnectionRow(connection=conn, group="") for conn in filtered]
+            return
+
+        grouped: Dict[str, List[Connection]] = {}
+        for conn in filtered:
+            meta = getattr(conn, "data", {}) or {}
+            group_name = meta.get("group") or self._default_group_name
+            grouped.setdefault(group_name, []).append(conn)
+
+        for group in sorted(grouped.keys(), key=lambda name: name.lower()):
+            self._rows.append(_ConnectionRow(connection=None, group=group, is_header=True))
+            for conn in sorted(grouped[group], key=lambda c: getattr(c, "nickname", "").lower()):
+                self._rows.append(_ConnectionRow(connection=conn, group=group, is_header=False))
+
+    def _accepts_connection(self, connection: Connection) -> bool:
+        if not self._filter_text:
+            return True
+        haystack = " ".join(
+            [
+                getattr(connection, "nickname", ""),
+                getattr(connection, "hostname", ""),
+                getattr(connection, "host", ""),
+                getattr(connection, "username", ""),
+            ]
+        ).lower()
+        return self._filter_text in haystack
+
+
+class ConnectionsView(QWidget):
+    """Composite widget wrapping search, list/tree view, and context menus."""
+
+    connection_requested = pyqtSignal(Connection)
+    edit_requested = pyqtSignal(Connection)
+    duplicate_requested = pyqtSignal(Connection)
+    delete_requested = pyqtSignal(Connection)
+
+    def __init__(self, *, use_tree: bool = True, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.model = ConnectionListModel([])
+        self.search = QLineEdit(self)
+        self.search.setPlaceholderText("Search connections…")
+        self.search.textChanged.connect(self.model.set_filter_text)
+
+        self.view = QTreeView(self) if use_tree else QListView(self)
+        self.view.setModel(self.model)
+        self.view.setUniformRowHeights(True)
+        self.view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.view.customContextMenuRequested.connect(self._open_context_menu)
+        self.view.setEditTriggers(QTreeView.EditTrigger.NoEditTriggers)
+        self.view.setHeaderHidden(True)
+        self.view.setRootIsDecorated(False)
+        self.view.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.search)
+        layout.addWidget(self.view)
+        self.setLayout(layout)
+
+    def bind_connections(self, connections: List[Connection]):
+        self.model.set_connections(connections)
+
+    def enable_grouping(self, enabled: bool):
+        self.model.set_grouping_enabled(enabled)
+        if isinstance(self.view, QTreeView):
+            self.view.expandAll()
+
+    def refresh(self):
+        self.model.layoutChanged.emit()
+
+    def _open_context_menu(self, point):
+        index = self.view.indexAt(point)
+        connection = self.model.connection_at(index)
+        if connection is None:
+            return
+
+        menu = QMenu(self)
+        menu.addAction("Connect", lambda: self.connection_requested.emit(connection))
+        menu.addAction("Edit", lambda: self.edit_requested.emit(connection))
+        menu.addAction("Duplicate", lambda: self.duplicate_requested.emit(connection))
+        menu.addSeparator()
+        menu.addAction("Delete", lambda: self.delete_requested.emit(connection))
+        menu.exec(self.view.viewport().mapToGlobal(point))
+
+    def select_connection(self, connection: Connection):
+        for row in range(self.model.rowCount()):
+            index = self.model.index(row, 0)
+            if self.model.connection_at(index) == connection:
+                self.view.setCurrentIndex(index)
+                break
+
+    def set_context_handlers(
+        self,
+        *,
+        on_connect: Optional[Callable[[Connection], None]] = None,
+        on_edit: Optional[Callable[[Connection], None]] = None,
+        on_duplicate: Optional[Callable[[Connection], None]] = None,
+        on_delete: Optional[Callable[[Connection], None]] = None,
+    ):
+        if on_connect:
+            self.connection_requested.connect(on_connect)
+        if on_edit:
+            self.edit_requested.connect(on_edit)
+        if on_duplicate:
+            self.duplicate_requested.connect(on_duplicate)
+        if on_delete:
+            self.delete_requested.connect(on_delete)

--- a/src/sshpilot_qt/preferences.py
+++ b/src/sshpilot_qt/preferences.py
@@ -1,0 +1,167 @@
+"""Preferences dialog implemented with Qt widgets."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from sshpilot.config import Config
+
+
+class _TerminalTab(QFormLayout):
+    def __init__(self, config: Config):
+        super().__init__()
+        self.config = config
+        terminal_settings = config.get_setting("terminal", {}) or {}
+
+        self.theme = QComboBox()
+        for key in sorted(config.terminal_themes.keys()):
+            self.theme.addItem(config.terminal_themes[key]["name"], key)
+        current_theme = terminal_settings.get("theme", "default")
+        idx = self.theme.findData(current_theme)
+        if idx >= 0:
+            self.theme.setCurrentIndex(idx)
+
+        self.font = QLineEdit(str(terminal_settings.get("font", "Monospace 12")))
+        self.scrollback = QSpinBox()
+        self.scrollback.setRange(1000, 500000)
+        self.scrollback.setValue(int(terminal_settings.get("scrollback_lines", 10000)))
+        self.cursor_blink = QCheckBox("Blinking cursor")
+        self.cursor_blink.setChecked(bool(terminal_settings.get("cursor_blink", True)))
+        self.audible_bell = QCheckBox("Audible bell")
+        self.audible_bell.setChecked(bool(terminal_settings.get("audible_bell", False)))
+
+        self.addRow("Theme", self.theme)
+        self.addRow("Font", self.font)
+        self.addRow("Scrollback", self.scrollback)
+        self.addRow("Cursor blink", self.cursor_blink)
+        self.addRow("Audible bell", self.audible_bell)
+
+    def serialize(self) -> Dict[str, object]:
+        return {
+            "theme": self.theme.currentData(),
+            "font": self.font.text(),
+            "scrollback_lines": self.scrollback.value(),
+            "cursor_blink": self.cursor_blink.isChecked(),
+            "audible_bell": self.audible_bell.isChecked(),
+        }
+
+
+class _UiTab(QFormLayout):
+    def __init__(self, config: Config):
+        super().__init__()
+        ui_settings = config.get_setting("ui", {}) or {}
+        self.show_hostname = QCheckBox("Show hostname in tabs")
+        self.show_hostname.setChecked(bool(ui_settings.get("show_hostname", True)))
+        self.auto_focus = QCheckBox("Focus terminal on connect")
+        self.auto_focus.setChecked(bool(ui_settings.get("auto_focus_terminal", True)))
+        self.confirm_close = QCheckBox("Confirm before closing tabs")
+        self.confirm_close.setChecked(bool(ui_settings.get("confirm_close_tabs", True)))
+        self.remember_size = QCheckBox("Remember window size")
+        self.remember_size.setChecked(bool(ui_settings.get("remember_window_size", True)))
+
+        self.addRow(self.show_hostname)
+        self.addRow(self.auto_focus)
+        self.addRow(self.confirm_close)
+        self.addRow(self.remember_size)
+
+    def serialize(self) -> Dict[str, object]:
+        return {
+            "show_hostname": self.show_hostname.isChecked(),
+            "auto_focus_terminal": self.auto_focus.isChecked(),
+            "confirm_close_tabs": self.confirm_close.isChecked(),
+            "remember_window_size": self.remember_size.isChecked(),
+        }
+
+
+class _SshTab(QFormLayout):
+    def __init__(self, config: Config):
+        super().__init__()
+        ssh_settings = config.get_setting("ssh", {}) or {}
+        self.compression = QCheckBox("Enable compression (-C)")
+        self.compression.setChecked(bool(ssh_settings.get("compression", False)))
+        self.auto_add = QCheckBox("Automatically add host keys")
+        self.auto_add.setChecked(bool(ssh_settings.get("auto_add_host_keys", True)))
+        self.batch_mode = QCheckBox("Batch mode")
+        self.batch_mode.setChecked(bool(ssh_settings.get("batch_mode", False)))
+        self.verbosity = QSpinBox()
+        self.verbosity.setRange(0, 3)
+        self.verbosity.setValue(int(ssh_settings.get("verbosity", 0)))
+
+        self.addRow(self.compression)
+        self.addRow(self.auto_add)
+        self.addRow(self.batch_mode)
+        self.addRow("Verbosity", self.verbosity)
+
+    def serialize(self) -> Dict[str, object]:
+        return {
+            "compression": self.compression.isChecked(),
+            "auto_add_host_keys": self.auto_add.isChecked(),
+            "batch_mode": self.batch_mode.isChecked(),
+            "verbosity": self.verbosity.value(),
+        }
+
+
+class PreferencesDialog(QDialog):
+    """Qt preferences dialog that writes to the existing Config backend."""
+
+    def __init__(self, *, parent=None):
+        super().__init__(parent)
+        self.config = Config()
+        self.setWindowTitle("Preferences")
+        self.tabs = QTabWidget(self)
+        self.terminal_tab = _TerminalTab(self.config)
+        self.ui_tab = _UiTab(self.config)
+        self.ssh_tab = _SshTab(self.config)
+        self._build_ui()
+
+    def _build_ui(self):
+        terminal_widget = QWidget()
+        terminal_widget.setLayout(self.terminal_tab)
+
+        ui_widget = QWidget()
+        ui_widget.setLayout(self.ui_tab)
+
+        ssh_widget = QWidget()
+        ssh_widget.setLayout(self.ssh_tab)
+
+        self.tabs.addTab(terminal_widget, "Terminal")
+        self.tabs.addTab(ui_widget, "Interface")
+        self.tabs.addTab(ssh_widget, "SSH")
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel, self)
+        buttons.accepted.connect(self._save_and_close)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.tabs)
+        layout.addWidget(buttons)
+        self.setLayout(layout)
+
+    def _save_and_close(self):
+        self._persist("terminal", self.terminal_tab.serialize())
+        self._persist("ui", self.ui_tab.serialize())
+        self._persist("ssh", self.ssh_tab.serialize())
+        self.accept()
+
+    def _persist(self, section: str, values: Dict[str, object]):
+        existing = self.config.get_setting(section, {}) or {}
+        merged = {**existing, **values}
+        self.config.set_setting(section, merged)
+
+    def set_initial_tab(self, name: str):
+        tab_map = {"terminal": 0, "interface": 1, "ssh": 2}
+        if name.lower() in tab_map:
+            self.tabs.setCurrentIndex(tab_map[name.lower()])

--- a/src/sshpilot_qt/terminal_pane.py
+++ b/src/sshpilot_qt/terminal_pane.py
@@ -1,0 +1,180 @@
+"""Qt terminal pane supporting QTermWidget when available."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pty
+import fcntl
+import termios
+import struct
+import subprocess
+from typing import Dict, Optional
+
+from PyQt6.QtCore import QEvent, QSocketNotifier, Qt
+from PyQt6.QtGui import QAction, QColor, QFont
+from PyQt6.QtWidgets import QPlainTextEdit, QVBoxLayout, QWidget
+
+_QTERM_SPEC = importlib.util.find_spec("qtermwidget")
+if _QTERM_SPEC and _QTERM_SPEC.loader:
+    _qterm_module = importlib.util.module_from_spec(_QTERM_SPEC)
+    _QTERM_SPEC.loader.exec_module(_qterm_module)
+    QTermWidget = getattr(_qterm_module, "QTermWidget", None)
+else:
+    QTermWidget = None
+
+
+class _PtyTerminal(QWidget):
+    """Fallback terminal using a PTY and QPlainTextEdit."""
+
+    def __init__(self, *, command: Optional[str] = None, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.command = command or os.environ.get("SHELL", "/bin/bash")
+        self.text = QPlainTextEdit(self)
+        self.text.setReadOnly(False)
+        self.text.setUndoRedoEnabled(False)
+        self.text.setTabChangesFocus(False)
+        self.text.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.text)
+        self.setLayout(layout)
+
+        self.master_fd, self.slave_fd = pty.openpty()
+        self.notifier = QSocketNotifier(self.master_fd, QSocketNotifier.Type.Read, self)
+        self.notifier.activated.connect(self._read_from_pty)
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=self.slave_fd,
+            stdout=self.slave_fd,
+            stderr=self.slave_fd,
+            shell=True,
+            close_fds=True,
+        )
+        self.text.installEventFilter(self)
+        self._apply_initial_size()
+
+    def _apply_initial_size(self):
+        columns, rows = 120, 32
+        self._resize_pty(rows, columns)
+
+    def _resize_pty(self, rows: int, columns: int):
+        winsize = struct.pack("HHHH", rows, columns, 0, 0)
+        fcntl.ioctl(self.master_fd, termios.TIOCSWINSZ, winsize)
+
+    def resizeEvent(self, event):  # noqa: D401, N802
+        super().resizeEvent(event)
+        char_width = self.text.fontMetrics().averageCharWidth() or 9
+        char_height = self.text.fontMetrics().height() or 18
+        columns = max(20, int(self.text.viewport().width() / char_width))
+        rows = max(2, int(self.text.viewport().height() / char_height))
+        self._resize_pty(rows, columns)
+
+    def _read_from_pty(self):
+        try:
+            data = os.read(self.master_fd, 4096)
+            if data:
+                self.text.moveCursor(self.text.textCursor().End)
+                self.text.insertPlainText(data.decode(errors="ignore"))
+                self.text.moveCursor(self.text.textCursor().End)
+        except OSError:
+            self.notifier.setEnabled(False)
+
+    def eventFilter(self, obj, event):  # noqa: D401, N802
+        if obj is self.text and event.type() == QEvent.Type.KeyPress:
+            text = event.text()
+            if text:
+                os.write(self.master_fd, text.encode())
+                return True
+        return super().eventFilter(obj, event)
+
+    def send_text(self, text: str):
+        os.write(self.master_fd, text.encode())
+
+    def copy(self):  # noqa: A003
+        self.text.copy()
+
+    def paste(self):
+        self.text.paste()
+
+    def set_color_scheme(self, scheme: Dict[str, str]):
+        palette = self.text.palette()
+        if "foreground" in scheme:
+            palette.setColor(self.text.foregroundRole(), QColor(scheme["foreground"]))
+        if "background" in scheme:
+            palette.setColor(self.text.backgroundRole(), QColor(scheme["background"]))
+        self.text.setPalette(palette)
+
+
+class TerminalPane(QWidget):
+    """Container that picks the most capable terminal backend available."""
+
+    def __init__(self, *, color_scheme: Optional[Dict[str, str]] = None, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.color_scheme = color_scheme or {}
+        self.backend: QWidget
+        self._init_backend()
+        self._install_actions()
+        if self.color_scheme:
+            self.set_color_scheme(self.color_scheme)
+
+    def _init_backend(self):
+        if QTermWidget is not None:
+            self.backend = QTermWidget(self)
+            self.backend.setColorScheme(0)
+            font = QFont("Monospace", 11)
+            self.backend.setTerminalFont(font)
+        else:
+            self.backend = _PtyTerminal(parent=self)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.backend)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+    def _install_actions(self):
+        copy_action = QAction("Copy", self)
+        copy_action.setShortcut(Qt.Modifier.CTRL | Qt.Key.Key_C)
+        copy_action.triggered.connect(self.copy)
+        paste_action = QAction("Paste", self)
+        paste_action.setShortcut(Qt.Modifier.CTRL | Qt.Key.Key_V)
+        paste_action.triggered.connect(self.paste)
+        self.addAction(copy_action)
+        self.addAction(paste_action)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.ActionsContextMenu)
+
+    def send_text(self, text: str):
+        if isinstance(self.backend, _PtyTerminal):
+            self.backend.send_text(text)
+        elif hasattr(self.backend, "sendText"):
+            self.backend.sendText(text)
+
+    def copy(self):  # noqa: A003
+        if hasattr(self.backend, "copyClipboard"):
+            self.backend.copyClipboard()
+        elif hasattr(self.backend, "copy"):
+            self.backend.copy()
+
+    def paste(self):
+        if hasattr(self.backend, "pasteClipboard"):
+            self.backend.pasteClipboard()
+        elif hasattr(self.backend, "paste"):
+            self.backend.paste()
+
+    def set_color_scheme(self, scheme: Dict[str, str]):
+        self.color_scheme = scheme
+        if isinstance(self.backend, _PtyTerminal):
+            self.backend.set_color_scheme(scheme)
+        elif hasattr(self.backend, "setColorScheme"):
+            self.backend.setColorScheme(0)
+            if "background" in scheme:
+                self.backend.setColorSchemeProperty("background", QColor(scheme["background"]))
+            if "foreground" in scheme:
+                self.backend.setColorSchemeProperty("foreground", QColor(scheme["foreground"]))
+
+    def resizeEvent(self, event):  # noqa: D401, N802
+        super().resizeEvent(event)
+        if hasattr(self.backend, "setTerminalSize"):
+            columns = max(20, int(self.width() / 8))
+            rows = max(2, int(self.height() / 16))
+            self.backend.setTerminalSize(columns, rows)


### PR DESCRIPTION
## Summary
- add Qt-based connection list widget with grouping, filtering, and context menu handling
- port connection editor, terminal pane, and preferences dialogs to PyQt6-compatible widgets
- provide fallback PTY terminal implementation when QTermWidget is unavailable and persist preferences via existing Config

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69383db4d614832998013241050cdf34)