### PR TITLE
Add URL detection and opening support in terminal context menu

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -2720,12 +2720,34 @@ class TerminalWidget(Gtk.Box):
         # Store PID for cleanup
         self.process_pid = pid
 
+    def _open_url_in_browser(self, url: str) -> None:
+        """Open *url* in the default browser."""
+        try:
+            Gtk.show_uri(None, url, 0)
+        except Exception:
+            try:
+                import subprocess
+                subprocess.Popen(["xdg-open", url])
+            except Exception:
+                logger.debug("Failed to open URL: %s", url)
+
     def _setup_context_menu(self):
         """Set up a robust per-terminal context menu and actions."""
         try:
             logger.debug("Setting up terminal context menu...")
+            self._menu_url: Optional[str] = None
+
             # Per-widget action group
             self._menu_actions = Gio.SimpleActionGroup()
+
+            # "Open URL" – disabled until a right-click lands on a link
+            act_open_url = Gio.SimpleAction.new("open_url", None)
+            act_open_url.set_enabled(False)
+            act_open_url.connect(
+                "activate", lambda a, p: self._open_url_in_browser(self._menu_url) if self._menu_url else None
+            )
+            self._menu_actions.add_action(act_open_url)
+
             act_copy = Gio.SimpleAction.new("copy", None)
             act_copy.connect("activate", lambda a, p: self.copy_text())
             self._menu_actions.add_action(act_copy)
@@ -2735,24 +2757,29 @@ class TerminalWidget(Gtk.Box):
             act_selall = Gio.SimpleAction.new("select_all", None)
             act_selall.connect("activate", lambda a, p: self.select_all())
             self._menu_actions.add_action(act_selall)
-            
+
             # Add zoom actions
             act_zoom_in = Gio.SimpleAction.new("zoom_in", None)
             act_zoom_in.connect("activate", lambda a, p: self.zoom_in())
             self._menu_actions.add_action(act_zoom_in)
-            
+
             act_zoom_out = Gio.SimpleAction.new("zoom_out", None)
             act_zoom_out.connect("activate", lambda a, p: self.zoom_out())
             self._menu_actions.add_action(act_zoom_out)
-            
+
             act_reset_zoom = Gio.SimpleAction.new("reset_zoom", None)
             act_reset_zoom.connect("activate", lambda a, p: self.reset_zoom())
             self._menu_actions.add_action(act_reset_zoom)
-            
+
             self.insert_action_group('term', self._menu_actions)
 
             # Menu model with keyboard shortcuts
             self._menu_model = Gio.Menu()
+
+            # URL section at top (always present; grayed-out when no link is under cursor)
+            url_section = Gio.Menu()
+            url_section.append(_("Open URL"), "term.open_url")
+            self._menu_model.append_section(None, url_section)
 
             if is_macos():
                 self._menu_model.append(_("Copy\t⌘C"), "term.copy")
@@ -2783,7 +2810,8 @@ class TerminalWidget(Gtk.Box):
             if parent_widget:
                 self._menu_popover.set_parent(parent_widget)
 
-            # Right-click gesture to open popover
+            # Right-click gesture to open popover; button=0 catches all buttons so
+            # we can also intercept Ctrl+left-click to open links.
             gesture = Gtk.GestureClick()
             gesture.set_button(0)
             def _on_pressed(gest, n_press, x, y):
@@ -2793,10 +2821,46 @@ class TerminalWidget(Gtk.Box):
                         btn = gest.get_current_button()
                     except Exception:
                         pass
+
+                    # Retrieve the underlying GdkEvent so we can ask VTE which URL
+                    # (if any) is under the pointer.
+                    gdk_event = None
+                    try:
+                        seq = gest.get_last_updated_sequence()
+                        gdk_event = gest.get_last_event(seq)
+                    except Exception:
+                        pass
+
+                    url = None
+                    if self.backend and hasattr(self.backend, "get_url_at_event"):
+                        try:
+                            url = self.backend.get_url_at_event(gdk_event)
+                        except Exception:
+                            pass
+
+                    # Ctrl+left-click → open URL directly without showing the menu
+                    if btn == Gdk.BUTTON_PRIMARY and url:
+                        try:
+                            modifier = gdk_event.get_modifier_state() if gdk_event else Gdk.ModifierType(0)
+                            if modifier & Gdk.ModifierType.CONTROL_MASK:
+                                gest.set_state(Gtk.EventSequenceState.CLAIMED)
+                                self._open_url_in_browser(url)
+                                return
+                        except Exception:
+                            pass
+
                     logger.debug(f"Context menu gesture: button={btn}, x={x}, y={y}")
                     if btn not in (Gdk.BUTTON_SECONDARY, 3):
                         logger.debug(f"Not a right-click button: {btn}")
                         return
+
+                    # Enable / disable "Open URL" depending on what's under the cursor
+                    self._menu_url = url
+                    try:
+                        self._menu_actions.lookup_action("open_url").set_enabled(bool(url))
+                    except Exception:
+                        pass
+
                     # Stop event propagation to prevent other context menus
                     gest.set_state(Gtk.EventSequenceState.CLAIMED)
                     # Focus terminal first for reliable copy/paste

