### PR TITLE
Add visual feedback for regex-matched URLs in terminal

### DIFF
--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -238,6 +238,12 @@ class VTETerminalBackend:
                 )
                 self._url_regex_tag = self.vte.match_add_regex(url_re, 0)
                 logger.debug("Registered plain-text URL regex (tag=%s)", self._url_regex_tag)
+                # Without this, VTE shows no visual feedback (no underline, no cursor change)
+                # for regex-matched URLs. match_set_cursor_name tells VTE what cursor to use
+                # on hover, which also triggers the underline decoration internally.
+                if hasattr(self.vte, "match_set_cursor_name") and self._url_regex_tag >= 0:
+                    self.vte.match_set_cursor_name(self._url_regex_tag, "pointer")
+                    logger.debug("Set pointer cursor for URL regex matches")
         except Exception:
             logger.debug("Failed to register URL regex", exc_info=True)
 


### PR DESCRIPTION
## Summary
This change improves the user experience when interacting with URLs in the terminal by adding visual feedback (cursor change and underline decoration) when hovering over detected URLs.

## Key Changes
- Added `match_set_cursor_name()` call to set the pointer cursor for URL regex matches
- Included safety checks to ensure the method exists and the regex tag is valid
- Added debug logging to track when the pointer cursor is successfully configured

## Implementation Details
The VTE (Virtual Terminal Emulator) library requires an explicit call to `match_set_cursor_name()` to enable visual feedback for regex-matched content. Without this call, matched URLs have no visual indication on hover. By setting the cursor name to "pointer", VTE internally triggers both the cursor change and the underline decoration for matched URLs, providing clear feedback to users that the text is interactive.

The implementation includes defensive checks:
- `hasattr()` check to ensure the method exists on the VTE widget
- Validation that the regex tag is valid (`>= 0`) before applying cursor settings
- Exception handling already in place to gracefully handle any failures

https://claude.ai/code/session_01UefBqjf4HU64Pq9UnS11Xr