### PR TITLE
Fix VTE URL detection on GTK4 using coordinate-based API

### DIFF
--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -2804,7 +2804,7 @@ class TerminalWidget(Gtk.Box):
                         try:
                             event = gest.get_last_event(None)
                             if event and self.backend and hasattr(self.backend, 'check_match_at_event'):
-                                url = self.backend.check_match_at_event(event)
+                                url = self.backend.check_match_at_event(event, x, y)
                                 if url:
                                     gest.set_state(Gtk.EventSequenceState.CLAIMED)
                                     Gio.AppInfo.launch_default_for_uri(url, None)

--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -238,13 +238,18 @@ class VTETerminalBackend:
         except Exception as e:
             logger.debug(f"Failed to register URL regex for VTE: {e}", exc_info=True)
 
-        # Probe once which event-based URL detection APIs are available on this VTE version.
-        self._has_hyperlink_check_event = hasattr(self.vte, "hyperlink_check_event")
-        self._has_match_check_event = hasattr(self.vte, "match_check_event")
-        if not self._has_hyperlink_check_event:
-            logger.debug("VTE hyperlink_check_event not available on this version; OSC 8 click detection disabled")
-        if not self._has_match_check_event:
-            logger.debug("VTE match_check_event not available on this version; regex URL click detection disabled")
+        # Probe once which URL detection APIs are available on this VTE build.
+        # GTK3 uses event-based APIs; GTK4 replaced them with coordinate-based *_at() variants.
+        self._has_hyperlink_check_event = hasattr(self.vte, "hyperlink_check_event")  # GTK3
+        self._has_match_check_event     = hasattr(self.vte, "match_check_event")       # GTK3
+        self._has_check_hyperlink_at    = hasattr(self.vte, "check_hyperlink_at")      # GTK4
+        self._has_check_match_at        = hasattr(self.vte, "check_match_at")          # GTK4
+        if self._has_check_hyperlink_at or self._has_check_match_at:
+            logger.debug("VTE URL detection: using GTK4 coordinate-based API")
+        elif self._has_hyperlink_check_event or self._has_match_check_event:
+            logger.debug("VTE URL detection: using GTK3 event-based API")
+        else:
+            logger.debug("VTE URL detection: no supported API found; link clicking disabled")
 
 
     def destroy(self) -> None:
@@ -579,13 +584,15 @@ class VTETerminalBackend:
         except Exception:
             return None
 
-    def check_match_at_event(self, event) -> Optional[str]:
-        """Return the URL under the cursor at the given GdkEvent, or None.
+    def check_match_at_event(self, event, x: float = None, y: float = None) -> Optional[str]:
+        """Return the URL under the cursor, or None.
 
-        Checks OSC 8 hyperlinks first (set_allow_hyperlink must be True), then
-        falls back to regex-matched plain-text URLs.
+        Tries the GTK3 event-based API first, then the GTK4 coordinate-based
+        API (check_hyperlink_at / check_match_at) using the supplied x, y pixel
+        coordinates.  Callers on GTK4 must pass x and y or link detection will
+        silently return None.
         """
-        # OSC 8 hyperlinks (proper hyperlinks embedded in terminal escape sequences)
+        # GTK3 path: event-based
         if self._has_hyperlink_check_event:
             try:
                 uri = self.vte.hyperlink_check_event(event)
@@ -594,7 +601,6 @@ class VTETerminalBackend:
             except Exception:
                 logger.debug("Failed to check OSC 8 hyperlink at event", exc_info=True)
 
-        # Fallback: regex-matched plain-text URLs
         if self._has_match_check_event:
             try:
                 result = self.vte.match_check_event(event)
@@ -602,6 +608,24 @@ class VTETerminalBackend:
                     return result[0]
             except Exception:
                 logger.debug("Failed to check regex URL match at event", exc_info=True)
+
+        # GTK4 path: coordinate-based
+        if x is not None and y is not None:
+            if self._has_check_hyperlink_at:
+                try:
+                    uri = self.vte.check_hyperlink_at(x, y)
+                    if uri:
+                        return uri
+                except Exception:
+                    logger.debug("Failed to check OSC 8 hyperlink at coords", exc_info=True)
+
+            if self._has_check_match_at:
+                try:
+                    result = self.vte.check_match_at(x, y)
+                    if result and result[0]:
+                        return result[0]
+                except Exception:
+                    logger.debug("Failed to check regex URL match at coords", exc_info=True)
 
         return None
 


### PR DESCRIPTION
## Summary

- VTE's GTK4 build removed the event-based `hyperlink_check_event` / `match_check_event` APIs and replaced them with coordinate-based `check_hyperlink_at(x, y)` / `check_match_at(x, y)`
- The previous fix (PR #930) silenced the `AttributeError` log spam but left link clicking non-functional on GTK4 builds
- This PR adds the GTK4 `*_at()` path so URL detection actually works

## Changes

**`sshpilot/terminal_backends.py`**
- Probes all four API variants at `initialize()` time: GTK3 event-based (`hyperlink_check_event`, `match_check_event`) and GTK4 coordinate-based (`check_hyperlink_at`, `check_match_at`)
- Logs a one-time debug message indicating which API generation is active
- `check_match_at_event()` accepts optional `x, y` pixel coordinates; tries the GTK3 event-based path first, then falls through to the GTK4 `*_at()` path when coordinates are provided

**`sshpilot/terminal.py`**
- Passes the gesture's `x, y` coordinates (already in scope) to `check_match_at_event()` so the GTK4 path is reachable

## Test plan

- [ ] Run the app on a GTK4 system; output a plain `https://` URL in the terminal and left-click it — it should open in the browser
- [ ] Run `ls --hyperlink` and left-click an OSC 8 hyperlink — it should open in the browser
- [ ] Confirm no `AttributeError` tracebacks appear in the debug log
- [ ] On a GTK3 build (if available), verify the event-based path still works unchanged

https://claude.ai/code/session_01ULUh3Ju2KNVJeA8w6q83k6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULUh3Ju2KNVJeA8w6q83k6)_