### PR TITLE
Fix port forward spec parser to handle IPv6 addresses in brackets

### DIFF
--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -2,6 +2,7 @@
 
 import gi
 import os
+import re
 import shlex
 import logging
 
@@ -42,42 +43,60 @@ SSH_OPTIONS_EXPECTING_ARGUMENT = {
 }
 
 
+# An address token is either an IPv6 literal in brackets [::1] or any
+# sequence of characters that contains no unbracketed colon (hostname/IPv4).
+_ADDR = r'(?:\[[^\]]*\]|[^\[\]:]+)'
+_PORT = r'\d+'
+
+# Matches [bind_addr:]port:host:hostport with full bracket-awareness.
+_FORWARD_RE = re.compile(
+    r'^(?:(' + _ADDR + r'):)?'   # optional bind_addr:
+    r'(' + _PORT + r')'           # listen_port
+    r':(' + _ADDR + r')'          # remote host
+    r':(' + _PORT + r')$'         # remote port
+)
+
+# Matches [bind_addr:]port for -D (dynamic SOCKS proxy).
+_DYNAMIC_RE = re.compile(
+    r'^(?:(' + _ADDR + r'):)?'   # optional bind_addr:
+    r'(' + _PORT + r')$'          # port
+)
+
+
 def _parse_forward_spec(spec: str, fwd_type: str):
-    """Parse -L/-R spec [bind_addr:]port:host:hostport into a forwarding_rules dict."""
-    parts = spec.split(':')
-    try:
-        if len(parts) == 4:
-            bind_addr, listen_port, remote_host, remote_port = parts
-        elif len(parts) == 3:
-            bind_addr = 'localhost'
-            listen_port, remote_host, remote_port = parts
-        else:
-            return None
-        rule = {'type': fwd_type, 'enabled': True,
-                'listen_addr': bind_addr, 'listen_port': int(listen_port)}
-        if fwd_type == 'local':
-            rule['remote_host'] = remote_host
-            rule['remote_port'] = int(remote_port)
-        else:
-            rule['local_host'] = remote_host
-            rule['local_port'] = int(remote_port)
-        return rule
-    except (ValueError, IndexError):
+    """Parse -L/-R spec [bind_addr:]port:host:hostport into a forwarding_rules dict.
+
+    Handles IPv6 literals in brackets (e.g. [::1]:8080:localhost:80).
+    Returns None if the spec cannot be parsed; callers should preserve the raw
+    spec in unparsed_args so the rule is not silently lost.
+    """
+    m = _FORWARD_RE.match(spec)
+    if not m:
         return None
+    bind_addr, listen_port, remote_host, remote_port = m.groups()
+    rule = {'type': fwd_type, 'enabled': True,
+            'listen_addr': bind_addr or 'localhost', 'listen_port': int(listen_port)}
+    if fwd_type == 'local':
+        rule['remote_host'] = remote_host
+        rule['remote_port'] = int(remote_port)
+    else:
+        rule['local_host'] = remote_host
+        rule['local_port'] = int(remote_port)
+    return rule
 
 
 def _parse_dynamic_spec(spec: str):
-    """Parse -D spec [bind_addr:]port into a forwarding_rules dict."""
-    parts = spec.split(':')
-    try:
-        if len(parts) == 2:
-            bind_addr, port = parts
-        else:
-            bind_addr, port = 'localhost', parts[0]
-        return {'type': 'dynamic', 'enabled': True,
-                'listen_addr': bind_addr, 'listen_port': int(port)}
-    except (ValueError, IndexError):
+    """Parse -D spec [bind_addr:]port into a forwarding_rules dict.
+
+    Handles IPv6 bind addresses in brackets (e.g. [::1]:1080).
+    Returns None if the spec cannot be parsed.
+    """
+    m = _DYNAMIC_RE.match(spec)
+    if not m:
         return None
+    bind_addr, port = m.groups()
+    return {'type': 'dynamic', 'enabled': True,
+            'listen_addr': bind_addr or 'localhost', 'listen_port': int(port)}
 
 
 def _append_extra_config(data: dict, line: str) -> None:


### PR DESCRIPTION
## Summary

- Replaces the `split(':')` approach in `_parse_forward_spec` and `_parse_dynamic_spec` with regex-based parsers that treat `[bracketed]` tokens as a single address segment.

## Problem

The previous implementation split the forwarding spec on every `:`, so a valid OpenSSH IPv6 form like `-L [::1]:8080:localhost:80` would produce 6 segments instead of 4, causing `_parse_forward_spec` to return `None`. Since callers silently skip `None` rules, users who entered IPv6-bound port forwards and clicked "Save Connection…" would lose those rules entirely in the connection dialog.

## Fix

Two compiled module-level regexes replace the split logic:

```python
_ADDR = r'(?:\[[^\]]*\]|[^\[\]:]+)'  # [IPv6] or hostname/IPv4
_FORWARD_RE = re.compile(r'^(?:(_ADDR):)?(_PORT):(_ADDR):(_PORT)$')
_DYNAMIC_RE = re.compile(r'^(?:(_ADDR):)?(_PORT)$')
```

All combinations now parse correctly:

| Spec | Result |
|---|---|
| `127.0.0.1:8080:localhost:80` | ✅ IPv4 bind addr |
| `8080:localhost:80` | ✅ no bind addr (defaults to `localhost`) |
| `[::1]:8080:localhost:80` | ✅ IPv6 bind addr |
| `8080:[::1]:80` | ✅ IPv6 remote host |
| `[::1]:8080:[::1]:80` | ✅ both IPv6 |
| `[::1]:1080` | ✅ dynamic with IPv6 |

## Test plan

- [ ] Enter `-L [::1]:8080:localhost:80` in Quick Connect and click "Save Connection…" — verify the local port forward appears in the connection dialog
- [ ] Existing regression tests pass

https://claude.ai/code/session_01JQ3A6pnD3anwdF4bGpLLF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ3A6pnD3anwdF4bGpLLF5)_