### PR TITLE
wake-on-lan flatpak deps

### DIFF
--- a/flatpak/python3-deps.yml
+++ b/flatpak/python3-deps.yml
@@ -232,3 +232,26 @@ modules:
         url: https://files.pythonhosted.org/packages/47/38/1b75b3ba3452860211ec87710f9854112911a436ee4d155533e0b83b5cd9/Flask_SocketIO-5.5.1-py3-none-any.whl
         sha256: 35a50166db44d055f68021d6ec32cb96f1f925cd82de4504314be79139ea846f
 
+  - name: python3-psutil
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "psutil==7.2.2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+        sha256: b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e
+        only-arches: [aarch64]
+
+  - name: python3-wakeonlan
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "wakeonlan==3.3.0" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a6/ab/d1a60da2f2c46a022ef15caaabe5bc468519c05dc855a0a40a83cb656c26/wakeonlan-3.3.0-py3-none-any.whl
+        sha256: 969d4e1f30add1a79790c99350e91c46ed45588770416257a3f806ca0314b17a
+


### PR DESCRIPTION
Hi! It turns out I missed python3-wakeonlan in my previous PR https://github.com/mfat/sshpilot/pull/881. This PR fixes that by adding the missing dependency to the Flatpak bundle.

