### PR TITLE
Refactor sshpass path resolution into reusable utility function

### DIFF
--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import shutil
 
 from gi.repository import GLib
 
@@ -27,6 +28,30 @@ def get_config_dir() -> str:
 def get_data_dir() -> str:
     """Return the per-user data directory for sshPilot."""
     return os.path.join(GLib.get_user_data_dir(), APP_NAME)
+
+
+_sshpass_path_cache: str | None = None
+_sshpass_checked: bool = False
+
+
+def get_sshpass_path() -> str | None:
+    """Return the path to the sshpass binary, or None if unavailable.
+
+    The result is cached after the first call so repeated lookups are free.
+    Checks the Flatpak-bundled location first, then falls back to PATH.
+    """
+    global _sshpass_path_cache, _sshpass_checked
+    if _sshpass_checked:
+        return _sshpass_path_cache
+
+    flatpak_path = "/app/bin/sshpass"
+    if os.path.exists(flatpak_path) and os.access(flatpak_path, os.X_OK):
+        _sshpass_path_cache = flatpak_path
+    else:
+        _sshpass_path_cache = shutil.which("sshpass")
+
+    _sshpass_checked = True
+    return _sshpass_path_cache
 
 
 def get_ssh_dir() -> str:

--- a/sshpilot/ssh_password_exec.py
+++ b/sshpilot/ssh_password_exec.py
@@ -1,7 +1,10 @@
 # ssh_password_exec.py
 import os, tempfile, threading, subprocess, shutil
 import re
+import logging
 from typing import Iterable, List, Tuple
+
+from .platform_utils import get_sshpass_path
 
 # Moved from scp_utils.py to avoid circular import
 _REMOTE_SPEC_RE = re.compile(r"^[^@]+@(?:\[[^\]]+\]|[^:]+):.+$")
@@ -134,17 +137,11 @@ def run_ssh_with_password(host: str, user: str, password: str, *,
     if extra_ssh_opts:
         ssh_opts += extra_ssh_opts
 
-    # Resolve sshpass and ssh binaries like in window.py/terminal.py
-    sshpass = ("/app/bin/sshpass" if os.path.exists("/app/bin/sshpass") and os.access("/app/bin/sshpass", os.X_OK) else None) or shutil.which("sshpass")
-    sshbin = shutil.which("ssh") or "/usr/bin/ssh"
-    
-    # Debug logging
-    import logging
     logger = logging.getLogger(__name__)
+    sshpass = get_sshpass_path()
+    sshbin = shutil.which("ssh") or "/usr/bin/ssh"
     logger.debug(f"sshpass resolved to: {sshpass}")
     logger.debug(f"sshbin resolved to: {sshbin}")
-    logger.debug(f"/app/bin/sshpass exists: {os.path.exists('/app/bin/sshpass')}")
-    logger.debug(f"/app/bin/sshpass executable: {os.access('/app/bin/sshpass', os.X_OK) if os.path.exists('/app/bin/sshpass') else False}")
     
     if sshpass:
         cmd = [sshpass, "-f", fifo, sshbin, "-p", str(port), *ssh_opts, f"{user}@{host}"]

--- a/sshpilot/startup_info.py
+++ b/sshpilot/startup_info.py
@@ -34,7 +34,7 @@ except Exception:
     KEYRING_AVAILABLE = False
 
 from . import __version__
-from .platform_utils import is_macos, is_flatpak, get_config_dir, get_ssh_dir
+from .platform_utils import is_macos, is_flatpak, get_config_dir, get_ssh_dir, get_sshpass_path
 
 
 logger = logging.getLogger(__name__)
@@ -201,13 +201,9 @@ class StartupInfo:
         else:
             tools['ssh'] = {'available': False, 'path': None, 'version': None}
         
-        # sshpass
-        sshpass_path = None
-        if os.path.exists('/app/bin/sshpass') and os.access('/app/bin/sshpass', os.X_OK):
-            sshpass_path = '/app/bin/sshpass'
-        else:
-            sshpass_path = shutil.which('sshpass')
-        
+        # sshpass — warm the cache and record availability
+        sshpass_path = get_sshpass_path()
+
         if sshpass_path:
             try:
                 import subprocess

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -21,7 +21,7 @@ import pwd
 from datetime import datetime
 from typing import Optional, List
 from .port_utils import get_port_checker
-from .platform_utils import is_flatpak, is_macos
+from .platform_utils import is_flatpak, is_macos, get_sshpass_path
 from .terminal_backends import BaseTerminalBackend, VTETerminalBackend, PyXtermTerminalBackend
 from .ssh_connection_builder import build_ssh_connection, ConnectionContext
 
@@ -1356,16 +1356,9 @@ class TerminalWidget(Gtk.Box):
 
             if password_value:
                 # Use sshpass for password authentication with FIFO (terminal-specific)
-                import shutil
-                sshpass_path = None
-                
-                # Check if sshpass is available and executable
-                if os.path.exists('/app/bin/sshpass') and os.access('/app/bin/sshpass', os.X_OK):
-                    sshpass_path = '/app/bin/sshpass'
-                    logger.debug("Found sshpass at /app/bin/sshpass")
-                elif shutil.which('sshpass'):
-                    sshpass_path = shutil.which('sshpass')
-                    logger.debug(f"Found sshpass in PATH: {sshpass_path}")
+                sshpass_path = get_sshpass_path()
+                if sshpass_path:
+                    logger.debug(f"Using sshpass at {sshpass_path}")
                 else:
                     logger.debug("sshpass not found or not executable")
                 


### PR DESCRIPTION
## Summary
Consolidates duplicated sshpass binary path resolution logic into a single cached utility function in `platform_utils.py`, eliminating code duplication across multiple modules.

## Key Changes
- **New utility function**: Added `get_sshpass_path()` in `platform_utils.py` that:
  - Checks the Flatpak-bundled location (`/app/bin/sshpass`) first
  - Falls back to searching PATH using `shutil.which()`
  - Caches results after the first call for performance
  
- **Updated imports**: Added `shutil` import to `platform_utils.py`

- **Refactored modules** to use the new utility:
  - `terminal.py`: Replaced inline sshpass detection logic with `get_sshpass_path()` call
  - `ssh_password_exec.py`: Replaced inline detection and added import of `get_sshpass_path()`
  - `startup_info.py`: Replaced inline detection with `get_sshpass_path()` call

## Implementation Details
- The caching mechanism uses module-level globals (`_sshpass_path_cache` and `_sshpass_checked`) to avoid repeated filesystem checks
- Maintains the same precedence: Flatpak bundled binary takes priority over system PATH
- Simplifies debugging by centralizing the sshpass resolution logic
- Reduces code duplication from ~4 separate implementations to a single source of truth

https://claude.ai/code/session_01CVHHehb3iDWD5pEhvDBkzi