### PR TITLE
Default VTE URL detection flags in __init__ to prevent AttributeError

### DIFF
--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -138,6 +138,10 @@ class VTETerminalBackend:
         self.widget = self.vte
         self._termprops_handler: Optional[int] = None
         self._populate_popup_handler: Optional[int] = None
+        self._has_hyperlink_check_event = False
+        self._has_match_check_event     = False
+        self._has_check_hyperlink_at    = False
+        self._has_check_match_at        = False
 
     def initialize(self) -> None:
         self.vte.set_hexpand(True)


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'VTETerminalBackend' object has no attribute '_has_hyperlink_check_event'` when a click gesture fires before `initialize()` has run
- The four `_has_*` capability flags were only assigned inside `initialize()`, leaving the object in an invalid state if `check_match_at_event()` was called earlier in the lifecycle
- Default all four flags to `False` in `__init__` so the method is safe to call at any point

## Test plan

- [ ] Left-click in the terminal immediately after the widget is constructed (before full init completes) — no `AttributeError` in the log
- [ ] Normal URL click still works as expected after `initialize()` runs

https://claude.ai/code/session_01ULUh3Ju2KNVJeA8w6q83k6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULUh3Ju2KNVJeA8w6q83k6)_