### PR TITLE
Fix WoL subnet broadcast and move WoL UI below ProxyJump

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -2565,7 +2565,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # X11 Forwarding moved to Port Forwarding view
         
         # Return groups for PreferencesPage
-        return [basic_group, wol_group, auth_group, proxy_group, advanced_group]
+        return [basic_group, auth_group, proxy_group, wol_group, advanced_group]
     
     def build_port_forwarding_groups(self):
         """Build PreferencesGroups for the Advanced page (Port Forwarding first, X11 last)"""

--- a/sshpilot/wol.py
+++ b/sshpilot/wol.py
@@ -75,7 +75,7 @@ def send_wol(
     if not target and host:
         ip = _resolve_host_to_ip(host, port=port)
         if ip:
-            target = get_subnet_broadcast(ip, prefix_bits=24)
+            target = get_subnet_broadcast(ip)
     if not target:
         target = "255.255.255.255"
     try:
@@ -91,25 +91,39 @@ def send_wol(
         return False, str(e)
 
 
-def get_subnet_broadcast(host_ip: str, prefix_bits: int = 24) -> Optional[str]:
+def get_subnet_broadcast(host_ip: str) -> Optional[str]:
     """
-    Compute subnet-directed broadcast address for a host (e.g. 192.168.1.50 -> 192.168.1.255).
-    Many routers and NICs only wake on subnet broadcast, not 255.255.255.255.
+    Compute the directed broadcast address for the local interface that can reach host_ip.
+    Queries actual interface netmasks via psutil so non-/24 subnets work correctly.
+    Falls back to 255.255.255.255 if the interface cannot be determined.
     """
     if not host_ip or not isinstance(host_ip, str):
         return None
     host_ip = host_ip.strip()
     try:
-        addr = socket.inet_pton(socket.AF_INET, host_ip)
+        target_bytes = socket.inet_pton(socket.AF_INET, host_ip)
     except OSError:
         return None
-    ip_int = int.from_bytes(addr, "big")
-    if prefix_bits <= 0 or prefix_bits >= 32:
-        return None
-    mask = (0xFFFFFFFF << (32 - prefix_bits)) & 0xFFFFFFFF
-    net = ip_int & mask
-    broadcast_int = net | (0xFFFFFFFF ^ mask)
-    return socket.inet_ntoa(broadcast_int.to_bytes(4, "big"))
+    target_int = int.from_bytes(target_bytes, "big")
+    try:
+        import psutil
+        for _iface, addrs in psutil.net_if_addrs().items():
+            for addr in addrs:
+                if addr.family != socket.AF_INET:
+                    continue
+                if not addr.address or not addr.netmask:
+                    continue
+                try:
+                    iface_int = int.from_bytes(socket.inet_pton(socket.AF_INET, addr.address), "big")
+                    mask_int = int.from_bytes(socket.inet_pton(socket.AF_INET, addr.netmask), "big")
+                    if (target_int & mask_int) == (iface_int & mask_int):
+                        broadcast_int = (iface_int & mask_int) | (~mask_int & 0xFFFFFFFF)
+                        return socket.inet_ntoa(broadcast_int.to_bytes(4, "big"))
+                except Exception:
+                    continue
+    except Exception as e:
+        logger.debug("Subnet broadcast detection failed: %s", e)
+    return None
 
 
 def _resolve_host_to_ip(host: str, port: int = 22) -> Optional[str]:

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,12 +1,15 @@
 """Tests for Wake-on-LAN module."""
 
 import pytest
+from unittest.mock import patch, MagicMock
+import socket
 
 from sshpilot.wol import (
     normalize_mac,
     validate_mac,
     send_wol,
     is_wol_available,
+    get_subnet_broadcast,
 )
 
 
@@ -42,3 +45,48 @@ def test_send_wol_empty_mac():
 def test_is_wol_available():
     # Just ensure it returns a bool (True if wakeonlan installed)
     assert isinstance(is_wol_available(), bool)
+
+
+def test_get_subnet_broadcast_uses_interface_mask():
+    """get_subnet_broadcast should use the real interface netmask, not hardcode /24."""
+    import psutil
+    snic = MagicMock()
+    snic.family = socket.AF_INET
+    snic.address = "10.0.0.5"
+    snic.netmask = "255.255.0.0"  # /16
+
+    with patch("psutil.net_if_addrs", return_value={"eth0": [snic]}):
+        result = get_subnet_broadcast("10.0.1.200")
+    # With /16 mask the broadcast is 10.0.255.255, not 10.0.1.255
+    assert result == "10.0.255.255"
+
+
+def test_get_subnet_broadcast_slash24():
+    """/24 network still works correctly."""
+    import psutil
+    snic = MagicMock()
+    snic.family = socket.AF_INET
+    snic.address = "192.168.1.10"
+    snic.netmask = "255.255.255.0"
+
+    with patch("psutil.net_if_addrs", return_value={"eth0": [snic]}):
+        result = get_subnet_broadcast("192.168.1.50")
+    assert result == "192.168.1.255"
+
+
+def test_get_subnet_broadcast_no_match_returns_none():
+    """Returns None when no local interface is on the same subnet as target."""
+    import psutil
+    snic = MagicMock()
+    snic.family = socket.AF_INET
+    snic.address = "10.0.0.5"
+    snic.netmask = "255.255.255.0"
+
+    with patch("psutil.net_if_addrs", return_value={"eth0": [snic]}):
+        result = get_subnet_broadcast("192.168.1.50")
+    assert result is None
+
+
+def test_get_subnet_broadcast_invalid_ip():
+    assert get_subnet_broadcast("not-an-ip") is None
+    assert get_subnet_broadcast("") is None


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fix**: `get_subnet_broadcast()` in `wol.py` was hard-coding a `/24` prefix, causing Wake-on-LAN to send the magic packet to the wrong broadcast address on any network that isn't `/24` (e.g. `/8` or `/16` subnets common in enterprise or VPN environments). It now queries actual local interface netmasks via `psutil` (already a required dependency) to derive the correct broadcast address. Falls back to `255.255.255.255` when no matching local interface is found.
- **UI reorder**: The Wake-on-LAN preferences group is moved below the ProxyJump group in the connection dialog. New order: Basic → Authentication → ProxyJump → Wake on LAN → Advanced.

## Details

Before (broken for non-/24 subnets):
```python
target = get_subnet_broadcast(ip, prefix_bits=24)  # always /24
```

After (uses real interface mask):
```python
# psutil.net_if_addrs() is iterated to find the local interface
# whose subnet contains the target IP, then its actual netmask is used
target = get_subnet_broadcast(ip)
```

Example: a host at `10.0.1.200` on a `/16` network previously got broadcast `10.0.1.255` (wrong); it now correctly gets `10.0.255.255`.

## Test plan

- [ ] `python -m pytest tests/test_wol.py -v` — all 9 tests pass, including 4 new cases covering /16 subnet, /24 subnet, no-match, and invalid IP
- [ ] Manually configure a connection with a MAC address and send WoL on a /24 network — toast shows "Wake-on-LAN sent"
- [ ] Verify Wake-on-LAN section appears below ProxyJump in the connection edit dialog

https://claude.ai/code/session_01P1NeeLdeqQeTsfZRFcLAgQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1NeeLdeqQeTsfZRFcLAgQ)_