### PR TITLE
Refactor sshpass bundling to use Resources/bin directory

### DIFF
--- a/.github/workflows/macos-pyinstaller-x86.yml
+++ b/.github/workflows/macos-pyinstaller-x86.yml
@@ -66,22 +66,29 @@ jobs:
           chmod +x pyinstaller.sh
           ./pyinstaller.sh
 
-      - name: Bundle sshpass binary into app
+      - name: Verify sshpass bundled correctly
         run: |
-          BREW_PREFIX="$(brew --prefix)"
-          SSHPASS_BIN="$BREW_PREFIX/bin/sshpass"
-          BUNDLE_BIN="dist/SSHPilot.app/Contents/MacOS"
-          
-          echo "=== DEBUG: Copying sshpass into bundle ==="
-          if [ -f "$SSHPASS_BIN" ]; then
-            cp "$SSHPASS_BIN" "$BUNDLE_BIN/sshpass"
-            chmod +x "$BUNDLE_BIN/sshpass"
-            echo "=== DEBUG: sshpass copied successfully ==="
-            file "$BUNDLE_BIN/sshpass"
-          else
-            echo "=== DEBUG: ERROR - sshpass not found at $SSHPASS_BIN ==="
+          SSHPASS_PATH="dist/SSHPilot.app/Contents/Resources/bin/sshpass"
+          echo "=== CHECK: Verifying sshpass bundle at $SSHPASS_PATH ==="
+          if [ ! -f "$SSHPASS_PATH" ]; then
+            echo "=== ERROR: sshpass NOT found at expected path: $SSHPASS_PATH ==="
+            echo "=== Searching entire bundle for sshpass: ==="
+            find dist/SSHPilot.app -name "sshpass" 2>/dev/null || echo "sshpass not found anywhere in bundle"
             exit 1
-          fi          
+          fi
+          echo "=== CHECK: sshpass found ==="
+          ls -la "$SSHPASS_PATH"
+          file "$SSHPASS_PATH"
+          if [ ! -x "$SSHPASS_PATH" ]; then
+            echo "=== ERROR: sshpass is not executable ==="
+            exit 1
+          fi
+          echo "=== CHECK: sshpass is executable ==="
+          if ! file "$SSHPASS_PATH" | grep -q "x86_64"; then
+            echo "=== ERROR: sshpass does not contain x86_64 slice — architecture mismatch ==="
+            exit 1
+          fi
+          echo "=== CHECK: sshpass x86_64 architecture verified ==="
 
 
       - name: Determine artifact names

--- a/.github/workflows/macos-pyinstaller.yml
+++ b/.github/workflows/macos-pyinstaller.yml
@@ -90,6 +90,30 @@ jobs:
           ./pyinstaller.sh
           echo "=== DEBUG: PyInstaller build completed ==="
 
+      - name: Verify sshpass bundled correctly
+        run: |
+          SSHPASS_PATH="dist/SSHPilot.app/Contents/Resources/bin/sshpass"
+          echo "=== CHECK: Verifying sshpass bundle at $SSHPASS_PATH ==="
+          if [ ! -f "$SSHPASS_PATH" ]; then
+            echo "=== ERROR: sshpass NOT found at expected path: $SSHPASS_PATH ==="
+            echo "=== Searching entire bundle for sshpass: ==="
+            find dist/SSHPilot.app -name "sshpass" 2>/dev/null || echo "sshpass not found anywhere in bundle"
+            exit 1
+          fi
+          echo "=== CHECK: sshpass found ==="
+          ls -la "$SSHPASS_PATH"
+          file "$SSHPASS_PATH"
+          if [ ! -x "$SSHPASS_PATH" ]; then
+            echo "=== ERROR: sshpass is not executable ==="
+            exit 1
+          fi
+          echo "=== CHECK: sshpass is executable ==="
+          if ! file "$SSHPASS_PATH" | grep -q "arm64"; then
+            echo "=== ERROR: sshpass does not contain arm64 slice — architecture mismatch ==="
+            exit 1
+          fi
+          echo "=== CHECK: sshpass arm64 architecture verified ==="
+
       - name: Determine artifact names
         id: artifact-info
         run: |

--- a/pyinstaller.sh
+++ b/pyinstaller.sh
@@ -60,7 +60,21 @@ python -m PyInstaller --clean --noconfirm sshpilot.spec
 # Check if build was successful
 if [ -d "dist/SSHPilot.app" ]; then
     echo "✅ Build successful! Bundle created at: dist/SSHPilot.app"
-    
+
+    # Bundle sshpass into the correct location expected by hook-gtk_runtime.py
+    # (Contents/Resources/bin/ — NOT Contents/MacOS/ which PyInstaller's binaries[] uses)
+    echo "🔑 Bundling sshpass..."
+    SSHPASS_SRC="$(command -v sshpass 2>/dev/null || true)"
+    if [ -n "$SSHPASS_SRC" ] && [ -f "$SSHPASS_SRC" ]; then
+        SSHPASS_DEST_DIR="dist/SSHPilot.app/Contents/Resources/bin"
+        mkdir -p "$SSHPASS_DEST_DIR"
+        cp "$SSHPASS_SRC" "$SSHPASS_DEST_DIR/sshpass"
+        chmod +x "$SSHPASS_DEST_DIR/sshpass"
+        echo "✅ sshpass bundled at: $SSHPASS_DEST_DIR/sshpass"
+    else
+        echo "⚠️  sshpass not found in PATH; bundle will require system sshpass"
+    fi
+
     # Create DMG file using create-dmg
     echo "📦 Creating DMG file..."
     

--- a/sshpilot.spec
+++ b/sshpilot.spec
@@ -146,11 +146,6 @@ if keyring_package.exists():
     print(f"Added keyring package: {keyring_package}")
 
 
-# Optional helper binaries
-sshpass = f"{homebrew}/bin/sshpass"
-if os.path.exists(sshpass):
-    binaries.append((sshpass, "Resources/bin"))
-
 # Cairo Python bindings (required for Cairo Context)
 gi_site_packages = site_packages_dir / "gi"
 if gi_site_packages.exists():


### PR DESCRIPTION
## Summary
Refactored the sshpass binary bundling process to use the `Contents/Resources/bin/` directory instead of `Contents/MacOS/`, and moved the bundling logic from the PyInstaller spec file to the build script. This ensures consistent placement and proper verification across both x86_64 and arm64 macOS builds.

## Key Changes

- **Moved sshpass bundling logic** from `sshpilot.spec` to `pyinstaller.sh`:
  - Removed the hardcoded sshpass bundling from the spec file's binaries configuration
  - Implemented dynamic bundling in the build script that checks for sshpass availability and copies it to `Contents/Resources/bin/`
  - Added graceful fallback with a warning if sshpass is not found in PATH

- **Updated CI/CD workflows** to verify sshpass bundling:
  - Replaced manual bundling step in `macos-pyinstaller-x86.yml` with comprehensive verification
  - Added new verification step in `macos-pyinstaller.yml` for arm64 builds
  - Both workflows now check for:
    - Presence of sshpass at the expected path
    - Executable permissions
    - Correct architecture (x86_64 for x86 build, arm64 for universal build)
    - Fallback search if not found at expected location

## Implementation Details

- The build script now uses `command -v sshpass` to locate the binary dynamically, making it more portable
- Verification steps provide detailed error messages and search the entire bundle if the binary is not at the expected location
- Architecture verification ensures the bundled binary matches the target platform
- The change maintains backward compatibility by warning (not failing) if sshpass is unavailable during build

https://claude.ai/code/session_01HBXPNe9pPqfxU3UfnWFK8F