### PR TITLE
Fix save path not setting auth_method=1 when password is entered in quick connect

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -1162,6 +1162,7 @@ class QuickConnectDialog(Adw.MessageDialog):
         password = self.password_row.get_text()
         if password:
             result["password"] = password
+            result["auth_method"] = 1
         if self._selected_keyfile:
             result["keyfile"] = self._selected_keyfile
             result["key_select_mode"] = 2


### PR DESCRIPTION
## Summary

- One-line bug fix in `QuickConnectDialog._on_save_connection()`: when the user enters a password, `auth_method` was not being set to `1` (password mode), unlike the connect path which already did this correctly.

## Problem

The connect path (`on_connect`) had:
```python
if password:
    result["password"] = password
    result["auth_method"] = 1  # ✅ correct
```

The save path (`_on_save_connection`) only had:
```python
if password:
    result["password"] = password
    # ❌ auth_method left at default 0 (key-based)
```

So if a user typed a password and clicked "Save Connection…", the `Connection` object passed to `ConnectionDialog` had `auth_method = 0`, meaning the dialog would open defaulting to key-based auth and downstream components would not treat it as a password-auth connection.

## Test plan

- [ ] Enter a password in quick connect and click "Save Connection…" — verify the connection dialog opens with the auth method set to "Password" and the password field pre-filled.

https://claude.ai/code/session_01JQ3A6pnD3anwdF4bGpLLF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ3A6pnD3anwdF4bGpLLF5)_