### PR TITLE
Fix port forwarding toggle sync and validate port range

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -2847,13 +2847,26 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         """Handle delete port forwarding rule button click"""
         if not hasattr(self, 'forwarding_rules'):
             return
-            
+
         # Remove the rule from the list
         self.forwarding_rules = [r for r in self.forwarding_rules if r != rule]
-        
+
+        # Sync old-style toggle switches so save-time validation doesn't block
+        for toggle_attr, rule_type in [
+            ('local_forwarding_enabled', 'local'),
+            ('remote_forwarding_enabled', 'remote'),
+            ('dynamic_forwarding_enabled', 'dynamic'),
+        ]:
+            if hasattr(self, toggle_attr):
+                has_rule = any(
+                    r.get('type') == rule_type and r.get('enabled', True)
+                    for r in self.forwarding_rules
+                )
+                getattr(self, toggle_attr).set_active(has_rule)
+
         # Reload the rules UI
         self.load_port_forwarding_rules()
-        
+
         logger.info(f"Deleted port forwarding rule: {rule}")
     
     def on_edit_forwarding_rule_clicked(self, button, rule):
@@ -3040,8 +3053,8 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             listen_port = int((listen_port_row.get_text() or '0').strip() or '0')
         except Exception:
             listen_port = 0
-        if listen_port <= 0:
-            self.show_error(_("Please enter a valid listen port (> 0)"))
+        if listen_port <= 0 or listen_port > 65535:
+            self.show_error(_("Please enter a valid listen port (1–65535)"))
             return
         
         # Check for port conflicts (for local and dynamic forwarding)


### PR DESCRIPTION
## Summary
This PR improves the port forwarding rule management by ensuring toggle switches stay synchronized when rules are deleted and by adding proper port number validation.

## Key Changes
- **Toggle switch synchronization**: When a port forwarding rule is deleted, the corresponding old-style toggle switches (local/remote/dynamic forwarding enabled) are now updated to reflect whether any enabled rules of that type still exist. This prevents save-time validation from being blocked by stale toggle states.
- **Port range validation**: Enhanced port number validation to reject ports outside the valid range (1–65535), in addition to the existing check for ports ≤ 0. The error message now clearly indicates the acceptable range.
- **Code cleanup**: Fixed trailing whitespace issues in the modified method.

## Implementation Details
The toggle synchronization iterates through the three forwarding types and checks if any enabled rules of each type remain after deletion. This ensures the UI state accurately reflects the actual forwarding rules configuration.

https://claude.ai/code/session_01MY6omVaihBQfvVuS6VyBsh