### PR TITLE
Refactor askpass dialog initialization and fix application flags

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -301,32 +301,32 @@ def _run_askpass_dialog(key_path: str, log_fn) -> "str | None":
     passphrase_result = [None]
     Adw.init()
 
-    try:
-        try:
-            config_dir = os.path.join(GLib.get_user_config_dir(), "sshpilot")
-        except Exception:
-            config_dir = os.path.join(os.path.expanduser("~"), ".config", "sshpilot")
-        config_file = os.path.join(config_dir, "config.json")
-        saved_theme = "default"
-        if os.path.exists(config_file):
-            try:
-                with open(config_file, "r") as f:
-                    saved_theme = str(json.load(f).get("app-theme", "default"))
-            except Exception:
-                pass
-        style_manager = Adw.StyleManager.get_default()
-        if saved_theme == "light":
-            style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
-        elif saved_theme == "dark":
-            style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
-        else:
-            style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
-    except Exception:
-        pass
-
-    app = Adw.Application.new("io.github.mfat.sshpilot.askpass", Gio.ApplicationFlags.FLAGS_NONE)
+    app = Adw.Application.new("io.github.mfat.sshpilot.askpass", Gio.ApplicationFlags.NON_UNIQUE)
 
     def on_activate(app):
+        try:
+            try:
+                config_dir = os.path.join(GLib.get_user_config_dir(), "sshpilot")
+            except Exception:
+                config_dir = os.path.join(os.path.expanduser("~"), ".config", "sshpilot")
+            config_file = os.path.join(config_dir, "config.json")
+            saved_theme = "default"
+            if os.path.exists(config_file):
+                try:
+                    with open(config_file, "r") as f:
+                        saved_theme = str(json.load(f).get("app-theme", "default"))
+                except Exception:
+                    pass
+            style_manager = Adw.StyleManager.get_default()
+            if saved_theme == "light":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+            elif saved_theme == "dark":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+            else:
+                style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
+        except Exception:
+            pass
+
         key_name = os.path.basename(key_path) if key_path else "key"
         window = Adw.ApplicationWindow()
         window.set_application(app)


### PR DESCRIPTION
## Summary
Restructured the askpass dialog initialization to move theme configuration logic inside the `on_activate` callback and corrected the application flags parameter.

## Key Changes
- Moved theme configuration code from module-level try-except block into the `on_activate` callback function
- Changed `Gio.ApplicationFlags.FLAGS_NONE` to `Gio.ApplicationFlags.NON_UNIQUE` when creating the Adw.Application instance
- Reorganized code flow so theme loading and style manager configuration occurs within the application activation context rather than before application creation

## Implementation Details
The refactoring ensures that theme configuration happens at the appropriate lifecycle point (during application activation) rather than before the application object is fully initialized. This change also corrects the application flags to use `NON_UNIQUE`, which allows multiple instances of the application to run simultaneously—appropriate for an askpass utility that may be invoked multiple times.

https://claude.ai/code/session_01QzAPoTieHT2spcFpSvSf3n