### PR TITLE
Use JSON content for sidebar drag-and-drop

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
+import json
+
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -34,6 +36,50 @@ _DEFAULT_ROW_WIDGET_MARGIN_START = -1
 _GROUP_DISPLAY_OPTIONS = {"fullwidth", "nested"}
 _GROUP_ROW_INDENT_WIDTH = 20
 _MIN_VALID_MARGIN = 0
+_DND_MIME_TYPE = "application/json"
+
+
+def _serialize_drag_payload(payload: Dict) -> Optional[Gdk.ContentProvider]:
+    """Convert a drag payload to a JSON-backed content provider."""
+
+    try:
+        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        payload_bytes = GLib.Bytes.new(serialized.encode("utf-8"))
+        return Gdk.ContentProvider.new_for_bytes(_DND_MIME_TYPE, payload_bytes)
+    except Exception:
+        logger.error("Failed to serialize drag payload", exc_info=True)
+        return None
+
+
+def _deserialize_drop_payload(value) -> Optional[Dict]:
+    """Decode drop data from GLib.Bytes or string content into a dictionary."""
+
+    if isinstance(value, dict):
+        return value
+
+    try:
+        raw_bytes: Optional[bytes] = None
+
+        if isinstance(value, GLib.Bytes):
+            data = value.get_data()
+            if isinstance(data, tuple):
+                data = data[0]
+            if hasattr(data, "tobytes"):
+                raw_bytes = data.tobytes()
+            else:
+                raw_bytes = bytes(data)
+        elif isinstance(value, (bytes, bytearray, memoryview)):
+            raw_bytes = bytes(value)
+        elif isinstance(value, str):
+            raw_bytes = value.encode("utf-8")
+
+        if raw_bytes is None:
+            return None
+
+        return json.loads(raw_bytes.decode("utf-8"))
+    except Exception:
+        logger.error("Failed to deserialize drop payload", exc_info=True)
+        return None
 
 
 def _install_sidebar_color_css():
@@ -431,9 +477,7 @@ class GroupRow(Gtk.ListBoxRow):
 
     def _on_drag_prepare(self, source, x, y):
         data = {"type": "group", "group_id": self.group_id}
-        return Gdk.ContentProvider.new_for_value(
-            GObject.Value(GObject.TYPE_PYOBJECT, data)
-        )
+        return _serialize_drag_payload(data)
 
     def _on_drag_begin(self, source, drag):
         try:
@@ -1103,9 +1147,7 @@ class ConnectionRow(Gtk.ListBoxRow):
         if window:
             window._dragged_connections = ordered_nicknames
 
-        return Gdk.ContentProvider.new_for_value(
-            GObject.Value(GObject.TYPE_PYOBJECT, data)
-        )
+        return _serialize_drag_payload(data)
 
     def _on_drag_begin(self, source, drag):
         try:
@@ -1268,7 +1310,11 @@ class ConnectionRow(Gtk.ListBoxRow):
 def setup_connection_list_dnd(window):
     """Set up drag and drop for the window's connection list."""
 
-    drop_target = Gtk.DropTarget.new(type=GObject.TYPE_PYOBJECT, actions=Gdk.DragAction.MOVE)
+    drop_target = Gtk.DropTarget.new(type=GLib.Bytes, actions=Gdk.DragAction.MOVE)
+    try:
+        drop_target.set_formats(Gdk.ContentFormats.parse(_DND_MIME_TYPE))
+    except Exception:
+        logger.debug("Failed to set drop target formats", exc_info=True)
     drop_target.connect("drop", lambda t, v, x, y: _on_connection_list_drop(window, t, v, x, y))
     drop_target.connect("motion", lambda t, x, y: _on_connection_list_motion(window, t, x, y))
     drop_target.connect("leave", lambda t: _on_connection_list_leave(window, t))
@@ -1499,8 +1545,9 @@ def _on_connection_list_drop(window, target, value, x, y):
             window._drag_in_progress = False
             window.connection_list.set_selection_mode(Gtk.SelectionMode.MULTIPLE)
 
-        # Extract Python object from GObject.Value drops
-        if isinstance(value, GObject.Value):
+        payload = _deserialize_drop_payload(value)
+
+        if payload is None and isinstance(value, GObject.Value):
             extracted = None
             for getter in ("get_boxed", "get_object", "get"):
                 try:
@@ -1509,35 +1556,34 @@ def _on_connection_list_drop(window, target, value, x, y):
                         break
                 except Exception:
                     continue
-            value = extracted
+            payload = _deserialize_drop_payload(extracted)
 
-
-        if not isinstance(value, dict):
+        if not isinstance(payload, dict):
             return False
 
-        drop_type = value.get("type")
+        drop_type = payload.get("type")
         changes_made = False
 
         if drop_type == "connection":
             connection_nicknames: List[str] = []
 
-            payload = value.get("connections")
-            if isinstance(payload, list):
-                for item in payload:
+            payload_connections = payload.get("connections")
+            if isinstance(payload_connections, list):
+                for item in payload_connections:
                     if isinstance(item, dict):
                         nickname = item.get("nickname")
                         if isinstance(nickname, str) and nickname not in connection_nicknames:
                             connection_nicknames.append(nickname)
 
             if not connection_nicknames:
-                raw_list = value.get("connection_nicknames")
+                raw_list = payload.get("connection_nicknames")
                 if isinstance(raw_list, list):
                     for nickname in raw_list:
                         if isinstance(nickname, str) and nickname not in connection_nicknames:
                             connection_nicknames.append(nickname)
 
             if not connection_nicknames:
-                nickname = value.get("connection_nickname")
+                nickname = payload.get("connection_nickname")
                 if isinstance(nickname, str):
                     connection_nicknames.append(nickname)
 
@@ -1627,7 +1673,7 @@ def _on_connection_list_drop(window, target, value, x, y):
                                     changes_made = True
 
         elif drop_type == "group":
-            group_id = value.get("group_id")
+            group_id = payload.get("group_id")
             if group_id:
                 target_row = window.connection_list.get_row_at_y(int(y))
                 if target_row and hasattr(target_row, "group_id"):


### PR DESCRIPTION
## Summary
- serialize sidebar drag payloads for groups and connections to JSON and wrap them in GLib bytes-based content providers
- update the drop target to accept application/json content and decode payloads before processing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69414e276f188329a207889cc583d1f7)