### PR TITLE
Enhance Quick Connect dialog with auth options and validation

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -1,18 +1,19 @@
 """Welcome page widget for sshPilot."""
 
 import gi
+import os
 import shlex
 import logging
 
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Adw, Gdk
+from gi.repository import Gtk, Adw, Gdk, Gio, GLib
 
 from gettext import gettext as _
 
 from .connection_manager import Connection
-from .platform_utils import is_macos
+from .platform_utils import is_macos, get_ssh_dir
 
 logger = logging.getLogger(__name__)
 
@@ -917,7 +918,7 @@ class WelcomePage(Gtk.Overlay):
                     option_key = arg
                     attached_value = ""
                     if option_key.startswith('--'):
-                        option_key, _, attached_value = option_key.partition('=')
+                        option_key, _sep, attached_value = option_key.partition('=')
                     elif option_key.startswith('-') and len(option_key) > 2:
                         option_key, attached_value = option_key[:2], option_key[2:]
 
@@ -969,109 +970,235 @@ class QuickConnectDialog(Adw.MessageDialog):
         super().__init__()
 
         self.parent_window = parent_window
-        
-        # Set dialog properties
+        self._selected_keyfile = ""
+
         self.set_modal(True)
         self.set_transient_for(parent_window)
-        self.set_title("Quick Connect")
-        
-        # Create content area
+        self.set_title(_("Quick Connect"))
+
         content_area = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         content_area.set_margin_top(12)
         content_area.set_margin_bottom(12)
         content_area.set_margin_start(12)
         content_area.set_margin_end(12)
-        
-        # Add description
+
+        # Inline error banner (hidden until validation fails)
+        self.error_label = Gtk.Label()
+        self.error_label.set_halign(Gtk.Align.START)
+        self.error_label.set_wrap(True)
+        self.error_label.set_visible(False)
+        self.error_label.add_css_class("error")
+        content_area.append(self.error_label)
+
         description = Gtk.Label()
-        description.set_text("Enter SSH command or connection details:")
+        description.set_text(_("Enter SSH command or connection details:"))
         description.set_halign(Gtk.Align.START)
         content_area.append(description)
-        
-        # Create entry field
+
         self.entry = Gtk.Entry()
         self.entry.set_placeholder_text("ssh -p 2222 user@host")
         self.entry.set_hexpand(True)
         self.entry.connect('activate', self.on_connect)
+        self.entry.connect('changed', self._on_entry_changed)
         content_area.append(self.entry)
 
-        # Add content to dialog
+        # Auth fields group
+        prefs_group = Adw.PreferencesGroup()
+
+        self.password_row = Adw.PasswordEntryRow(title=_("Password (optional)"))
+        prefs_group.add(self.password_row)
+
+        self.keyfile_row = Adw.ActionRow()
+        self.keyfile_row.set_title(_("Key File (optional)"))
+        self.keyfile_row.set_subtitle(_("No key file selected"))
+        browse_button = Gtk.Button(label=_("Browse…"))
+        browse_button.set_valign(Gtk.Align.CENTER)
+        browse_button.connect('clicked', self._browse_for_key_file)
+        self.keyfile_row.add_suffix(browse_button)
+        prefs_group.add(self.keyfile_row)
+
+        content_area.append(prefs_group)
+
         self.set_extra_child(content_area)
 
-        # Add response buttons
-        self.add_response("cancel", "Cancel")
-        self.add_response("connect", "Connect")
+        self.add_response("cancel", _("Cancel"))
+        self.add_response("save", _("Save Connection…"))
+        self.add_response("connect", _("Connect"))
         self.set_response_appearance("connect", Adw.ResponseAppearance.SUGGESTED)
-        
-        # Connect response signal
-        self.connect('response', self.on_response)
 
-        # Focus the entry when dialog is shown
+        self.connect('response', self.on_response)
         self.entry.grab_focus()
 
