### PR TITLE
Handle missing SSH config path fallback

### DIFF
--- a/tests/test_ssh_directory_creation.py
+++ b/tests/test_ssh_directory_creation.py
@@ -41,3 +41,46 @@ def test_update_connection_creates_ssh_directory(tmp_path):
     assert config_path.exists()
     contents = Path(config_path).read_text()
     assert "Host demo" in contents
+
+
+def test_update_connection_recovers_missing_config_path(tmp_path, monkeypatch):
+    """Updating a connection with an empty config path should rebuild defaults."""
+    fallback_dir = tmp_path / "fallback_ssh"
+    default_config = fallback_dir / "config"
+    monkeypatch.setenv("SSHPILOT_SSH_DIR", str(fallback_dir))
+
+    manager = ConnectionManager.__new__(ConnectionManager)
+    manager.connections = []
+    manager.rules = []
+    manager.isolated_mode = False
+    manager.ssh_config_path = ""
+    manager.known_hosts_path = ""
+    manager.emit = lambda *args, **kwargs: None
+    manager.store_password = lambda *args, **kwargs: True
+    manager.delete_password = lambda *args, **kwargs: True
+
+    connection_data = {
+        "nickname": "demo",
+        "hostname": "example.com",
+        "username": "alice",
+        "port": 22,
+        "auth_method": 0,
+        "keyfile": "",
+        "password": "",
+        "forwarding_rules": [],
+    }
+
+    connection = Connection(connection_data)
+    manager.connections.append(connection)
+
+    assert not fallback_dir.exists()
+
+    result = manager.update_connection(connection, dict(connection_data))
+
+    assert result is True
+    assert fallback_dir.exists()
+    assert default_config.exists()
+    assert manager.ssh_config_path == str(default_config)
+    assert connection.source == str(default_config)
+    contents = default_config.read_text()
+    assert "Host demo" in contents


### PR DESCRIPTION
## Summary
- fall back to the default SSH config path when updates are missing a target
- guard config path normalization with clearer fallback logging
- add regression coverage for rebuilding the SSH config path when empty

## Testing
- pytest tests/test_ssh_directory_creation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694e4dda49188329aa9a5dd670f0c3ae)