### PR TITLE
Fix quick connect mode priority over native mode for custom SSH flags

### DIFF
--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -380,9 +380,28 @@ def build_ssh_connection(
         except Exception:
             pass
     
-    # Handle native mode early - minimal SSH command
+    # Handle quick connect mode first — an explicit user-typed SSH command takes
+    # priority over native mode so flags like -p, -i, -X etc. are not dropped.
+    if ctx.quick_connect_mode and ctx.quick_connect_command:
+        import shlex
+        try:
+            base_cmd = shlex.split(ctx.quick_connect_command)
+        except ValueError:
+            base_cmd = ctx.quick_connect_command.split()
+        # Use default environment
+        env = os.environ.copy()
+        env.pop('SSH_ASKPASS', None)
+        env.pop('SSH_ASKPASS_REQUIRE', None)
+        return SSHConnectionCommand(
+            command=base_cmd,
+            env=env,
+            use_sshpass=False,
+            password=None,
+            use_askpass=False
+        )
+
+    # Handle native mode - minimal SSH command, let SSH config handle everything
     if ctx.native_mode:
-        # Native mode: just use ssh with host_label, let SSH config handle everything
         base_cmd = ['ssh']
         config_override = None
         if hasattr(connection, '_resolve_config_override_path'):
@@ -405,25 +424,6 @@ def build_ssh_connection(
                 pass
         base_cmd.append(host_label)
         # Use default environment (no askpass, no sshpass)
-        env = os.environ.copy()
-        env.pop('SSH_ASKPASS', None)
-        env.pop('SSH_ASKPASS_REQUIRE', None)
-        return SSHConnectionCommand(
-            command=base_cmd,
-            env=env,
-            use_sshpass=False,
-            password=None,
-            use_askpass=False
-        )
-    
-    # Handle quick connect mode early
-    if ctx.quick_connect_mode and ctx.quick_connect_command:
-        import shlex
-        try:
-            base_cmd = shlex.split(ctx.quick_connect_command)
-        except ValueError:
-            base_cmd = ctx.quick_connect_command.split()
-        # Use default environment
         env = os.environ.copy()
         env.pop('SSH_ASKPASS', None)
         env.pop('SSH_ASKPASS_REQUIRE', None)

--- a/tests/test_quick_connect.py
+++ b/tests/test_quick_connect.py
@@ -78,3 +78,46 @@ def test_quick_connect_preserves_original_command():
 
     assert connected is True
     assert connection.ssh_cmd == shlex.split(command)
+
+
+def test_quick_connect_custom_port_with_native_mode():
+    """Regression test for issue #899: -p flag must survive when native mode is active.
+
+    native_connect() (called by default since ssh.native_connect=True) passes
+    both native_mode=True and quick_connect_mode=True to build_ssh_connection().
+    The quick_connect_mode branch must take priority so the full user-supplied
+    command, including -p, is used verbatim.
+    """
+    command = "ssh -p 2222 root@192.168.8.1"
+
+    parsed = _parse_quick_command(command)
+
+    assert parsed["quick_connect_command"] == command
+    assert parsed["host"] == "192.168.8.1"
+    assert parsed["username"] == "root"
+    assert parsed["port"] == 2222
+
+    new_loop = asyncio.new_event_loop()
+    previous_loop = None
+    try:
+        try:
+            previous_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            previous_loop = None
+        asyncio.set_event_loop(new_loop)
+
+        connection = Connection(parsed)
+        assert connection.quick_connect_command == command
+
+        # native_connect() is the default code path (ssh.native_connect=True).
+        # It sets native_mode=True alongside quick_connect_mode=True; the
+        # quick_connect branch must win and preserve -p 2222.
+        connected = new_loop.run_until_complete(connection.native_connect())
+    finally:
+        asyncio.set_event_loop(previous_loop)
+        new_loop.close()
+
+    assert connected is True
+    assert connection.ssh_cmd == shlex.split(command)
+    assert '-p' in connection.ssh_cmd
+    assert '2222' in connection.ssh_cmd


### PR DESCRIPTION
## Summary
This PR fixes a regression where custom SSH flags (like `-p` for port) were being dropped when both native mode and quick connect mode were active. The issue occurred because native mode was being processed before quick connect mode, causing user-supplied SSH command flags to be lost.

## Key Changes
- **Reordered mode handling in `build_ssh_connection()`**: Quick connect mode is now checked and processed before native mode, ensuring that explicit user-typed SSH commands take priority and preserve all flags
- **Added regression test**: New test `test_quick_connect_custom_port_with_native_mode()` verifies that the `-p` flag survives when both `native_mode=True` and `quick_connect_mode=True` are set (the default code path via `native_connect()`)

## Implementation Details
- When both modes are active, quick connect mode now wins, allowing the full user-supplied command (including flags like `-p 2222`, `-i`, `-X`, etc.) to be used verbatim
- The test confirms that `native_connect()` (the default since `ssh.native_connect=True`) correctly preserves custom port specifications and other SSH flags
- The fix maintains backward compatibility by only affecting the case where both modes are explicitly enabled

https://claude.ai/code/session_01CP44277CmkqvjEFRhgq5Jx