+    def _on_entry_changed(self, entry):
+        if self.error_label.get_visible():
+            self.error_label.set_visible(False)
+
+    def _show_error(self, message: str):
+        self.error_label.set_text(message)
+        self.error_label.set_visible(True)
+
     def on_response(self, dialog, response):
-        """Handle dialog response"""
         if response == "connect":
             self.on_connect()
-        self.destroy()
+        elif response == "save":
+            self._on_save_connection()
+        else:
+            self.destroy()
 
     def on_connect(self, *args):
-        """Handle connect button or Enter key"""
         text = self.entry.get_text().strip()
         if not text:
             return
-        
-        # Parse the SSH command
-        connection_data = self._parse_ssh_command(text)
-        if connection_data:
-            connection = Connection(connection_data)
-            self.parent_window.terminal_manager.connect_to_host(connection, force_new=False)
-            self.destroy()
+
+        result = self._parse_ssh_command(text)
+        if result is None:
+            self._show_error(_("Could not parse command. Use: ssh user@host or user@host"))
+            return
+        if "error" in result:
+            self._show_error(result["error"])
+            return
+
+        errors = self._validate_parsed(result)
+        if errors:
+            self._show_error("\n".join(errors))
+            return
+
+        password = self.password_row.get_text()
+        if password:
+            result["password"] = password
+            result["auth_method"] = 1
+        if self._selected_keyfile:
+            result["keyfile"] = self._selected_keyfile
+            result["key_select_mode"] = 2
+
+        connection = Connection(result)
+        self.parent_window.terminal_manager.connect_to_host(connection, force_new=False)
+        self.destroy()
+
+    def _on_save_connection(self):
+        text = self.entry.get_text().strip()
+        if not text:
+            return
+
+        result = self._parse_ssh_command(text)
+        if result is None:
+            self._show_error(_("Could not parse command. Use: ssh user@host or user@host"))
+            return
+        if "error" in result:
+            self._show_error(result["error"])
+            return
+
+        errors = self._validate_parsed(result)
+        if errors:
+            self._show_error("\n".join(errors))
+            return
+
+        password = self.password_row.get_text()
+        if password:
+            result["password"] = password
+        if self._selected_keyfile:
+            result["keyfile"] = self._selected_keyfile
+            result["key_select_mode"] = 2
+
+        connection = Connection(result)
+        self.destroy()
+
+        from .connection_dialog import ConnectionDialog
+        conn_dialog = ConnectionDialog(
+            self.parent_window,
+            connection=connection,
+            connection_manager=getattr(self.parent_window, 'connection_manager', None),
+        )
+        conn_dialog.connect('connection-saved', self._on_connection_saved)
+        conn_dialog.present()
+
+    def _on_connection_saved(self, dialog, connection_data):
+        if hasattr(self.parent_window, 'on_connection_saved'):
+            self.parent_window.on_connection_saved(dialog, connection_data)
+
+    def _browse_for_key_file(self, button):
+        dialog = Gtk.FileDialog(title=_("Select SSH Key File"))
+        ssh_dir = get_ssh_dir()
+        if ssh_dir and os.path.isdir(ssh_dir):
+            dialog.set_initial_folder(Gio.File.new_for_path(ssh_dir))
+        dialog.open(self, None, self._on_key_file_selected)
+
+    def _on_key_file_selected(self, dialog, result):
+        try:
+            gfile = dialog.open_finish(result)
+            self._selected_keyfile = gfile.get_path()
+            self.keyfile_row.set_subtitle(self._selected_keyfile)
+        except Exception:
+            pass
+
+    def _validate_parsed(self, connection_data: dict) -> list:
+        from .connection_dialog import SSHConnectionValidator
+        validator = SSHConnectionValidator()
+        errors = []
+
+        hostname = connection_data.get("hostname") or connection_data.get("host", "")
+        result = validator.validate_hostname(hostname)
+        if not result.is_valid:
+            errors.append(result.message)
+
+        port = connection_data.get("port", 22)
+        result = validator.validate_port(str(port))
+        if not result.is_valid:
+            errors.append(result.message)
+
+        return errors
 
     def _parse_ssh_command(self, command_text):
