### PR TITLE
fix: capture right-click events before ListBox selection logic

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -2015,6 +2015,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             # Use a simple gesture but avoid all coordinate-based operations
             context_click = Gtk.GestureClick()
             context_click.set_button(Gdk.BUTTON_SECONDARY)  # Only handle right-click
+            # Capture phase so the gesture fires before child widgets consume the
+            # event — without this, right-clicking an unselected row is silently
+            # swallowed by the ListBox's own selection logic on the first press.
+            context_click.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
             
             def _on_right_click(gesture, n_press, x, y):
                 try:
@@ -2058,6 +2062,10 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         logger.debug("No row available for context menu")
                         return
                     
+                    # Select/highlight the right-clicked row so the UI reflects
+                    # which connection the context menu applies to.
+                    self.connection_list.select_row(row)
+
                     # Set context menu data
                     self._context_menu_row = row
                     self._context_menu_connection = getattr(row, 'connection', None)


### PR DESCRIPTION
## Summary
Fix right-click context menu on unselected rows in the connection list. Previously, right-clicking an unselected row would be silently consumed by the ListBox's own selection logic on the first press, preventing the context menu from appearing.

## Changes
- **Set gesture propagation phase to CAPTURE**: Configure the right-click gesture to fire during the capture phase, before child widgets (the ListBox) can consume the event. This ensures the context menu handler runs even on unselected rows.
- **Auto-select right-clicked row**: When a context menu is triggered, explicitly select/highlight the row so the UI clearly reflects which connection the menu applies to, improving user feedback.

## Implementation Details
- The `GestureClick` for secondary (right-click) button now uses `Gtk.PropagationPhase.CAPTURE` to intercept events before the ListBox's default selection behavior.
- After identifying the row under the cursor, `self.connection_list.select_row(row)` is called to ensure the row is visually selected before the context menu appears.

https://claude.ai/code/session_01Ttx3a1vsG8Ej66hhqmYXDx