--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -138,6 +138,9 @@ class VTETerminalBackend:
         self.widget = self.vte
         self._termprops_handler: Optional[int] = None
         self._populate_popup_handler: Optional[int] = None
+        self._hyperlink_handler: Optional[int] = None
+        self._hover_uri: str = ""
+        self._url_tag: int = -1
 
     def initialize(self) -> None:
         self.vte.set_hexpand(True)
@@ -207,6 +210,33 @@ class VTETerminalBackend:
         except Exception:
             logger.debug("Failed to show VTE widget", exc_info=True)
         
+        # Enable OSC 8 hyperlinks and connect hover signal
+        try:
+            if hasattr(self.vte, "set_allow_hyperlink"):
+                self.vte.set_allow_hyperlink(True)
+                self._hyperlink_handler = self.vte.connect(
+                    "hyperlink-hover-uri-changed", self._on_hyperlink_hover
+                )
+        except Exception:
+            logger.debug("Failed to enable OSC 8 hyperlinks", exc_info=True)
+
+        # Add regex match for plain-text URLs so the pointer cursor appears on hover
+        try:
+            url_pattern = (
+                r'(?:https?://|ftp://|file://|ssh://|git://)'
+                r'[^\s<>"\'\)\]\}]*'
+                r'[^\s<>"\'\)\]\}\.,;:!?]'
+            )
+            url_regex = GLib.Regex.new(
+                url_pattern,
+                GLib.RegexCompileFlags.OPTIMIZE | GLib.RegexCompileFlags.CASELESS,
+                GLib.RegexMatchFlags.NOTEMPTY,
+            )
+            self._url_tag = self.vte.match_add_regex(url_regex, 0)
+            self.vte.match_set_cursor_name(self._url_tag, "pointer")
+        except Exception:
+            logger.debug("Failed to add URL regex match", exc_info=True)
+
         # Disable VTE's built-in context menu to prevent duplication with our custom menu
         try:
             if hasattr(self.vte, "connect"):
@@ -231,6 +261,39 @@ class VTETerminalBackend:
                 self.vte.disconnect(self._populate_popup_handler)  # type: ignore[arg-type]
         except Exception:
             pass
+        try:
+            if self._hyperlink_handler is not None:
+                self.vte.disconnect(self._hyperlink_handler)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            if self._url_tag >= 0 and hasattr(self.vte, "match_remove"):
+                self.vte.match_remove(self._url_tag)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Hyperlink helpers
+    # ------------------------------------------------------------------
+    def _on_hyperlink_hover(self, terminal: Vte.Terminal, uri: str, bbox: Any) -> None:
+        self._hover_uri = uri or ""
+
+    def get_url_at_event(self, event: Optional[Gdk.Event]) -> Optional[str]:
+        """Return the URL under the given GDK event, or None.
+
+        OSC 8 hover URI is checked first; then the regex match at the event
+        position is used as a fallback for plain-text URLs.
+        """
+        if self._hover_uri:
+            return self._hover_uri
+        if event is not None and hasattr(self.vte, "match_check_event"):
+            try:
+                match, _tag = self.vte.match_check_event(event)
+                if match:
+                    return match
+            except Exception:
+                pass
+        return None
 
     # ------------------------------------------------------------------
     # Lifecycle helpers


### PR DESCRIPTION
## Summary
This PR adds URL detection and opening capabilities to the terminal widget. Users can now right-click on URLs to open them via a context menu, or use Ctrl+left-click to open URLs directly without showing the menu.

## Key Changes

- **URL Detection**: Implemented URL detection using both OSC 8 hyperlinks (for terminal-aware applications) and regex pattern matching (for plain-text URLs)
  - Added `_on_hyperlink_hover()` handler to track OSC 8 hyperlinks
  - Added regex pattern matching for common URL schemes (http, https, ftp, file, ssh, git)
  - Pointer cursor appears on hover over detected URLs

- **Context Menu Integration**: 
  - Added "Open URL" action to the context menu that is enabled/disabled based on whether a URL is under the cursor
  - URL action is disabled by default and only enabled when right-clicking on a detected URL

- **Direct URL Opening**:
  - Ctrl+left-click on a URL now opens it directly without showing the context menu
  - Implemented `_open_url_in_browser()` method with fallback support (GTK's `show_uri()` → `xdg-open`)

- **Backend Support**:
  - Added `get_url_at_event()` method to retrieve URLs at a given event position
  - Checks OSC 8 hover URI first, then falls back to regex match detection
  - Properly tracks and cleans up hyperlink handlers and regex matches on widget destruction

## Implementation Details

- The gesture handler now captures the underlying GDK event to query VTE for URL information
- URL detection prioritizes OSC 8 hyperlinks (more reliable) over regex matches (fallback for plain text)
- Proper exception handling and cleanup to prevent memory leaks
- Code formatting improvements (trailing whitespace cleanup)

https://claude.ai/code/session_01AFbiCLW63TRPQWoqFCRGv8