-        """Parse SSH command text and extract connection parameters"""
+        """Parse an SSH command string into connection parameters.
+
+        Returns a connection data dict, a dict with an "error" key for user-visible
+        errors, or None when the input cannot be parsed at all.
+        Only accepts bare user@host or commands starting with 'ssh'.
+        """
         try:
             raw_command = command_text.strip()
 
-            # Handle simple user@host format (backward compatibility)
-            if not raw_command.startswith('ssh') and '@' in raw_command and ' ' not in raw_command:
-                username, host = raw_command.split('@', 1)
+            # Allow bare user@host without the 'ssh' prefix
+            if '@' in raw_command and ' ' not in raw_command and not raw_command.startswith('ssh'):
+                parts = raw_command.split('@', 1)
+                username, host = parts[0], parts[1]
+                if not host:
+                    return None
                 return {
                     "nickname": host,
                     "host": host,
+                    "hostname": host,
                     "username": username,
                     "port": 22,
-                    "auth_method": 0,  # Default to key-based auth
-                    "key_select_mode": 0,  # Try all keys
+                    "auth_method": 0,
+                    "key_select_mode": 0,
                     "quick_connect_command": "",
                     "unparsed_args": [],
                 }
 
-            quick_connect_command = raw_command if raw_command.startswith('ssh') else ""
-            working_text = raw_command
-
-            # Parse full SSH command
-            # Remove 'ssh' prefix if present
-            if working_text.startswith('ssh '):
-                working_text = working_text[4:]
-            elif working_text.startswith('ssh'):
-                working_text = working_text[3:]
-
-            # Use shlex to properly parse the command with quoted arguments
+            # For any other input the first token must be exactly "ssh"
             try:
-                args = shlex.split(working_text)
+                tokens = shlex.split(raw_command)
             except ValueError:
-                # If shlex fails, fall back to simple split
-                args = working_text.split()
+                tokens = raw_command.split()
 
