### PR TITLE
Refactor askpass handler to separate password output from logging

### DIFF
--- a/run.py
+++ b/run.py
@@ -12,9 +12,9 @@ import os
 if len(sys.argv) > 1 and sys.argv[1] == '--askpass':
     CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, CURRENT_DIR)
-    from sshpilot.askpass_utils import handle_askpass_cli
+    from sshpilot.askpass_utils import run_askpass_and_write
     prompt = sys.argv[2] if len(sys.argv) > 2 else ""
-    sys.exit(handle_askpass_cli(prompt))
+    sys.exit(run_askpass_and_write(prompt))
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 PARENT = os.path.dirname(CURRENT_DIR)

--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -401,12 +401,13 @@ def _run_askpass_dialog(key_path: str, log_fn) -> "str | None":
     return passphrase_result[0]
 
 
-def handle_askpass_cli(prompt: str) -> int:
+def handle_askpass_cli(prompt: str) -> "str | None":
     """Handle --askpass CLI mode (re-invoked by SSH as SSH_ASKPASS handler).
 
     Looks up stored passphrases using the app's own environment (keyring,
-    libsecret) and falls back to a GTK dialog. Prints the passphrase to
-    stdout and returns 0 on success, 1 on failure.
+    libsecret) and falls back to a GTK dialog. Returns the passphrase string
+    on success, or None on failure. The caller is responsible for writing the
+    passphrase to the real stdout fd.
     """
     log_path = get_askpass_log_path()
 
@@ -427,16 +428,16 @@ def handle_askpass_cli(prompt: str) -> int:
 
     if "password" in pl and "passphrase" not in pl:
         _log("ASKPASS: Ignoring password prompt")
-        return 1
+        return None
 
     if "passphrase" not in pl:
         _log("ASKPASS: No passphrase found, exiting with code 1")
-        return 1
+        return None
 
     key_path = _extract_key_path(prompt)
     if not key_path:
         _log("ASKPASS: Could not extract key path from prompt")
-        return 1
+        return None
 
     _log(f"ASKPASS: Extracted key path: {key_path}")
 
@@ -448,12 +449,11 @@ def handle_askpass_cli(prompt: str) -> int:
                 session_passphrase = f.read().strip()
             if session_passphrase:
                 _log("ASKPASS: Found session passphrase from secure temp file")
-                print(session_passphrase)
                 try:
                     os.unlink(session_passphrase_file)
                 except Exception:
                     pass
-                return 0
+                return session_passphrase
         except Exception as exc:
             _log(f"ASKPASS: Error reading session passphrase file: {exc}")
 
@@ -462,20 +462,62 @@ def handle_askpass_cli(prompt: str) -> int:
         passphrase = lookup_passphrase(candidate)
         if passphrase:
             _log(f"ASKPASS: Found passphrase for {candidate}")
-            print(passphrase)
-            _log("ASKPASS: Returning passphrase and exiting with code 0")
-            return 0
+            _log("ASKPASS: Returning passphrase to caller")
+            return passphrase
         _log(f"ASKPASS: No passphrase found for {candidate}")
 
     # Fall back to interactive GUI dialog
     passphrase = _run_askpass_dialog(key_path, _log)
     if passphrase is not None:
         _log("ASKPASS: User entered passphrase in GUI dialog")
-        print(passphrase)
-        return 0
+        return passphrase
 
     _log("ASKPASS: No passphrase found, exiting with code 1")
