### PR TITLE
Fix connection dialog to treat duplicated connections as new

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -1175,6 +1175,11 @@ class QuickConnectDialog(Adw.MessageDialog):
             connection=connection,
             connection_manager=getattr(self.parent_window, 'connection_manager', None),
         )
+        # load_connection_data() already ran inside __init__ to pre-fill the form.
+        # Mark as new so window.on_connection_saved takes the new-connection branch
+        # that appends to connection_manager.connections instead of the edit branch
+        # that tries to update a transient object not registered in the manager.
+        conn_dialog.is_editing = False
         conn_dialog.connect('connection-saved', self._on_connection_saved)
         conn_dialog.present()
 


### PR DESCRIPTION
## Summary
Fixed a bug where duplicating an existing SSH connection would incorrectly attempt to update a transient connection object instead of creating a new one in the connection manager.

## Key Changes
- Added `conn_dialog.is_editing = False` after creating a connection dialog from an existing connection
- This ensures the connection is treated as a new connection rather than an edit operation
- Prevents the dialog from trying to update a non-registered transient object when saved

## Implementation Details
The issue occurred because `load_connection_data()` is called during dialog initialization to pre-fill the form with the source connection's data. However, without explicitly setting `is_editing = False`, the dialog would treat this as an edit operation. This caused `window.on_connection_saved` to take the edit branch, which attempts to update the connection object in the manager rather than appending it as a new connection.

By setting `is_editing = False` after initialization, the save handler correctly takes the new-connection branch, properly registering the duplicated connection in the connection manager.

https://claude.ai/code/session_015Rirev2N2jw4GY8qVtQSUX