### PR TITLE
Add ad-hoc code signing to macOS app bundle build

### DIFF
--- a/pyinstaller.sh
+++ b/pyinstaller.sh
@@ -75,6 +75,12 @@ if [ -d "dist/SSHPilot.app" ]; then
         echo "⚠️  sshpass not found in PATH; bundle will require system sshpass"
     fi
 
+    # Ad-hoc sign the app bundle — prevents "damaged app" Gatekeeper error when downloaded
+    echo "🔐 Ad-hoc code signing app bundle..."
+    codesign --sign - --force --deep --timestamp=none "dist/SSHPilot.app"
+    codesign --verify --verbose "dist/SSHPilot.app" 2>&1 || true
+    echo "✅ App bundle signed (ad-hoc)"
+
     # Create DMG file using create-dmg
     echo "📦 Creating DMG file..."
     


### PR DESCRIPTION
## Summary
Added ad-hoc code signing to the macOS app bundle during the build process to prevent Gatekeeper "damaged app" errors when the application is downloaded.

## Key Changes
- Added `codesign` command to ad-hoc sign the app bundle with `--sign -` flag
- Included `--force` and `--deep` flags to ensure all nested components are signed
- Added verification step to confirm the signature was applied successfully
- Disabled timestamp validation with `--timestamp=none` for reproducible builds

## Implementation Details
The code signing is performed after bundling sshpass (if available) and before creating the DMG file. The verification step uses `|| true` to prevent build failures if verification produces warnings, while still providing visibility into the signing status.

https://claude.ai/code/session_01BG4YoL5KWXJFC22Lx7Ywve