-    return 1
+    return None
+
+
+def run_askpass_and_write(prompt: str) -> int:
+    """Entry-point wrapper: separates password output from all other I/O.
+
+    Saves the real stdout fd, redirects fd 1 to stderr so any accidental
+    logging or print cannot contaminate the password, calls
+    handle_askpass_cli, then writes the returned passphrase to the original
+    stdout fd using os.write (bypassing Python buffering).
+
+    Returns 0 on success, 1 on failure.
+    """
+    try:
+        real_stdout_fd = os.dup(1)
+    except OSError:
+        real_stdout_fd = None
+
+    try:
+        try:
+            os.dup2(2, 1)
+        except OSError:
+            pass
+        sys.stdout = sys.stderr
+
+        passphrase = handle_askpass_cli(prompt)
+    finally:
+        if real_stdout_fd is not None:
+            try:
+                os.dup2(real_stdout_fd, 1)
+            except OSError:
+                pass
+            try:
+                os.close(real_stdout_fd)
+            except OSError:
+                pass
+
+    if passphrase is None:
+        return 1
+
+    try:
+        os.write(1, (passphrase + "\n").encode())
+    except OSError:
+        return 1
+    return 0
 
 
 def store_passphrase(key_path: str, passphrase: str) -> bool:
@@ -638,9 +680,9 @@ def ensure_passphrase_askpass() -> str:
         with open(helper_path, "w", encoding="utf-8") as f:
             f.write("import sys\n")
             f.write(f"sys.path.insert(0, {pkg_parent!r})\n")
-            f.write("from sshpilot.askpass_utils import handle_askpass_cli\n")
+            f.write("from sshpilot.askpass_utils import run_askpass_and_write\n")
             f.write("prompt = sys.argv[1] if len(sys.argv) > 1 else ''\n")
-            f.write("sys.exit(handle_askpass_cli(prompt))\n")
+            f.write("sys.exit(run_askpass_and_write(prompt))\n")
         os.chmod(helper_path, 0o600)
         with open(script_path, "w", encoding="utf-8") as f:
             f.write(f'#!/bin/sh\nexec "{sys.executable}" "{helper_path}" "$@"\n')

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -754,9 +754,9 @@ def main():
     # This is reached when the app is invoked via a console-script entry point
     # (e.g. Homebrew pip-installed binary) where run.py is not used.
     if len(sys.argv) > 1 and sys.argv[1] == '--askpass':
-        from .askpass_utils import handle_askpass_cli
+        from .askpass_utils import run_askpass_and_write
         prompt = sys.argv[2] if len(sys.argv) > 2 else ""
-        sys.exit(handle_askpass_cli(prompt))
+        sys.exit(run_askpass_and_write(prompt))
 
     parser = argparse.ArgumentParser(description="sshPilot SSH connection manager")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose debug logging")


### PR DESCRIPTION
## Summary
Refactored the SSH askpass handler to prevent accidental logging or print statements from contaminating the password output sent to SSH. This improves security and reliability by ensuring only the passphrase is written to stdout.

## Key Changes
- **Split responsibility**: Separated `handle_askpass_cli()` into two functions:
  - `handle_askpass_cli()` now returns the passphrase string (or None) instead of printing and returning exit codes
  - New `run_askpass_and_write()` wrapper handles all I/O redirection and writes the passphrase to stdout

- **I/O isolation**: `run_askpass_and_write()` implements secure output handling:
  - Saves the real stdout file descriptor before any operations
  - Redirects fd 1 to stderr to prevent accidental logging contamination
  - Restores the original stdout after `handle_askpass_cli()` completes
  - Uses `os.write()` to bypass Python buffering when writing the passphrase

- **Updated return types**: Changed `handle_askpass_cli()` return type from `int` to `str | None` to reflect the new behavior

- **Updated all entry points**: Modified `run.py` and `main.py` to call the new `run_askpass_and_write()` wrapper instead of `handle_askpass_cli()` directly

## Implementation Details
- The refactored code removes all `print()` calls from the passphrase retrieval logic
- Error handling is preserved with proper cleanup of file descriptors in a try/finally block
- The wrapper function maintains the original exit code contract (0 for success, 1 for failure) expected by SSH
- All three entry points (direct CLI, run.py, and console-script) now use the same secure wrapper

https://claude.ai/code/session_01PAinAAnhZxjCmV6udCGW5L