### PR TITLE
Strip SSH_ASKPASS variables for password authentication

### DIFF
--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -632,6 +632,8 @@ def build_ssh_connection(
         else:
             # Password authentication selected - use default SSH behavior
             env = os.environ.copy()
+            env.pop('SSH_ASKPASS', None)
+            env.pop('SSH_ASKPASS_REQUIRE', None)
             logger.debug("Password authentication selected - not using askpass")
     else:
         # Password authentication selected

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1336,7 +1336,14 @@ class TerminalWidget(Gtk.Box):
                 ssh_conn_cmd = build_ssh_connection(ctx)
                 ssh_cmd = ssh_conn_cmd.command
                 env.update(ssh_conn_cmd.env)
-                
+                # dict.update() doesn't remove keys absent from the source; propagate
+                # deletions explicitly so that SSH_ASKPASS stripped for password auth
+                # (e.g. ksshaskpass from KDE host env) doesn't bleed into the SSH process.
+                if 'SSH_ASKPASS' not in ssh_conn_cmd.env:
+                    env.pop('SSH_ASKPASS', None)
+                if 'SSH_ASKPASS_REQUIRE' not in ssh_conn_cmd.env:
+                    env.pop('SSH_ASKPASS_REQUIRE', None)
+
                 # Get password for sshpass if needed
                 password_value = None
                 if ssh_conn_cmd.use_sshpass and ssh_conn_cmd.password:


### PR DESCRIPTION
## Summary
Prevent SSH_ASKPASS and SSH_ASKPASS_REQUIRE environment variables from being inherited by SSH processes when using password authentication. This ensures that interactive password prompts work correctly and aren't interfered with by askpass utilities from the parent environment.

## Changes
- **ssh_connection_builder.py**: Explicitly remove SSH_ASKPASS and SSH_ASKPASS_REQUIRE from the environment when password authentication is selected, before passing to SSH
- **terminal.py**: Add explicit cleanup of SSH_ASKPASS variables after updating the environment dict, since `dict.update()` doesn't remove keys that are absent from the source dictionary

## Implementation Details
The fix addresses a subtle issue where environment variables from the host system (e.g., ksshaskpass from KDE) could leak into SSH processes even when password authentication was explicitly selected. By explicitly popping these variables when they're not set in the SSH connection configuration, we ensure clean environment isolation and prevent unintended askpass behavior from interfering with password authentication flows.

https://claude.ai/code/session_013z5aGSYvfoBQADdBGCWfmf