-            # Initialize connection data with defaults
+            if not tokens:
+                return None
+
+            if tokens[0] != "ssh":
+                return {"error": _("Only SSH commands are allowed. Example: ssh user@host")}
+
+            quick_connect_command = raw_command
+            args = tokens[1:]
+
             connection_data = {
                 "nickname": "",
                 "host": "",
+                "hostname": "",
                 "username": "",
                 "port": 22,
-                "auth_method": 0,  # Key-based auth
-                "key_select_mode": 0,  # Try all keys
+                "auth_method": 0,
+                "key_select_mode": 0,
                 "keyfile": "",
                 "certificate": "",
                 "x11_forwarding": False,
@@ -1086,7 +1213,6 @@ class QuickConnectDialog(Adw.MessageDialog):
             while i < len(args):
                 arg = args[i]
 
-                # Handle options with values
                 if arg == '-p' and i + 1 < len(args):
                     try:
                         connection_data["port"] = int(args[i + 1])
@@ -1096,11 +1222,10 @@ class QuickConnectDialog(Adw.MessageDialog):
                         pass
                 elif arg == '-i' and i + 1 < len(args):
                     connection_data["keyfile"] = args[i + 1]
-                    connection_data["key_select_mode"] = 2  # Use specific key without forcing IdentitiesOnly by default
+                    connection_data["key_select_mode"] = 2
                     i += 2
                     continue
                 elif arg == '-o' and i + 1 < len(args):
-                    # Handle SSH options like -o "UserKnownHostsFile=/dev/null"
                     option = args[i + 1]
                     parsed = option.split('=', 1)
                     if len(parsed) == 2:
@@ -1150,25 +1275,18 @@ class QuickConnectDialog(Adw.MessageDialog):
                     i += 1
                     continue
                 elif arg == '-L' and i + 1 < len(args):
-                    # Local port forwarding: -L [bind_address:]port:host:hostport
-                    forward_spec = args[i + 1]
-                    connection_data["local_port_forwards"].append(forward_spec)
+                    connection_data["local_port_forwards"].append(args[i + 1])
                     i += 2
                     continue
                 elif arg == '-R' and i + 1 < len(args):
-                    # Remote port forwarding: -R [bind_address:]port:host:hostport
-                    forward_spec = args[i + 1]
-                    connection_data["remote_port_forwards"].append(forward_spec)
+                    connection_data["remote_port_forwards"].append(args[i + 1])
                     i += 2
                     continue
                 elif arg == '-D' and i + 1 < len(args):
-                    # Dynamic port forwarding: -D [bind_address:]port
-                    forward_spec = args[i + 1]
-                    connection_data["dynamic_forwards"].append(forward_spec)
+                    connection_data["dynamic_forwards"].append(args[i + 1])
                     i += 2
                     continue
                 elif arg.startswith('-p'):
-                    # Handle -p2222 format (no space)
                     try:
                         connection_data["port"] = int(arg[2:])
                         i += 1
@@ -1176,33 +1294,30 @@ class QuickConnectDialog(Adw.MessageDialog):
                     except ValueError:
                         pass
                 elif arg.startswith('-i'):
-                    # Handle -i/path/to/key format (no space)
                     connection_data["keyfile"] = arg[2:]
                     connection_data["key_select_mode"] = 2
                     i += 1
                     continue
                 elif not arg.startswith('-'):
-                    # This should be the host specification (user@host)
                     if not connection_data["host"]:
                         if '@' in arg:
                             username, host = arg.split('@', 1)
                             connection_data["username"] = username
                             connection_data["host"] = host
+                            connection_data["hostname"] = host
                             connection_data["nickname"] = host
                         else:
-                            # Just hostname, no username
                             connection_data["host"] = arg
+                            connection_data["hostname"] = arg
                             connection_data["nickname"] = arg
                     else:
                         connection_data["unparsed_args"].append(arg)
                     i += 1
                 else:
-
-                    # Unknown option. Determine whether it normally expects an argument.
                     option_key = arg
                     attached_value = ""
                     if option_key.startswith('--'):
-                        option_key, _, attached_value = option_key.partition('=')
+                        option_key, _sep, attached_value = option_key.partition('=')
                     elif option_key.startswith('-') and len(option_key) > 2:
                         option_key, attached_value = option_key[:2], option_key[2:]
 
@@ -1224,8 +1339,6 @@ class QuickConnectDialog(Adw.MessageDialog):
                         i += 1
                     continue
 
-
-            # Validate that we have at least a host
             if not connection_data["host"]:
                 return None
 
@@ -1235,20 +1348,22 @@ class QuickConnectDialog(Adw.MessageDialog):
             return connection_data
 
         except Exception:
-            # If parsing fails, try simple fallback
-            if '@' in command_text:
+            # Last-resort fallback for bare user@host that somehow raised
+            if '@' in command_text and ' ' not in command_text:
                 try:
                     username, host = command_text.split('@', 1)
-                    return {
-                        "nickname": host,
-                        "host": host,
-                        "username": username,
-                        "port": 22,
-                        "auth_method": 0,
-                        "key_select_mode": 0,
-                        "quick_connect_command": "",
-                        "unparsed_args": [],
-                    }
+                    if host:
+                        return {
+                            "nickname": host,
+                            "host": host,
+                            "hostname": host,
+                            "username": username,
+                            "port": 22,
+                            "auth_method": 0,
+                            "key_select_mode": 0,
+                            "quick_connect_command": "",
+                            "unparsed_args": [],
+                        }
                 except Exception:
                     pass
             return None

--- a/tests/test_quick_connect.py
+++ b/tests/test_quick_connect.py
@@ -23,9 +23,29 @@ def _ensure_gi_stubs():
             sys.modules['gi.repository'] = repository
 
     for name, attr_map in (
-        ('Gtk', {'Overlay': type('Overlay', (object,), {})}),
-        ('Adw', {'MessageDialog': type('MessageDialog', (object,), {})}),
+        ('Gtk', {'Overlay': type('Overlay', (object,), {}),
+                 'Box': type('Box', (object,), {'__init__': lambda s, **kw: None}),
+                 'Label': type('Label', (object,), {}),
+                 'Entry': type('Entry', (object,), {}),
+                 'Button': type('Button', (object,), {}),
+                 'FileDialog': type('FileDialog', (object,), {}),
+                 'Align': type('Align', (object,), {'START': 0, 'CENTER': 1}),
+                 'Orientation': type('Orientation', (object,), {'VERTICAL': 0, 'HORIZONTAL': 1})}),
+        ('Adw', {'MessageDialog': type('MessageDialog', (object,), {}),
+                 'PreferencesGroup': type('PreferencesGroup', (object,), {}),
+                 'PasswordEntryRow': type('PasswordEntryRow', (object,), {}),
+                 'ActionRow': type('ActionRow', (object,), {}),
+                 'ResponseAppearance': type('ResponseAppearance', (object,), {'SUGGESTED': 0})}),
         ('Gdk', {}),
+        ('GObject', {'Object': type('Object', (object,), {}),
+                     'SignalFlags': type('SignalFlags', (object,), {'RUN_FIRST': 0})}),
+        ('Gio', {'File': type('File', (object,), {'new_for_path': staticmethod(lambda p: None)})}),
+        ('GLib', {
+            'get_user_config_dir': lambda: '/tmp',
+            'get_user_data_dir': lambda: '/tmp',
+            'get_home_dir': lambda: '/tmp',
+            'idle_add': lambda *a, **kw: None,
+        }),
     ):
         module_name = f'gi.repository.{name}'
         module = sys.modules.get(module_name)


### PR DESCRIPTION
## Summary
Enhanced the Quick Connect dialog to support password and key file authentication options, improved SSH command parsing with better error handling, and added connection validation before connecting or saving.

## Key Changes

- **Authentication Options**: Added password entry field and key file browser to the Quick Connect dialog, allowing users to specify credentials directly
- **Improved SSH Command Parsing**: 
  - Stricter validation requiring commands to start with "ssh" or be bare "user@host" format
  - Better error messages for invalid input
  - Added "hostname" field to parsed connection data for consistency
  - Improved handling of edge cases and malformed input
- **Connection Validation**: Implemented `_validate_parsed()` method using `SSHConnectionValidator` to validate hostname and port before connecting
- **Save Connection Feature**: Added "Save Connection…" button to save parsed connections to the connection manager via `ConnectionDialog`
- **Error Display**: Added inline error banner that displays validation errors and clears when user modifies input
- **UI Improvements**:
  - Wrapped UI strings with `_()` for internationalization
  - Organized auth fields into a `PreferencesGroup` for better layout
  - Key file selection defaults to SSH directory if available
  - Improved variable naming (e.g., `_sep` instead of `_` for unused partition separator)
- **Test Updates**: Enhanced test stubs to support new GTK/Adw widgets and GLib/Gio functionality

## Implementation Details

- The parser now returns `None` for completely unparseable input, a dict with "error" key for user-visible errors, and a valid connection dict on success
- Password and keyfile are only added to connection data if explicitly provided by the user
- The "Save Connection…" response creates a `ConnectionDialog` with the parsed connection for full editing before saving
- File dialog for key selection uses `Gio.File` and respects the user's SSH directory location

https://claude.ai/code/session_01JQ3A6pnD3anwdF4bGpLLF5