### PR TITLE
Enable close button on prefrences window

### DIFF
--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -629,6 +629,7 @@ class PreferencesWindow(Adw.Window):
         self.header_title_label.set_single_line_mode(True)
         self.header_title_label.set_xalign(0.0)
         self.header_bar.set_title_widget(self.header_title_label)
+        self.header_bar.set_decoration_layout('close')
         
         # Explicitly enable window controls to ensure they're always visible,
         # even with custom themes that might not render WindowControls properly


### PR DESCRIPTION
Setting the decoration layout with the close string allowed the close button to appear, but in the top left. This is a bit different from the established theme. I'm curious if this would conflict with other windowing systems since the problem doesn't seem to exist for all users right now. Would be nice to test.