### PR TITLE
Add authorized_keys editor (remote + local)

### DIFF
--- a/sshpilot/actions.py
+++ b/sshpilot/actions.py
@@ -1696,6 +1696,12 @@ def register_window_actions(window):
         window.edit_known_hosts_action.connect('activate', window.on_edit_known_hosts_action)
         window.add_action(window.edit_known_hosts_action)
 
+    # Action for managing the local authorized_keys file
+    if hasattr(window, 'on_manage_local_authorized_keys_action'):
+        window.manage_local_authorized_keys_action = Gio.SimpleAction.new('manage-local-authorized-keys', None)
+        window.manage_local_authorized_keys_action.connect('activate', window.on_manage_local_authorized_keys_action)
+        window.add_action(window.manage_local_authorized_keys_action)
+
     # Group management actions
     window.create_group_action = Gio.SimpleAction.new('create-group', None)
     window.create_group_action.connect('activate', window.on_create_group_action)

--- a/sshpilot/authorized_keys_parser.py
+++ b/sshpilot/authorized_keys_parser.py
@@ -1,0 +1,387 @@
+"""Round-trippable parser/serialiser for OpenSSH ``authorized_keys`` files.
+
+The parser preserves the original line text for any untouched entry so that an
+unmodified parse → serialise cycle is byte-identical, including unknown
+options (security-critical: a silently dropped option is a regression).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple, Union
+
+
+# Known SSH public key type prefixes. Anything not in this set is treated as an
+# option token rather than a keytype during line parsing.
+KEYTYPE_PREFIXES = (
+    "ssh-rsa",
+    "ssh-dss",
+    "ssh-ed25519",
+    "ssh-ed448",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "sk-ecdsa-sha2-nistp256@openssh.com",
+    "sk-ssh-ed25519@openssh.com",
+)
+
+# Cert variants: same prefixes with -cert-v01@openssh.com suffix.
+CERT_SUFFIX = "-cert-v01@openssh.com"
+
+
+def _is_keytype(token: str) -> bool:
+    if token in KEYTYPE_PREFIXES:
+        return True
+    if token.endswith(CERT_SUFFIX):
+        base = token[: -len(CERT_SUFFIX)]
+        return base in KEYTYPE_PREFIXES or base in (
+            "ssh-rsa",
+            "ssh-dss",
+            "ssh-ed25519",
+            "ecdsa-sha2-nistp256",
+            "ecdsa-sha2-nistp384",
+            "ecdsa-sha2-nistp521",
+        )
+    return False
+
+
+# Known option names. Flag options have no '=' value. Value options take a
+# quoted string. Repeatable options may appear more than once on a line.
+FLAG_OPTIONS = {
+    "cert-authority",
+    "no-agent-forwarding",
+    "no-port-forwarding",
+    "no-pty",
+    "no-user-rc",
+    "no-X11-forwarding",
+    "no-x11-forwarding",
+    "restrict",
+    "agent-forwarding",
+    "port-forwarding",
+    "pty",
+    "user-rc",
+    "X11-forwarding",
+    "x11-forwarding",
+    "verify-required",
+    "no-touch-required",
+    "touch-required",
+}
+
+VALUE_OPTIONS = {
+    "command",
+    "environment",
+    "expiry-time",
+    "from",
+    "permitlisten",
+    "permitopen",
+    "principals",
+    "tunnel",
+}
+
+REPEATABLE_OPTIONS = {"environment", "permitopen", "permitlisten"}
+
+KNOWN_OPTIONS = FLAG_OPTIONS | VALUE_OPTIONS
+
+
+OptionValue = Union[str, bool]
+OptionTuple = Tuple[str, OptionValue]
+
+
+@dataclass
+class AuthorizedKeyEntry:
+    """One parsed entry from an authorized_keys file.
+
+    ``raw_line`` is the original input line (without trailing newline). It is
+    used to emit byte-identical output when the entry has not been mutated.
+    """
+
+    raw_line: str
+    disabled: bool
+    options: List[OptionTuple]
+    unknown_options: List[str]
+    keytype: str
+    key_b64: str
+    comment: str
+    fingerprint_sha256: str = ""
+    dirty: bool = False
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    def get_option(self, name: str) -> Optional[OptionValue]:
+        for n, v in self.options:
+            if n == name:
+                return v
+        return None
+
+    def get_options(self, name: str) -> List[OptionValue]:
+        return [v for n, v in self.options if n == name]
+
+    def set_flag(self, name: str, on: bool) -> None:
+        self.options = [(n, v) for n, v in self.options if n != name]
+        if on:
+            self.options.append((name, True))
+        self.mark_dirty()
+
+    def set_value(self, name: str, value: Optional[str]) -> None:
+        self.options = [(n, v) for n, v in self.options if n != name]
+        if value is not None and value != "":
+            self.options.append((name, value))
+        self.mark_dirty()
+
+    def set_repeatable(self, name: str, values: List[str]) -> None:
+        self.options = [(n, v) for n, v in self.options if n != name]
+        for v in values:
+            if v:
+                self.options.append((name, v))
+        self.mark_dirty()
+
+
+PassthroughLine = str
+Item = Union[AuthorizedKeyEntry, PassthroughLine]
+
+
+def _tokenize_options(s: str) -> List[OptionTuple]:
+    """Split a comma-separated option list, respecting quoted values."""
+    out: List[OptionTuple] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        # name
+        j = i
+        while j < n and s[j] not in (",", "="):
+            j += 1
+        name = s[i:j]
+        if j < n and s[j] == "=":
+            # quoted value
+            j += 1
+            if j < n and s[j] == '"':
+                j += 1
+                buf = []
+                while j < n:
+                    c = s[j]
+                    if c == "\\" and j + 1 < n:
+                        buf.append(s[j + 1])
+                        j += 2
+                        continue
+                    if c == '"':
+                        break
+                    buf.append(c)
+                    j += 1
+                value = "".join(buf)
+                # skip closing quote
+                if j < n and s[j] == '"':
+                    j += 1
+            else:
+                start = j
+                while j < n and s[j] != ",":
+                    j += 1
+                value = s[start:j]
+            out.append((name, value))
+        else:
+            out.append((name, True))
+        # consume optional comma + whitespace
+        while j < n and s[j] in (",", " ", "\t"):
+            j += 1
+        i = j
+    return out
+
+
+def _split_line(line: str) -> Optional[Tuple[str, str, str, str]]:
+    """Return (options_str, keytype, key_b64, comment) or None if not a key line."""
+    # Skip leading whitespace.
+    stripped = line.lstrip()
+    if not stripped:
+        return None
+    n = len(stripped)
+    # First, try: does the line start with a keytype? Then options_str = "".
+    first_space = stripped.find(" ")
+    if first_space == -1:
+        return None
+    first_token = stripped[:first_space]
+    if _is_keytype(first_token):
+        keytype = first_token
+        rest = stripped[first_space + 1 :].lstrip()
+        parts = rest.split(" ", 1)
+        if not parts or not parts[0]:
+            return None
+        key_b64 = parts[0]
+        comment = parts[1] if len(parts) > 1 else ""
+        return "", keytype, key_b64, comment
+
+    # Otherwise: scan forward to find the keytype, respecting quotes inside
+    # option values.
+    in_quote = False
+    j = 0
+    while j < n:
+        c = stripped[j]
+        if c == "\\" and in_quote and j + 1 < n:
+            j += 2
+            continue
+        if c == '"':
+            in_quote = not in_quote
+            j += 1
+            continue
+        if c == " " and not in_quote:
+            # Candidate boundary: token from current word-start to j may be
+            # the keytype. Look at the next non-space token.
+            k = j
+            while k < n and stripped[k] == " ":
+                k += 1
+            # find end of next token
+            m = k
+            while m < n and stripped[m] != " ":
+                m += 1
+            tok = stripped[k:m]
+            if _is_keytype(tok):
+                options_str = stripped[:j]
+                rest = stripped[k:]
+                parts = rest.split(" ", 2)
+                keytype = parts[0]
+                if len(parts) < 2:
+                    return None
+                key_b64 = parts[1]
+                comment = parts[2] if len(parts) > 2 else ""
+                return options_str, keytype, key_b64, comment
+            j = m
+            continue
+        j += 1
+    return None
+
+
+def compute_fingerprint(keytype: str, key_b64: str) -> str:
+    """Return the OpenSSH SHA256 fingerprint of a public key.
+
+    Output format matches ``ssh-keygen -lf``: ``SHA256:<base64-no-padding>``.
+    Returns an empty string if the key data is not decodable.
+    """
+    try:
+        raw = base64.b64decode(key_b64, validate=False)
+    except Exception:
+        return ""
+    digest = hashlib.sha256(raw).digest()
+    b64 = base64.b64encode(digest).decode("ascii").rstrip("=")
+    return f"SHA256:{b64}"
+
+
+def _classify_options(
+    tokens: List[OptionTuple],
+) -> Tuple[List[OptionTuple], List[str]]:
+    """Split tokens into (known, unknown_raw).
+
+    Unknown options are preserved verbatim as their original token text so
+    they can be re-emitted unchanged.
+    """
+    known: List[OptionTuple] = []
+    unknown: List[str] = []
+    for name, value in tokens:
+        if name in KNOWN_OPTIONS:
+            known.append((name, value))
+        else:
+            unknown.append(_serialize_option(name, value))
+    return known, unknown
+
+
+def _serialize_option(name: str, value: OptionValue) -> str:
+    if value is True:
+        return name
+    if value is False:
+        return name  # shouldn't happen
+    # Escape backslashes and double quotes.
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'{name}="{escaped}"'
+
+
+def parse_file(text: str) -> List[Item]:
+    """Parse an authorized_keys file. Returns a list of entries / passthrough lines."""
+    items: List[Item] = []
+    for raw in text.splitlines():
+        line = raw
+        stripped = line.strip()
+        if not stripped:
+            items.append(line)
+            continue
+
+        disabled = False
+        body = line
+        if stripped.startswith("#"):
+            # Could be a disabled key entry or just a comment line.
+            # Heuristic: try to parse the line with the leading '#' (and any
+            # whitespace after it) removed; if we recover a keytype, it's a
+            # disabled entry. Otherwise treat as passthrough.
+            after_hash = stripped[1:].lstrip()
+            candidate = after_hash
+            split = _split_line(candidate)
+            if split is None:
+                items.append(line)
+                continue
+            disabled = True
+            body = candidate
+
+        split = _split_line(body) if not disabled else _split_line(body)
+        if split is None:
+            items.append(line)
+            continue
+
+        options_str, keytype, key_b64, comment = split
+        if options_str:
+            tokens = _tokenize_options(options_str)
+            known, unknown = _classify_options(tokens)
+        else:
+            known, unknown = [], []
+
+        entry = AuthorizedKeyEntry(
+            raw_line=line,
+            disabled=disabled,
+            options=known,
+            unknown_options=unknown,
+            keytype=keytype,
+            key_b64=key_b64,
+            comment=comment,
+            fingerprint_sha256=compute_fingerprint(keytype, key_b64),
+            dirty=False,
+        )
+        items.append(entry)
+    # Preserve trailing newline behavior in serialize via marker.
+    if text.endswith("\n"):
+        items.append("")  # trailing blank to produce trailing newline
+    return items
+
+
+def _serialize_entry(entry: AuthorizedKeyEntry) -> str:
+    if not entry.dirty:
+        return entry.raw_line
+    # Options: known first (in stored order), then unknown verbatim.
+    opt_pieces: List[str] = []
+    for name, value in entry.options:
+        opt_pieces.append(_serialize_option(name, value))
+    opt_pieces.extend(entry.unknown_options)
+    line_parts: List[str] = []
+    if opt_pieces:
+        line_parts.append(",".join(opt_pieces))
+    line_parts.append(entry.keytype)
+    line_parts.append(entry.key_b64)
+    if entry.comment:
+        line_parts.append(entry.comment)
+    body = " ".join(line_parts)
+    if entry.disabled:
+        body = "# " + body
+    return body
+
+
+def serialize(items: List[Item]) -> str:
+    """Serialize parsed items back to text. Round-trips clean parses byte-identically."""
+    lines: List[str] = []
+    for item in items:
+        if isinstance(item, AuthorizedKeyEntry):
+            lines.append(_serialize_entry(item))
+        else:
+            lines.append(item)
+    if not lines:
+        return ""
+    # If the last item is a passthrough empty string, treat it as trailing newline marker.
+    if lines and lines[-1] == "":
+        return "\n".join(lines[:-1]) + "\n"
+    return "\n".join(lines)

--- a/sshpilot/authorized_keys_parser.py
+++ b/sshpilot/authorized_keys_parser.py
@@ -280,7 +280,9 @@ def _classify_options(
         if name in KNOWN_OPTIONS:
             known.append((name, value))
         else:
-            unknown.append(_serialize_option(name, value))
+            tok = _serialize_option(name, value)
+            if tok:
+                unknown.append(tok)
     return known, unknown
 
 
@@ -288,7 +290,9 @@ def _serialize_option(name: str, value: OptionValue) -> str:
     if value is True:
         return name
     if value is False:
-        return name  # shouldn't happen
+        # A False flag means the option is *not* set; emitting the bare name
+        # would silently re-enable it. Return empty and let the caller filter.
+        return ""
     # Escape backslashes and double quotes.
     escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
     return f'{name}="{escaped}"'
@@ -320,7 +324,7 @@ def parse_file(text: str) -> List[Item]:
             disabled = True
             body = candidate
 
-        split = _split_line(body) if not disabled else _split_line(body)
+        split = _split_line(body)
         if split is None:
             items.append(line)
             continue
@@ -356,7 +360,9 @@ def _serialize_entry(entry: AuthorizedKeyEntry) -> str:
     # Options: known first (in stored order), then unknown verbatim.
     opt_pieces: List[str] = []
     for name, value in entry.options:
-        opt_pieces.append(_serialize_option(name, value))
+        tok = _serialize_option(name, value)
+        if tok:
+            opt_pieces.append(tok)
     opt_pieces.extend(entry.unknown_options)
     line_parts: List[str] = []
     if opt_pieces:

--- a/sshpilot/authorized_keys_service.py
+++ b/sshpilot/authorized_keys_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import posixpath
+import shutil
 import time
 from concurrent.futures import Future
 from typing import List
@@ -84,43 +85,64 @@ class AuthorizedKeysService:
 
         def _do() -> None:
             sftp = self._manager._sftp
-            ssh = self._manager._client
-            if sftp is None or ssh is None:
+            if sftp is None:
                 raise RuntimeError("SFTP session is not connected")
             _, ssh_dir, ak_path = self._resolve_paths(sftp)
 
-            # Ensure ~/.ssh exists with correct mode. mkdir -p is harmless.
-            quoted = _shell_quote(ssh_dir)
-            _, stdout, stderr = ssh.exec_command(
-                f"mkdir -p {quoted} && chmod 700 {quoted}"
-            )
-            exit_status = stdout.channel.recv_exit_status()
-            if exit_status != 0:
-                err = stderr.read().decode("utf-8", errors="replace")
-                raise IOError(f"Failed to ensure {ssh_dir}: {err.strip()}")
+            # Ensure ~/.ssh exists with mode 0700. Use SFTP rather than
+            # ssh.exec_command so we don't depend on a POSIX login shell
+            # being available on the remote (Windows OpenSSH, restricted
+            # shells, etc).
+            try:
+                sftp.mkdir(ssh_dir, 0o700)
+            except IOError:
+                # Already exists — that's fine.
+                pass
+            try:
+                sftp.chmod(ssh_dir, 0o700)
+            except IOError as exc:
+                # Non-fatal: continue and let the write fail with a clearer
+                # error if the directory really isn't writable.
+                logger.debug("chmod 700 on %s failed: %s", ssh_dir, exc)
 
-            # Backup existing file if requested and it exists.
+            # Back up the existing file by *copying* (not renaming). A
+            # rename would leave no authorized_keys on the host between the
+            # rename and the subsequent atomic install — if the connection
+            # dies there, the user is locked out. A copy keeps the live
+            # file in place until the final posix_rename swaps it.
             if do_backup:
                 try:
                     sftp.stat(ak_path)
-                    backup_path = f"{ak_path}.bak-{int(time.time())}"
-                    # posix_rename overwrites; use it to keep the move atomic.
-                    sftp.posix_rename(ak_path, backup_path)
-                    logger.info("Backed up authorized_keys to %s", backup_path)
                 except IOError:
-                    # No existing file to back up.
-                    pass
+                    pass  # nothing to back up
+                else:
+                    backup_path = f"{ak_path}.bak-{int(time.time())}"
+                    with sftp.file(ak_path, "r") as src:
+                        existing = src.read()
+                    with sftp.file(backup_path, "w") as dst:
+                        dst.write(existing)
+                    try:
+                        sftp.chmod(backup_path, 0o600)
+                    except IOError as exc:
+                        logger.debug("chmod 600 on backup failed: %s", exc)
+                    logger.info("Backed up authorized_keys to %s", backup_path)
 
+            # Create tmp file, set restrictive mode *before* writing the
+            # content, so the keys are never world-readable on the remote.
             tmp_path = ak_path + ".sshpilot.tmp"
             payload = serialized.encode("utf-8")
-            with sftp.file(tmp_path, "w") as fh:
-                fh.write(payload)
+            fh = sftp.file(tmp_path, "w")
             try:
-                sftp.chmod(tmp_path, 0o600)
-            except IOError as exc:
-                logger.debug("chmod on tmp failed (continuing): %s", exc)
+                try:
+                    sftp.chmod(tmp_path, 0o600)
+                except IOError as exc:
+                    logger.debug("chmod on empty tmp failed: %s", exc)
+                fh.write(payload)
+            finally:
+                fh.close()
+            # posix_rename preserves the source's mode, so the final file
+            # is 0600 without a follow-up chmod.
             sftp.posix_rename(tmp_path, ak_path)
-            sftp.chmod(ak_path, 0o600)
 
         future = self._manager._submit(_do)
 
@@ -130,11 +152,6 @@ class AuthorizedKeysService:
 
         future.add_done_callback(_mark_backup_done)
         return future
-
-
-def _shell_quote(s: str) -> str:
-    """Minimal POSIX shell single-quoting for paths."""
-    return "'" + s.replace("'", "'\\''") + "'"
 
 
 class LocalAuthorizedKeysService:
@@ -174,20 +191,29 @@ class LocalAuthorizedKeysService:
             except OSError as exc:
                 logger.debug("chmod 700 on %s failed: %s", ssh_dir, exc)
 
+            # Backup is a copy, not a rename, so the live file stays in
+            # place if anything goes wrong before the final replace.
             if make_backup and not self._backup_done and os.path.exists(self.path):
                 backup = f"{self.path}.bak-{int(time.time())}"
-                os.replace(self.path, backup)
+                shutil.copy2(self.path, backup)
+                try:
+                    os.chmod(backup, 0o600)
+                except OSError as exc:
+                    logger.debug("chmod 600 on backup failed: %s", exc)
                 logger.info("Backed up %s -> %s", self.path, backup)
 
+            # Create the tmp file with restrictive perms *before* writing
+            # any content, so the keys are never world-readable.
             tmp = self.path + ".sshpilot.tmp"
-            payload = serialize(items).encode("utf-8")
-            with open(tmp, "wb") as fh:
-                fh.write(payload)
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
-                os.chmod(tmp, 0o600)
-            except OSError as exc:
-                logger.debug("chmod on tmp failed: %s", exc)
+                payload = serialize(items).encode("utf-8")
+                os.write(fd, payload)
+            finally:
+                os.close(fd)
             os.replace(tmp, self.path)
+            # Belt-and-braces: ensure final file is 0600 even if the
+            # platform's umask interfered with O_CREAT mode.
             os.chmod(self.path, 0o600)
             if make_backup and not self._backup_done:
                 self._backup_done = True

--- a/sshpilot/authorized_keys_service.py
+++ b/sshpilot/authorized_keys_service.py
@@ -1,0 +1,196 @@
+"""Async service for loading and saving a remote ``~/.ssh/authorized_keys`` file.
+
+Sits on top of :class:`AsyncSFTPManager` from ``file_manager_window`` and
+returns futures so callers can dispatch back to the GTK main thread via the
+existing pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+import time
+from concurrent.futures import Future
+from typing import List
+
+from .authorized_keys_parser import Item, parse_file, serialize
+
+logger = logging.getLogger(__name__)
+
+
+REMOTE_BASENAME = "authorized_keys"
+SSH_DIR_BASENAME = ".ssh"
+
+
+class AuthorizedKeysService:
+    """Load / save the remote authorized_keys file via an AsyncSFTPManager."""
+
+    def __init__(self, sftp_manager) -> None:
+        self._manager = sftp_manager
+        self._backup_done = False
+
+    # -- path helpers ---------------------------------------------------
+
+    def _resolve_paths(self, sftp) -> tuple[str, str, str]:
+        """Return (home, ssh_dir, authorized_keys_path) as remote POSIX paths."""
+        home = sftp.normalize(".")
+        ssh_dir = posixpath.join(home, SSH_DIR_BASENAME)
+        ak_path = posixpath.join(ssh_dir, REMOTE_BASENAME)
+        return home, ssh_dir, ak_path
+
+    # -- load -----------------------------------------------------------
+
+    def load(self) -> Future:
+        """Read and parse ``~/.ssh/authorized_keys``. Missing file -> empty list."""
+
+        def _do() -> List[Item]:
+            sftp = self._manager._sftp
+            if sftp is None:
+                raise RuntimeError("SFTP session is not connected")
+            _, ssh_dir, ak_path = self._resolve_paths(sftp)
+            try:
+                sftp.stat(ssh_dir)
+            except IOError:
+                logger.debug("Remote ~/.ssh does not exist yet")
+                return []
+            try:
+                with sftp.file(ak_path, "r") as fh:
+                    data = fh.read()
+            except IOError:
+                logger.debug("Remote authorized_keys does not exist yet")
+                return []
+            if isinstance(data, bytes):
+                text = data.decode("utf-8", errors="replace")
+            else:
+                text = data
+            return parse_file(text)
+
+        return self._manager._submit(_do)
+
+    # -- save -----------------------------------------------------------
+
+    def save(self, items: List[Item], *, make_backup: bool = True) -> Future:
+        """Atomically write items back. Returns a future resolving when done.
+
+        - Ensures ``~/.ssh`` exists with mode 0700.
+        - On first save in this session (when ``make_backup`` true), renames
+          the existing file to ``authorized_keys.bak-<unix-ts>``.
+        - Writes to a temp sibling, then ``posix_rename`` over the target.
+        - chmods the target to 0600.
+        """
+        serialized = serialize(items)
+        do_backup = make_backup and not self._backup_done
+
+        def _do() -> None:
+            sftp = self._manager._sftp
+            ssh = self._manager._client
+            if sftp is None or ssh is None:
+                raise RuntimeError("SFTP session is not connected")
+            _, ssh_dir, ak_path = self._resolve_paths(sftp)
+
+            # Ensure ~/.ssh exists with correct mode. mkdir -p is harmless.
+            quoted = _shell_quote(ssh_dir)
+            _, stdout, stderr = ssh.exec_command(
+                f"mkdir -p {quoted} && chmod 700 {quoted}"
+            )
+            exit_status = stdout.channel.recv_exit_status()
+            if exit_status != 0:
+                err = stderr.read().decode("utf-8", errors="replace")
+                raise IOError(f"Failed to ensure {ssh_dir}: {err.strip()}")
+
+            # Backup existing file if requested and it exists.
+            if do_backup:
+                try:
+                    sftp.stat(ak_path)
+                    backup_path = f"{ak_path}.bak-{int(time.time())}"
+                    # posix_rename overwrites; use it to keep the move atomic.
+                    sftp.posix_rename(ak_path, backup_path)
+                    logger.info("Backed up authorized_keys to %s", backup_path)
+                except IOError:
+                    # No existing file to back up.
+                    pass
+
+            tmp_path = ak_path + ".sshpilot.tmp"
+            payload = serialized.encode("utf-8")
+            with sftp.file(tmp_path, "w") as fh:
+                fh.write(payload)
+            try:
+                sftp.chmod(tmp_path, 0o600)
+            except IOError as exc:
+                logger.debug("chmod on tmp failed (continuing): %s", exc)
+            sftp.posix_rename(tmp_path, ak_path)
+            sftp.chmod(ak_path, 0o600)
+
+        future = self._manager._submit(_do)
+
+        def _mark_backup_done(fut: Future) -> None:
+            if fut.exception() is None and do_backup:
+                self._backup_done = True
+
+        future.add_done_callback(_mark_backup_done)
+        return future
+
+
+def _shell_quote(s: str) -> str:
+    """Minimal POSIX shell single-quoting for paths."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+class LocalAuthorizedKeysService:
+    """Same interface as :class:`AuthorizedKeysService`, but operates on a local file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = os.path.expanduser(path)
+        self._backup_done = False
+
+    def _resolved_future(self, value=None, exc=None) -> Future:
+        fut: Future = Future()
+        if exc is not None:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(value)
+        return fut
+
+    def load(self) -> Future:
+        try:
+            ssh_dir = os.path.dirname(self.path)
+            if not os.path.isdir(ssh_dir):
+                return self._resolved_future([])
+            if not os.path.exists(self.path):
+                return self._resolved_future([])
+            with open(self.path, "r", encoding="utf-8") as fh:
+                text = fh.read()
+            return self._resolved_future(parse_file(text))
+        except Exception as exc:
+            return self._resolved_future(exc=exc)
+
+    def save(self, items: List[Item], *, make_backup: bool = True) -> Future:
+        try:
+            ssh_dir = os.path.dirname(self.path)
+            os.makedirs(ssh_dir, exist_ok=True)
+            try:
+                os.chmod(ssh_dir, 0o700)
+            except OSError as exc:
+                logger.debug("chmod 700 on %s failed: %s", ssh_dir, exc)
+
+            if make_backup and not self._backup_done and os.path.exists(self.path):
+                backup = f"{self.path}.bak-{int(time.time())}"
+                os.replace(self.path, backup)
+                logger.info("Backed up %s -> %s", self.path, backup)
+
+            tmp = self.path + ".sshpilot.tmp"
+            payload = serialize(items).encode("utf-8")
+            with open(tmp, "wb") as fh:
+                fh.write(payload)
+            try:
+                os.chmod(tmp, 0o600)
+            except OSError as exc:
+                logger.debug("chmod on tmp failed: %s", exc)
+            os.replace(tmp, self.path)
+            os.chmod(self.path, 0o600)
+            if make_backup and not self._backup_done:
+                self._backup_done = True
+            return self._resolved_future(None)
+        except Exception as exc:
+            return self._resolved_future(exc=exc)

--- a/sshpilot/authorized_keys_window.py
+++ b/sshpilot/authorized_keys_window.py
@@ -88,6 +88,10 @@ class AuthorizedKeysWindow(Adw.Window):
         self._dirty = False
         self._loaded = False
         self._local_path: Optional[str] = None
+        self._closing = False
+        self._manager_signal_ids: List[int] = []
+        self._open_raw_editors: List[Gtk.Window] = []
+        self._teardown_when_idle = False
 
         if local_path is not None:
             self._local_path = os.path.expanduser(local_path)
@@ -119,8 +123,10 @@ class AuthorizedKeysWindow(Adw.Window):
             assert manager is not None  # constructor enforces this
             if getattr(manager, "_sftp", None) is None:
                 try:
-                    manager.connect("connected", lambda *_: GLib.idle_add(self._reload))
-                    manager.connect("connection-error", lambda _m, msg: GLib.idle_add(self._toast, _("Connection error: {}").format(msg)))
+                    sid = manager.connect("connected", self._on_manager_connected)
+                    self._manager_signal_ids.append(sid)
+                    sid = manager.connect("connection-error", self._on_manager_connection_error)
+                    self._manager_signal_ids.append(sid)
                 except Exception as exc:
                     logger.debug("Could not hook SFTP signals: %s", exc)
                 try:
@@ -222,6 +228,20 @@ class AuthorizedKeysWindow(Adw.Window):
         )
         controller.add_shortcut(save_shortcut)
         self.add_controller(controller)
+
+    # ------------------------------------------------------------------
+    # Manager signal handlers (kept named so we can disconnect them)
+    # ------------------------------------------------------------------
+
+    def _on_manager_connected(self, _manager) -> None:
+        if self._closing:
+            return
+        GLib.idle_add(self._reload)
+
+    def _on_manager_connection_error(self, _manager, msg) -> None:
+        if self._closing:
+            return
+        GLib.idle_add(self._toast, _("Connection error: {}").format(msg))
 
     # ------------------------------------------------------------------
     # Toast / status
@@ -478,6 +498,14 @@ class AuthorizedKeysWindow(Adw.Window):
         dlg.present()
 
     def _append_pubkey_from_path(self, public_path: str) -> None:
+        # KeyManager.discover_keys() derives public_path as private_path
+        # + ".pub" without checking existence — the .pub file may not be
+        # on disk if the user imported only the private key.
+        if not os.path.exists(public_path):
+            self._toast(
+                _("No public-key file found at {}. Generate it with `ssh-keygen -y -f <private>` and try again.").format(public_path)
+            )
+            return
         try:
             with open(public_path, "r", encoding="utf-8") as fh:
                 text = fh.read().strip()
@@ -520,7 +548,8 @@ class AuthorizedKeysWindow(Adw.Window):
                     file_name="authorized_keys",
                     is_local=True,
                 )
-                editor.connect("close-request", lambda *_: (self._reload(), False)[1])
+                editor.connect("close-request", self._on_raw_editor_close)
+                self._open_raw_editors.append(editor)
                 editor.present()
             except Exception as exc:
                 logger.error("Failed to open raw editor: %s", exc)
@@ -545,11 +574,26 @@ class AuthorizedKeysWindow(Adw.Window):
                 is_local=False,
                 sftp_manager=self._manager,
             )
-            editor.connect("close-request", lambda *_: (self._reload(), False)[1])
+            editor.connect("close-request", self._on_raw_editor_close)
+            self._open_raw_editors.append(editor)
             editor.present()
         except Exception as exc:
             logger.error("Failed to open raw editor: %s", exc)
             self._toast(_("Raw editor failed: {}").format(exc))
+
+    def _on_raw_editor_close(self, editor) -> bool:
+        try:
+            self._open_raw_editors.remove(editor)
+        except ValueError:
+            pass
+        if not self._closing:
+            # Refresh the list — the raw editor may have changed the file.
+            self._reload()
+        # If our own window was closed while a raw editor was still open,
+        # we deferred shutting down the SFTP manager. Do it now if this
+        # was the last child.
+        self._maybe_close_manager()
+        return False
 
     # ------------------------------------------------------------------
     # Close
@@ -583,13 +627,39 @@ class AuthorizedKeysWindow(Adw.Window):
         return True  # block default close while we ask
 
     def _teardown(self) -> None:
+        self._closing = True
+        # Disconnect any handlers we attached to the manager so it can't
+        # call back into a destroyed widget.
+        manager = self._manager
+        if manager is not None:
+            for sid in self._manager_signal_ids:
+                try:
+                    manager.disconnect(sid)
+                except Exception as exc:
+                    logger.debug("disconnect %s failed: %s", sid, exc)
+            self._manager_signal_ids.clear()
+
         if self._local_path is not None:
             return
+
+        # Defer closing the SFTP manager if a raw editor is still using it.
+        # The raw editor's close-request handler calls _maybe_close_manager
+        # which will close it once we're the last reference.
+        if self._open_raw_editors:
+            self._teardown_when_idle = True
+            return
+        self._close_manager_now()
+
+    def _close_manager_now(self) -> None:
         try:
             if self._manager is not None:
                 self._manager.close()
         except Exception as exc:
             logger.debug("Error closing SFTP manager: %s", exc)
+
+    def _maybe_close_manager(self) -> None:
+        if not self._open_raw_editors and self._teardown_when_idle:
+            self._close_manager_now()
 
 
 # ---------------------------------------------------------------------------
@@ -874,16 +944,19 @@ class AuthorizedKeyEntryDialog(Adw.Window):
 
         new_opts = [(n, v) for n, v in entry.options if n not in managed]
 
+        # Emit BOTH groups according to their switch state, not just the
+        # currently-visible one. The opt-out switches stay set to their
+        # last value when greyed, and silently dropping them on save would
+        # erase the user's no-* preferences across a restrict on/off toggle.
         restrict_on = self._restrict_switch.get_active()
         if restrict_on:
             new_opts.append(("restrict", True))
-            for name, sw in self._opt_in_switches.items():
-                if sw.get_active():
-                    new_opts.append((name, True))
-        else:
-            for name, sw in self._opt_out_switches.items():
-                if sw.get_active():
-                    new_opts.append((name, True))
+        for name, sw in self._opt_in_switches.items():
+            if sw.get_active():
+                new_opts.append((name, True))
+        for name, sw in self._opt_out_switches.items():
+            if sw.get_active():
+                new_opts.append((name, True))
 
         if self._cert_authority_switch.get_active():
             new_opts.append(("cert-authority", True))

--- a/sshpilot/authorized_keys_window.py
+++ b/sshpilot/authorized_keys_window.py
@@ -1,0 +1,955 @@
+"""GTK/Adwaita editor window for a remote ``~/.ssh/authorized_keys`` file."""
+
+from __future__ import annotations
+
+import logging
+import os
+import posixpath
+from gettext import gettext as _
+from typing import List, Optional
+
+from gi.repository import Adw, GLib, Gtk
+
+from .authorized_keys_parser import (
+    AuthorizedKeyEntry,
+    Item,
+    compute_fingerprint,
+    parse_file,
+)
+from .authorized_keys_service import AuthorizedKeysService, LocalAuthorizedKeysService
+
+logger = logging.getLogger(__name__)
+
+
+# Restriction-related flag options the user can toggle from the dialog.
+# Stored as (name, label) so we can render uniformly.
+_RESTRICT_OPT_INS = (
+    ("pty", _("Allow PTY")),
+    ("agent-forwarding", _("Allow agent forwarding")),
+    ("port-forwarding", _("Allow port forwarding")),
+    ("user-rc", _("Run ~/.ssh/rc")),
+    ("X11-forwarding", _("Allow X11 forwarding")),
+)
+
+_NO_OPT_OUTS = (
+    ("no-pty", _("Disable PTY")),
+    ("no-agent-forwarding", _("Disable agent forwarding")),
+    ("no-port-forwarding", _("Disable port forwarding")),
+    ("no-user-rc", _("Skip ~/.ssh/rc")),
+    ("no-X11-forwarding", _("Disable X11 forwarding")),
+)
+
+
+def _short(s: str, n: int = 28) -> str:
+    if len(s) <= n:
+        return s
+    return s[: n - 1] + "…"
+
+
+def _summary(entry: AuthorizedKeyEntry) -> str:
+    chips: List[str] = []
+    if entry.get_option("command"):
+        chips.append(_("forced cmd"))
+    src = entry.get_option("from")
+    if isinstance(src, str) and src:
+        chips.append(f"from={_short(src, 24)}")
+    if entry.get_option("restrict") is True:
+        chips.append("restrict")
+    if entry.get_option("cert-authority") is True:
+        chips.append("CA")
+    if entry.get_option("expiry-time"):
+        chips.append("expiry")
+    if entry.get_options("permitopen"):
+        chips.append("permitopen")
+    if entry.unknown_options:
+        chips.append(_("+unknown"))
+    return " · ".join(chips) or _("no options")
+
+
+class AuthorizedKeysWindow(Adw.Window):
+    """List + edit ``~/.ssh/authorized_keys`` over SFTP."""
+
+    def __init__(
+        self,
+        parent,
+        connection=None,
+        sftp_manager=None,
+        connection_manager=None,
+        key_manager=None,
+        local_path: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self._parent = parent
+        self._connection = connection
+        self._manager = sftp_manager
+        self._connection_manager = connection_manager
+        self._key_manager = key_manager
+        self._items: List[Item] = []
+        self._dirty = False
+        self._loaded = False
+        self._local_path: Optional[str] = None
+
+        if local_path is not None:
+            self._local_path = os.path.expanduser(local_path)
+            self._service = LocalAuthorizedKeysService(self._local_path)
+            title = _("Authorized keys — this computer")
+        else:
+            if sftp_manager is None or connection is None:
+                raise ValueError("Either local_path or (connection + sftp_manager) is required")
+            self._service = AuthorizedKeysService(sftp_manager)
+            user = getattr(connection, "username", "") or ""
+            host = (
+                getattr(connection, "hostname", None)
+                or getattr(connection, "host", None)
+                or getattr(connection, "nickname", "")
+            )
+            title = _("Authorized keys — {who}").format(who=f"{user}@{host}" if user else host)
+
+        self.set_title(title)
+        self.set_transient_for(parent)
+        self.set_modal(False)
+        self.set_default_size(720, 560)
+
+        self._build_ui(title)
+
+        if self._local_path is not None:
+            GLib.idle_add(self._reload)
+        else:
+            manager = self._manager
+            assert manager is not None  # constructor enforces this
+            if getattr(manager, "_sftp", None) is None:
+                try:
+                    manager.connect("connected", lambda *_: GLib.idle_add(self._reload))
+                    manager.connect("connection-error", lambda _m, msg: GLib.idle_add(self._toast, _("Connection error: {}").format(msg)))
+                except Exception as exc:
+                    logger.debug("Could not hook SFTP signals: %s", exc)
+                try:
+                    manager.connect_to_server()
+                except Exception as exc:
+                    logger.error("Failed to start SFTP connection: %s", exc)
+            else:
+                GLib.idle_add(self._reload)
+
+        self.connect("close-request", self._on_close_request)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self, title: str) -> None:
+        self._toast_overlay = Adw.ToastOverlay()
+        self.set_content(self._toast_overlay)
+
+        tv = Adw.ToolbarView()
+        self._toast_overlay.set_child(tv)
+
+        hb = Adw.HeaderBar()
+        hb.set_title_widget(Gtk.Label(label=title))
+        tv.add_top_bar(hb)
+
+        # Add menu button
+        self._add_button = Gtk.MenuButton()
+        self._add_button.set_icon_name("list-add-symbolic")
+        self._add_button.set_tooltip_text(_("Add key"))
+        popover = Gtk.PopoverMenu.new_from_model(self._build_add_menu_model())
+        self._add_button.set_popover(popover)
+        hb.pack_start(self._add_button)
+
+        self._reload_button = Gtk.Button.new_from_icon_name("view-refresh-symbolic")
+        self._reload_button.set_tooltip_text(_("Reload from server"))
+        self._reload_button.connect("clicked", lambda *_: self._reload())
+        hb.pack_start(self._reload_button)
+
+        self._raw_button = Gtk.Button.new_from_icon_name("text-x-generic-symbolic")
+        self._raw_button.set_tooltip_text(_("Open raw editor…"))
+        self._raw_button.connect("clicked", self._on_raw_edit_clicked)
+        hb.pack_start(self._raw_button)
+
+        self._save_button = Gtk.Button(label=_("Save"))
+        self._save_button.add_css_class("suggested-action")
+        self._save_button.set_sensitive(False)
+        self._save_button.connect("clicked", self._on_save_clicked)
+        hb.pack_end(self._save_button)
+
+        # Body
+        body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        tv.set_content(body)
+
+        self._status_label = Gtk.Label(label=_("Loading…"))
+        self._status_label.set_margin_top(8)
+        self._status_label.set_margin_bottom(8)
+        body.append(self._status_label)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_vexpand(True)
+        scrolled.set_hexpand(True)
+        body.append(scrolled)
+
+        self._list_box = Gtk.ListBox()
+        self._list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._list_box.add_css_class("boxed-list")
+        self._list_box.set_margin_top(12)
+        self._list_box.set_margin_bottom(12)
+        self._list_box.set_margin_start(12)
+        self._list_box.set_margin_end(12)
+        scrolled.set_child(self._list_box)
+
+        # Add an action set on the window for Ctrl+S.
+        self._install_shortcuts()
+
+    def _build_add_menu_model(self):
+        from gi.repository import Gio
+        menu = Gio.Menu()
+        menu.append(_("Add from local keys…"), "ak.add-local")
+        menu.append(_("Paste public key…"), "ak.add-paste")
+
+        group = Gio.SimpleActionGroup()
+        action_local = Gio.SimpleAction.new("add-local", None)
+        action_local.connect("activate", lambda *_: self._on_add_from_local())
+        group.add_action(action_local)
+        action_paste = Gio.SimpleAction.new("add-paste", None)
+        action_paste.connect("activate", lambda *_: self._on_add_from_paste())
+        group.add_action(action_paste)
+        self.insert_action_group("ak", group)
+        return menu
+
+    def _install_shortcuts(self) -> None:
+        controller = Gtk.ShortcutController()
+        controller.set_scope(Gtk.ShortcutScope.LOCAL)
+        save_shortcut = Gtk.Shortcut.new(
+            Gtk.ShortcutTrigger.parse_string("<Control>s"),
+            Gtk.CallbackAction.new(lambda *_: (self._on_save_clicked(None), True)[1]),
+        )
+        controller.add_shortcut(save_shortcut)
+        self.add_controller(controller)
+
+    # ------------------------------------------------------------------
+    # Toast / status
+    # ------------------------------------------------------------------
+
+    def _toast(self, message: str) -> bool:
+        try:
+            self._toast_overlay.add_toast(Adw.Toast.new(message))
+        except Exception as exc:
+            logger.debug("toast failed: %s", exc)
+        return False
+
+    def _set_status(self, text: str) -> None:
+        self._status_label.set_text(text)
+
+    def _set_dirty(self, dirty: bool) -> None:
+        self._dirty = dirty
+        self._save_button.set_sensitive(dirty)
+
+    # ------------------------------------------------------------------
+    # Load / save
+    # ------------------------------------------------------------------
+
+    def _reload(self) -> bool:
+        self._set_status(_("Loading…"))
+        future = self._service.load()
+
+        def _done(fut):
+            try:
+                items = fut.result()
+            except Exception as exc:
+                logger.error("Failed to load authorized_keys: %s", exc)
+                GLib.idle_add(self._toast, _("Failed to load: {}").format(exc))
+                GLib.idle_add(self._set_status, _("Error loading authorized_keys"))
+                return
+            GLib.idle_add(self._apply_loaded, items)
+
+        future.add_done_callback(_done)
+        return False
+
+    def _apply_loaded(self, items: List[Item]) -> bool:
+        self._items = items
+        self._loaded = True
+        self._set_dirty(False)
+        self._refresh_list()
+        entries = [it for it in items if isinstance(it, AuthorizedKeyEntry)]
+        self._set_status(
+            _("Loaded {n} entries").format(n=len(entries))
+            if entries
+            else _("No keys yet — use “Add key” to install one.")
+        )
+        return False
+
+    def _on_save_clicked(self, _btn) -> None:
+        if not self._dirty:
+            return
+        # Recompute fingerprints / mark dirty entries before serializing.
+        for it in self._items:
+            if isinstance(it, AuthorizedKeyEntry) and it.dirty:
+                it.fingerprint_sha256 = compute_fingerprint(it.keytype, it.key_b64)
+        self._set_status(_("Saving…"))
+        self._save_button.set_sensitive(False)
+        future = self._service.save(self._items, make_backup=True)
+
+        def _done(fut):
+            try:
+                fut.result()
+            except Exception as exc:
+                logger.error("Failed to save authorized_keys: %s", exc)
+                GLib.idle_add(self._toast, _("Save failed: {}").format(exc))
+                GLib.idle_add(self._save_button.set_sensitive, True)
+                GLib.idle_add(self._set_status, _("Save failed"))
+                return
+            GLib.idle_add(self._after_save)
+
+        future.add_done_callback(_done)
+
+    def _after_save(self) -> bool:
+        self._toast(_("Saved"))
+        self._set_dirty(False)
+        # Refresh from disk so we display exactly what was written.
+        self._reload()
+        return False
+
+    # ------------------------------------------------------------------
+    # List rendering
+    # ------------------------------------------------------------------
+
+    def _refresh_list(self) -> None:
+        child = self._list_box.get_first_child()
+        while child is not None:
+            nxt = child.get_next_sibling()
+            self._list_box.remove(child)
+            child = nxt
+
+        for idx, item in enumerate(self._items):
+            if isinstance(item, AuthorizedKeyEntry):
+                self._list_box.append(self._build_row(idx, item))
+
+    def _build_row(self, _index: int, entry: AuthorizedKeyEntry) -> Gtk.Widget:
+        row = Adw.ActionRow()
+        title = entry.comment or _("(no comment)")
+        row.set_title(GLib.markup_escape_text(title))
+        fp = entry.fingerprint_sha256 or compute_fingerprint(entry.keytype, entry.key_b64)
+        subtitle_parts = [entry.keytype, fp, _summary(entry)]
+        row.set_subtitle(" · ".join(p for p in subtitle_parts if p))
+
+        switch = Gtk.Switch()
+        switch.set_valign(Gtk.Align.CENTER)
+        switch.set_active(not entry.disabled)
+        switch.connect("notify::active", self._on_enable_toggled, entry)
+        row.add_prefix(switch)
+
+        edit_btn = Gtk.Button.new_from_icon_name("document-edit-symbolic")
+        edit_btn.set_tooltip_text(_("Edit entry"))
+        edit_btn.add_css_class("flat")
+        edit_btn.set_valign(Gtk.Align.CENTER)
+        edit_btn.connect("clicked", self._on_edit_clicked, entry)
+        row.add_suffix(edit_btn)
+
+        del_btn = Gtk.Button.new_from_icon_name("user-trash-symbolic")
+        del_btn.set_tooltip_text(_("Delete entry"))
+        del_btn.add_css_class("flat")
+        del_btn.set_valign(Gtk.Align.CENTER)
+        del_btn.connect("clicked", self._on_delete_clicked, entry)
+        row.add_suffix(del_btn)
+
+        return row
+
+    # ------------------------------------------------------------------
+    # Row callbacks
+    # ------------------------------------------------------------------
+
+    def _on_enable_toggled(self, switch, _pspec, entry: AuthorizedKeyEntry) -> None:
+        new_disabled = not switch.get_active()
+        if new_disabled == entry.disabled:
+            return
+        entry.disabled = new_disabled
+        entry.mark_dirty()
+        self._set_dirty(True)
+
+    def _on_delete_clicked(self, _btn, entry: AuthorizedKeyEntry) -> None:
+        dlg = Adw.MessageDialog(
+            transient_for=self,
+            modal=True,
+            heading=_("Delete this key?"),
+            body=entry.comment or entry.fingerprint_sha256 or _("This authorized_keys entry will be removed."),
+        )
+        dlg.add_response("cancel", _("Cancel"))
+        dlg.add_response("delete", _("Delete"))
+        dlg.set_response_appearance("delete", Adw.ResponseAppearance.DESTRUCTIVE)
+        dlg.set_default_response("cancel")
+        dlg.set_close_response("cancel")
+
+        def _on_response(_d, resp):
+            if resp == "delete":
+                try:
+                    self._items.remove(entry)
+                except ValueError:
+                    return
+                self._set_dirty(True)
+                self._refresh_list()
+
+        dlg.connect("response", _on_response)
+        dlg.present()
+
+    def _on_edit_clicked(self, _btn, entry: AuthorizedKeyEntry) -> None:
+        AuthorizedKeyEntryDialog(self, entry, on_saved=self._on_entry_edited).present()
+
+    def _on_entry_edited(self, _entry: AuthorizedKeyEntry) -> None:
+        self._set_dirty(True)
+        self._refresh_list()
+
+    # ------------------------------------------------------------------
+    # Add key
+    # ------------------------------------------------------------------
+
+    def _on_add_from_local(self) -> None:
+        if self._key_manager is None:
+            try:
+                from .key_manager import KeyManager
+                self._key_manager = KeyManager(self._connection_manager)
+            except Exception as exc:
+                self._toast(_("Cannot list local keys: {}").format(exc))
+                return
+        try:
+            keys = self._key_manager.discover_keys() or []
+        except Exception as exc:
+            self._toast(_("Failed to read local keys: {}").format(exc))
+            return
+        if not keys:
+            self._toast(_("No local SSH keys found in ~/.ssh"))
+            return
+
+        names = [os.path.basename(k.private_path) for k in keys]
+        dlg = Adw.MessageDialog(
+            transient_for=self,
+            modal=True,
+            heading=_("Add public key"),
+            body=_("Pick a local key whose public counterpart to install."),
+        )
+        dropdown = Gtk.DropDown.new_from_strings(names)
+        dropdown.set_selected(0)
+        dlg.set_extra_child(dropdown)
+        dlg.add_response("cancel", _("Cancel"))
+        dlg.add_response("add", _("Add"))
+        dlg.set_response_appearance("add", Adw.ResponseAppearance.SUGGESTED)
+        dlg.set_default_response("add")
+        dlg.set_close_response("cancel")
+
+        def _on_response(_d, resp):
+            if resp != "add":
+                return
+            idx = dropdown.get_selected()
+            if idx < 0 or idx >= len(keys):
+                return
+            self._append_pubkey_from_path(keys[idx].public_path)
+
+        dlg.connect("response", _on_response)
+        dlg.present()
+
+    def _on_add_from_paste(self) -> None:
+        dlg = Adw.MessageDialog(
+            transient_for=self,
+            modal=True,
+            heading=_("Paste public key"),
+            body=_("Paste a single OpenSSH public key line."),
+        )
+        text_view = Gtk.TextView()
+        text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        text_view.set_size_request(480, 100)
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_child(text_view)
+        scrolled.set_size_request(480, 100)
+        dlg.set_extra_child(scrolled)
+
+        dlg.add_response("cancel", _("Cancel"))
+        dlg.add_response("add", _("Add"))
+        dlg.set_response_appearance("add", Adw.ResponseAppearance.SUGGESTED)
+        dlg.set_default_response("add")
+        dlg.set_close_response("cancel")
+
+        def _on_response(_d, resp):
+            if resp != "add":
+                return
+            buf = text_view.get_buffer()
+            start, end = buf.get_bounds()
+            text = buf.get_text(start, end, False).strip()
+            if not text:
+                return
+            self._append_pubkey_text(text)
+
+        dlg.connect("response", _on_response)
+        dlg.present()
+
+    def _append_pubkey_from_path(self, public_path: str) -> None:
+        try:
+            with open(public_path, "r", encoding="utf-8") as fh:
+                text = fh.read().strip()
+        except OSError as exc:
+            self._toast(_("Could not read {}: {}").format(public_path, exc))
+            return
+        self._append_pubkey_text(text)
+
+    def _append_pubkey_text(self, text: str) -> None:
+        parsed = parse_file(text + "\n")
+        added = 0
+        for it in parsed:
+            if isinstance(it, AuthorizedKeyEntry):
+                it.mark_dirty()
+                self._items.append(it)
+                added += 1
+        if added == 0:
+            self._toast(_("Could not parse a public key from input"))
+            return
+        self._set_dirty(True)
+        self._refresh_list()
+        self._toast(_("Added {n} key").format(n=added))
+
+    # ------------------------------------------------------------------
+    # Raw edit fallback
+    # ------------------------------------------------------------------
+
+    def _on_raw_edit_clicked(self, _btn) -> None:
+        try:
+            from .text_editor import RemoteFileEditorWindow
+        except Exception as exc:
+            self._toast(_("Raw editor unavailable: {}").format(exc))
+            return
+
+        if self._local_path is not None:
+            try:
+                editor = RemoteFileEditorWindow(
+                    parent=self,
+                    file_path=self._local_path,
+                    file_name="authorized_keys",
+                    is_local=True,
+                )
+                editor.connect("close-request", lambda *_: (self._reload(), False)[1])
+                editor.present()
+            except Exception as exc:
+                logger.error("Failed to open raw editor: %s", exc)
+                self._toast(_("Raw editor failed: {}").format(exc))
+            return
+
+        sftp = getattr(self._manager, "_sftp", None)
+        if sftp is None:
+            self._toast(_("Not connected yet — please wait."))
+            return
+        try:
+            home = sftp.normalize(".")
+        except Exception as exc:
+            self._toast(_("Could not resolve home dir: {}").format(exc))
+            return
+        ak_path = posixpath.join(home, ".ssh", "authorized_keys")
+        try:
+            editor = RemoteFileEditorWindow(
+                parent=self,
+                file_path=ak_path,
+                file_name="authorized_keys",
+                is_local=False,
+                sftp_manager=self._manager,
+            )
+            editor.connect("close-request", lambda *_: (self._reload(), False)[1])
+            editor.present()
+        except Exception as exc:
+            logger.error("Failed to open raw editor: %s", exc)
+            self._toast(_("Raw editor failed: {}").format(exc))
+
+    # ------------------------------------------------------------------
+    # Close
+    # ------------------------------------------------------------------
+
+    def _on_close_request(self, _window) -> bool:
+        if not self._dirty:
+            self._teardown()
+            return False
+
+        dlg = Adw.MessageDialog(
+            transient_for=self,
+            modal=True,
+            heading=_("Unsaved changes"),
+            body=_("Discard changes to authorized_keys?"),
+        )
+        dlg.add_response("cancel", _("Cancel"))
+        dlg.add_response("discard", _("Discard"))
+        dlg.set_response_appearance("discard", Adw.ResponseAppearance.DESTRUCTIVE)
+        dlg.set_default_response("cancel")
+        dlg.set_close_response("cancel")
+
+        def _on_response(_d, resp):
+            if resp == "discard":
+                self._dirty = False
+                self._teardown()
+                self.destroy()
+
+        dlg.connect("response", _on_response)
+        dlg.present()
+        return True  # block default close while we ask
+
+    def _teardown(self) -> None:
+        if self._local_path is not None:
+            return
+        try:
+            if self._manager is not None:
+                self._manager.close()
+        except Exception as exc:
+            logger.debug("Error closing SFTP manager: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Per-entry edit dialog
+# ---------------------------------------------------------------------------
+
+
+class AuthorizedKeyEntryDialog(Adw.Window):
+    """Modal dialog for editing one AuthorizedKeyEntry's options."""
+
+    def __init__(self, parent: AuthorizedKeysWindow, entry: AuthorizedKeyEntry, *, on_saved):
+        super().__init__()
+        self._entry = entry
+        self._on_saved = on_saved
+        self.set_transient_for(parent)
+        self.set_modal(True)
+        self.set_default_size(640, 720)
+        self.set_title(_("Edit authorized_keys entry"))
+
+        tv = Adw.ToolbarView()
+        self.set_content(tv)
+        hb = Adw.HeaderBar()
+        hb.set_show_end_title_buttons(False)
+        hb.set_show_start_title_buttons(False)
+        tv.add_top_bar(hb)
+
+        cancel = Gtk.Button(label=_("Cancel"))
+        cancel.connect("clicked", lambda *_: self.close())
+        hb.pack_start(cancel)
+        save = Gtk.Button(label=_("Apply"))
+        save.add_css_class("suggested-action")
+        save.connect("clicked", self._on_save_clicked)
+        hb.pack_end(save)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_vexpand(True)
+        tv.set_content(scroller)
+
+        # Esc closes
+        key_ctrl = Gtk.EventControllerKey()
+
+        def _on_key(_c, keyval, _code, _state):
+            from gi.repository import Gdk
+            if keyval == Gdk.KEY_Escape:
+                self.close()
+                return True
+            return False
+
+        key_ctrl.connect("key-pressed", _on_key)
+        self.add_controller(key_ctrl)
+
+        body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        body.set_margin_top(16)
+        body.set_margin_bottom(16)
+        body.set_margin_start(16)
+        body.set_margin_end(16)
+        scroller.set_child(body)
+
+        # Identity / comment
+        info = Adw.PreferencesGroup()
+        info.set_title(_("Key"))
+        info_row = Adw.ActionRow()
+        info_row.set_title(entry.keytype)
+        info_row.set_subtitle(entry.fingerprint_sha256 or compute_fingerprint(entry.keytype, entry.key_b64))
+        info.add(info_row)
+        self._comment_row = Adw.EntryRow()
+        self._comment_row.set_title(_("Comment"))
+        self._comment_row.set_text(entry.comment or "")
+        info.add(self._comment_row)
+        body.append(info)
+
+        # Restrictions group
+        restrict_group = Adw.PreferencesGroup()
+        restrict_group.set_title(_("Restrictions"))
+        restrict_group.set_description(
+            _("If ‘restrict’ is on, all forwardings/PTY/user-rc are denied unless re-enabled here.")
+        )
+        self._restrict_switch = Adw.SwitchRow()
+        self._restrict_switch.set_title(_("Apply ‘restrict’"))
+        self._restrict_switch.set_active(entry.get_option("restrict") is True)
+        self._restrict_switch.connect("notify::active", self._on_restrict_toggled)
+        restrict_group.add(self._restrict_switch)
+
+        self._cert_authority_switch = Adw.SwitchRow()
+        self._cert_authority_switch.set_title(_("cert-authority"))
+        self._cert_authority_switch.set_subtitle(_("Treat this entry as a CA that signs user certificates."))
+        self._cert_authority_switch.set_active(entry.get_option("cert-authority") is True)
+        restrict_group.add(self._cert_authority_switch)
+
+        # opt-in switches (only meaningful when restrict is on)
+        self._opt_in_switches = {}
+        for name, label in _RESTRICT_OPT_INS:
+            sw = Adw.SwitchRow()
+            sw.set_title(label)
+            sw.set_active(entry.get_option(name) is True)
+            restrict_group.add(sw)
+            self._opt_in_switches[name] = sw
+
+        # opt-out switches (no-*) for non-restrict mode
+        self._opt_out_switches = {}
+        for name, label in _NO_OPT_OUTS:
+            sw = Adw.SwitchRow()
+            sw.set_title(label)
+            active = entry.get_option(name) is True
+            # Treat the case-variant duplicates uniformly
+            if not active and name.lower() != name:
+                active = entry.get_option(name.lower()) is True
+            sw.set_active(active)
+            restrict_group.add(sw)
+            self._opt_out_switches[name] = sw
+
+        body.append(restrict_group)
+
+        # Source / identity
+        src_group = Adw.PreferencesGroup()
+        src_group.set_title(_("Source / identity"))
+        self._from_row = Adw.EntryRow()
+        self._from_row.set_title(_("from= (pattern list, e.g. 10.0.0.0/8,!10.0.0.5)"))
+        v = entry.get_option("from")
+        self._from_row.set_text(v if isinstance(v, str) else "")
+        src_group.add(self._from_row)
+
+        self._principals_row = Adw.EntryRow()
+        self._principals_row.set_title(_("principals= (comma-separated)"))
+        v = entry.get_option("principals")
+        self._principals_row.set_text(v if isinstance(v, str) else "")
+        src_group.add(self._principals_row)
+
+        body.append(src_group)
+
+        # Command / env / expiry
+        cmd_group = Adw.PreferencesGroup()
+        cmd_group.set_title(_("Command, environment, expiry"))
+
+        cmd_label = Gtk.Label(label=_("Forced command (command=)"), xalign=0)
+        cmd_label.set_margin_top(4)
+        cmd_group.add(cmd_label)
+        self._command_buf = Gtk.TextBuffer()
+        v = entry.get_option("command")
+        self._command_buf.set_text(v if isinstance(v, str) else "", -1)
+        cmd_view = Gtk.TextView(buffer=self._command_buf)
+        cmd_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        cmd_view.set_monospace(True)
+        cmd_view.add_css_class("card")
+        cmd_view.set_size_request(-1, 80)
+        cmd_group.add(cmd_view)
+
+        self._expiry_row = Adw.EntryRow()
+        self._expiry_row.set_title(_("expiry-time (e.g. YYYYMMDDHHMM or 20260101)"))
+        v = entry.get_option("expiry-time")
+        self._expiry_row.set_text(v if isinstance(v, str) else "")
+        cmd_group.add(self._expiry_row)
+
+        env_label = Gtk.Label(
+            label=_("environment= entries (NAME=value, one per line). Often ignored unless sshd's PermitUserEnvironment is on."),
+            xalign=0,
+            wrap=True,
+        )
+        env_label.set_margin_top(4)
+        cmd_group.add(env_label)
+        self._env_buf = Gtk.TextBuffer()
+        existing_envs = [v for v in entry.get_options("environment") if isinstance(v, str)]
+        self._env_buf.set_text("\n".join(existing_envs), -1)
+        env_view = Gtk.TextView(buffer=self._env_buf)
+        env_view.set_monospace(True)
+        env_view.add_css_class("card")
+        env_view.set_size_request(-1, 80)
+        cmd_group.add(env_view)
+
+        body.append(cmd_group)
+
+        # Tunneling
+        tun_group = Adw.PreferencesGroup()
+        tun_group.set_title(_("Tunneling"))
+
+        po_label = Gtk.Label(label=_("permitopen= entries (host:port, one per line)"), xalign=0)
+        tun_group.add(po_label)
+        self._permitopen_buf = Gtk.TextBuffer()
+        self._permitopen_buf.set_text(
+            "\n".join(v for v in entry.get_options("permitopen") if isinstance(v, str)), -1
+        )
+        po_view = Gtk.TextView(buffer=self._permitopen_buf)
+        po_view.set_monospace(True)
+        po_view.add_css_class("card")
+        po_view.set_size_request(-1, 60)
+        tun_group.add(po_view)
+
+        pl_label = Gtk.Label(label=_("permitlisten= entries (port or host:port, one per line)"), xalign=0)
+        tun_group.add(pl_label)
+        self._permitlisten_buf = Gtk.TextBuffer()
+        self._permitlisten_buf.set_text(
+            "\n".join(v for v in entry.get_options("permitlisten") if isinstance(v, str)), -1
+        )
+        pl_view = Gtk.TextView(buffer=self._permitlisten_buf)
+        pl_view.set_monospace(True)
+        pl_view.add_css_class("card")
+        pl_view.set_size_request(-1, 60)
+        tun_group.add(pl_view)
+
+        self._tunnel_row = Adw.EntryRow()
+        self._tunnel_row.set_title(_("tunnel= (device number)"))
+        v = entry.get_option("tunnel")
+        self._tunnel_row.set_text(v if isinstance(v, str) else "")
+        tun_group.add(self._tunnel_row)
+
+        body.append(tun_group)
+
+        # FIDO group, only when keytype indicates sk-*
+        if entry.keytype.startswith("sk-"):
+            fido_group = Adw.PreferencesGroup()
+            fido_group.set_title(_("FIDO security key"))
+            self._verify_required = Adw.SwitchRow()
+            self._verify_required.set_title(_("verify-required"))
+            self._verify_required.set_subtitle(_("Require PIN/biometric verification on the security key."))
+            self._verify_required.set_active(entry.get_option("verify-required") is True)
+            fido_group.add(self._verify_required)
+            self._no_touch_required = Adw.SwitchRow()
+            self._no_touch_required.set_title(_("no-touch-required"))
+            self._no_touch_required.set_subtitle(_("Skip the touch step (less secure)."))
+            self._no_touch_required.set_active(entry.get_option("no-touch-required") is True)
+            fido_group.add(self._no_touch_required)
+            body.append(fido_group)
+        else:
+            self._verify_required = None
+            self._no_touch_required = None
+
+        # Unknown options (preserved)
+        if entry.unknown_options:
+            unk_group = Adw.PreferencesGroup()
+            unk_group.set_title(_("Preserved unknown options"))
+            unk_group.set_description(_("These options are not modelled by this editor but will be re-emitted verbatim."))
+            self._unknown_check_rows = []
+            for token in entry.unknown_options:
+                row = Adw.ActionRow()
+                row.set_title(GLib.markup_escape_text(token))
+                keep = Gtk.CheckButton()
+                keep.set_active(True)
+                keep.set_valign(Gtk.Align.CENTER)
+                row.add_suffix(keep)
+                unk_group.add(row)
+                self._unknown_check_rows.append((token, keep))
+            body.append(unk_group)
+        else:
+            self._unknown_check_rows = []
+
+        self._on_restrict_toggled(self._restrict_switch, None)
+
+    def _on_restrict_toggled(self, switch, _pspec) -> None:
+        restrict_on = switch.get_active()
+        for sw in self._opt_in_switches.values():
+            sw.set_sensitive(restrict_on)
+        for sw in self._opt_out_switches.values():
+            sw.set_sensitive(not restrict_on)
+
+    def _on_save_clicked(self, _btn) -> None:
+        entry = self._entry
+
+        new_comment = (self._comment_row.get_text() or "").strip()
+        if new_comment != entry.comment:
+            entry.comment = new_comment
+            entry.mark_dirty()
+
+        # Drop everything we manage, then re-apply from form state.
+        managed = {
+            "command",
+            "expiry-time",
+            "from",
+            "principals",
+            "tunnel",
+            "restrict",
+            "cert-authority",
+            "verify-required",
+            "no-touch-required",
+            "environment",
+            "permitopen",
+            "permitlisten",
+        }
+        for name, _label in _RESTRICT_OPT_INS:
+            managed.add(name)
+        for name, _label in _NO_OPT_OUTS:
+            managed.add(name)
+
+        new_opts = [(n, v) for n, v in entry.options if n not in managed]
+
+        restrict_on = self._restrict_switch.get_active()
+        if restrict_on:
+            new_opts.append(("restrict", True))
+            for name, sw in self._opt_in_switches.items():
+                if sw.get_active():
+                    new_opts.append((name, True))
+        else:
+            for name, sw in self._opt_out_switches.items():
+                if sw.get_active():
+                    new_opts.append((name, True))
+
+        if self._cert_authority_switch.get_active():
+            new_opts.append(("cert-authority", True))
+
+        src = (self._from_row.get_text() or "").strip()
+        if src:
+            new_opts.append(("from", src))
+        principals = (self._principals_row.get_text() or "").strip()
+        if principals:
+            new_opts.append(("principals", principals))
+
+        cmd_text = self._command_buf.get_text(
+            self._command_buf.get_start_iter(), self._command_buf.get_end_iter(), False
+        ).strip()
+        if cmd_text:
+            new_opts.append(("command", cmd_text))
+
+        expiry = (self._expiry_row.get_text() or "").strip()
+        if expiry:
+            new_opts.append(("expiry-time", expiry))
+
+        env_text = self._env_buf.get_text(
+            self._env_buf.get_start_iter(), self._env_buf.get_end_iter(), False
+        )
+        for line in env_text.splitlines():
+            v = line.strip()
+            if v:
+                new_opts.append(("environment", v))
+
+        po_text = self._permitopen_buf.get_text(
+            self._permitopen_buf.get_start_iter(), self._permitopen_buf.get_end_iter(), False
+        )
+        for line in po_text.splitlines():
+            v = line.strip()
+            if v:
+                new_opts.append(("permitopen", v))
+
+        pl_text = self._permitlisten_buf.get_text(
+            self._permitlisten_buf.get_start_iter(), self._permitlisten_buf.get_end_iter(), False
+        )
+        for line in pl_text.splitlines():
+            v = line.strip()
+            if v:
+                new_opts.append(("permitlisten", v))
+
+        tun = (self._tunnel_row.get_text() or "").strip()
+        if tun:
+            new_opts.append(("tunnel", tun))
+
+        if self._verify_required is not None and self._verify_required.get_active():
+            new_opts.append(("verify-required", True))
+        if self._no_touch_required is not None and self._no_touch_required.get_active():
+            new_opts.append(("no-touch-required", True))
+
+        # Unknown options that user did not uncheck.
+        new_unknown = [tok for tok, chk in self._unknown_check_rows if chk.get_active()]
+
+        if (
+            new_opts != entry.options
+            or new_unknown != entry.unknown_options
+        ):
+            entry.options = new_opts
+            entry.unknown_options = new_unknown
+            entry.mark_dirty()
+
+        if self._on_saved is not None:
+            self._on_saved(entry)
+        self.close()
+

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -2231,6 +2231,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     menu.add_section(
                         menu.add_item('folder-symbolic', _('Manage Files'), lambda: self.on_manage_files_action(None, None)) if not should_hide_file_manager_options() else None,
                         menu.add_item('dialog-password-symbolic', _('Copy Key to Server'), lambda: self.on_copy_key_to_server_action(None, None)),
+                        menu.add_item('dialog-password-symbolic', _('Manage authorized_keys…'), lambda: self.on_manage_authorized_keys_action(None, None)),
                         wol_item,
                         menu.add_item('utilities-terminal-symbolic', _('Open in System Terminal'), lambda: self.on_open_in_system_terminal_action(None, None)) if not should_hide_external_terminal_options() else None,
                     )
@@ -3335,6 +3336,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
         menu.append('Copy Key to Server', 'app.new-key')
         menu.append('SSH Config Editor', 'app.edit-ssh-config')
         menu.append('Known Hosts Editor', 'win.edit-known-hosts')
+        menu.append('Manage Local authorized_keys…', 'win.manage-local-authorized-keys')
         menu.append('Broadcast Command', 'app.broadcast-command')
         
         # Sessions submenu
@@ -8981,6 +8983,86 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                 self._open_manage_files_for_connection(connection)
             except Exception as e:
                 logger.error(f"Error opening file manager: {e}")
+
+    def on_manage_local_authorized_keys_action(self, action, param=None):
+        """Open the structured editor on the local user's ~/.ssh/authorized_keys."""
+        try:
+            from .authorized_keys_window import AuthorizedKeysWindow
+        except Exception as exc:
+            logger.error("authorized_keys editor unavailable: %s", exc)
+            return
+        try:
+            window = AuthorizedKeysWindow(
+                parent=self,
+                local_path="~/.ssh/authorized_keys",
+                connection_manager=self.connection_manager,
+                key_manager=getattr(self, 'key_manager', None),
+            )
+            window.present()
+        except Exception as exc:
+            logger.error("Failed to open local authorized_keys editor: %s", exc)
+
+    def on_manage_authorized_keys_action(self, action, param=None):
+        """Open the structured authorized_keys editor for the right-clicked connection."""
+        if not (hasattr(self, '_context_menu_connection') and self._context_menu_connection):
+            return
+        connection = self._context_menu_connection
+        try:
+            from .authorized_keys_window import AuthorizedKeysWindow
+            from .file_manager_window import AsyncSFTPManager
+        except Exception as exc:
+            logger.error("authorized_keys editor unavailable: %s", exc)
+            return
+
+        host_value = _get_connection_host(connection) or _get_connection_alias(connection)
+        username = getattr(connection, 'username', '') or ''
+        port_value = getattr(connection, 'port', 22) or 22
+
+        ssh_config = None
+        if hasattr(self, 'config') and self.config is not None:
+            try:
+                ssh_config = self.config.get_ssh_config()
+            except Exception as exc:
+                logger.debug("Failed to read SSH configuration for authorized_keys editor: %s", exc)
+                ssh_config = None
+
+        initial_password = getattr(connection, 'password', None) or None
+        if not initial_password and self.connection_manager is not None:
+            try:
+                initial_password = self.connection_manager.get_password(host_value, username)
+            except Exception as exc:
+                logger.debug("Password lookup failed for authorized_keys editor: %s", exc)
+                initial_password = None
+
+        try:
+            manager = AsyncSFTPManager(
+                str(host_value or ''),
+                str(username or ''),
+                int(port_value),
+                password=initial_password,
+                connection=connection,
+                connection_manager=self.connection_manager,
+                ssh_config=ssh_config,
+            )
+        except Exception as exc:
+            logger.error("Failed to create SFTP manager for authorized_keys: %s", exc)
+            return
+
+        try:
+            window = AuthorizedKeysWindow(
+                parent=self,
+                connection=connection,
+                sftp_manager=manager,
+                connection_manager=self.connection_manager,
+                key_manager=getattr(self, 'key_manager', None),
+            )
+            window.present()
+        except Exception as exc:
+            logger.error("Failed to open authorized_keys editor: %s", exc)
+            try:
+                manager.close()
+            except Exception:
+                pass
 
     def _open_manage_files_for_connection(self, connection):
         """Open files for the supplied connection.

--- a/tests/test_authorized_keys_parser.py
+++ b/tests/test_authorized_keys_parser.py
@@ -143,3 +143,22 @@ def test_flag_option_no_equals():
     e = _entries(items)[0]
     assert ("restrict", True) in e.options
     assert ("cert-authority", True) in e.options
+
+
+def test_false_flag_is_not_emitted():
+    """A flag option stored with value False must NOT round-trip as the
+    bare name (which would silently re-enable it). It should be dropped."""
+    text = f"ssh-ed25519 {KEY_BLOB} alice\n"
+    items = parse_file(text)
+    e = _entries(items)[0]
+    # Inject an inconsistent False flag and ensure serialisation drops it.
+    e.options = [("restrict", False), ("cert-authority", False)]
+    e.mark_dirty()
+    out = serialize(items)
+    assert "restrict" not in out
+    assert "cert-authority" not in out
+    # The key line is still emitted.
+    assert "ssh-ed25519" in out
+    # And it's well-formed (no stray commas / leading space).
+    line = out.strip().splitlines()[0]
+    assert line.startswith("ssh-ed25519 ")

--- a/tests/test_authorized_keys_parser.py
+++ b/tests/test_authorized_keys_parser.py
@@ -1,0 +1,145 @@
+"""Unit tests for the authorized_keys parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from sshpilot.authorized_keys_parser import (
+    AuthorizedKeyEntry,
+    compute_fingerprint,
+    parse_file,
+    serialize,
+)
+
+
+KEY_BLOB = (
+    "AAAAC3NzaC1lZDI1NTE5AAAAIK1eKZmcG3zP7Q9XzYx0sLh9G6mP6Q3OwPgkqJ"
+    "x6r1Pq"
+)
+
+
+def _entries(items):
+    return [it for it in items if isinstance(it, AuthorizedKeyEntry)]
+
+
+def test_parses_plain_line():
+    text = f"ssh-ed25519 {KEY_BLOB} alice@host\n"
+    items = parse_file(text)
+    entries = _entries(items)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.keytype == "ssh-ed25519"
+    assert e.key_b64 == KEY_BLOB
+    assert e.comment == "alice@host"
+    assert e.options == []
+    assert e.unknown_options == []
+    assert not e.disabled
+
+
+def test_roundtrip_clean_is_byte_identical():
+    text = (
+        "# header comment\n"
+        "\n"
+        f'command="/usr/local/bin/run.sh",from="10.0.0.0/8,!10.0.0.5",restrict ssh-ed25519 {KEY_BLOB} alice\n'
+        f"ssh-rsa {KEY_BLOB} bob with spaces in comment\n"
+        f"# ssh-ed25519 {KEY_BLOB} disabled-key\n"
+    )
+    items = parse_file(text)
+    assert serialize(items) == text
+
+
+def test_unknown_option_preserved_verbatim():
+    text = (
+        f'weird-future-option="x,y",command="/bin/echo" ssh-ed25519 {KEY_BLOB} bob\n'
+    )
+    items = parse_file(text)
+    entries = _entries(items)
+    assert len(entries) == 1
+    e = entries[0]
+    assert any(name == "command" for name, _ in e.options)
+    assert e.unknown_options == ['weird-future-option="x,y"']
+    # Even after mutating something, the unknown option must still be emitted.
+    e.set_value("command", "/bin/true")
+    out = serialize(items)
+    assert 'weird-future-option="x,y"' in out
+    assert 'command="/bin/true"' in out
+
+
+def test_repeatable_options():
+    text = (
+        f'permitopen="host1:22",permitopen="host2:80",environment="FOO=bar" '
+        f"ssh-ed25519 {KEY_BLOB} repeatable\n"
+    )
+    items = parse_file(text)
+    e = _entries(items)[0]
+    permits = e.get_options("permitopen")
+    assert permits == ["host1:22", "host2:80"]
+    assert e.get_options("environment") == ["FOO=bar"]
+
+
+def test_disabled_entry_roundtrips():
+    text = f"# ssh-ed25519 {KEY_BLOB} old-key\n"
+    items = parse_file(text)
+    entries = _entries(items)
+    assert len(entries) == 1
+    assert entries[0].disabled is True
+    assert serialize(items) == text
+
+
+def test_pure_comment_passthrough():
+    text = "# just a note about this file\n"
+    items = parse_file(text)
+    # No entries; the comment is passthrough.
+    assert _entries(items) == []
+    assert serialize(items) == text
+
+
+def test_quoted_values_with_escapes():
+    text = (
+        f'command="echo \\"hi\\" && true" ssh-ed25519 {KEY_BLOB} esc\n'
+    )
+    items = parse_file(text)
+    e = _entries(items)[0]
+    assert e.get_option("command") == 'echo "hi" && true'
+    # Round-trip the mutation re-quotes it.
+    e.set_value("command", 'echo "hi" && true')
+    out = serialize(items)
+    assert '\\"hi\\"' in out
+
+
+def test_fingerprint_format():
+    fp = compute_fingerprint("ssh-ed25519", KEY_BLOB)
+    assert fp.startswith("SHA256:")
+    # base64 sha256 (no padding) is 43 chars.
+    assert len(fp) == len("SHA256:") + 43
+
+
+def test_mutation_marks_dirty_and_serializes_change():
+    text = f"ssh-ed25519 {KEY_BLOB} alice\n"
+    items = parse_file(text)
+    e = _entries(items)[0]
+    e.set_flag("restrict", True)
+    out = serialize(items)
+    assert out.startswith("restrict ssh-ed25519 ")
+
+
+def test_blank_lines_preserved():
+    text = f"\n\nssh-ed25519 {KEY_BLOB} a\n\n"
+    items = parse_file(text)
+    assert serialize(items) == text
+
+
+def test_cert_keytype_recognized():
+    cert = "ssh-ed25519-cert-v01@openssh.com"
+    text = f"{cert} {KEY_BLOB} certuser\n"
+    items = parse_file(text)
+    e = _entries(items)[0]
+    assert e.keytype == cert
+
+
+def test_flag_option_no_equals():
+    text = f"restrict,cert-authority ssh-ed25519 {KEY_BLOB} ca\n"
+    items = parse_file(text)
+    e = _entries(items)[0]
+    assert ("restrict", True) in e.options
+    assert ("cert-authority", True) in e.options

--- a/tests/test_authorized_keys_service.py
+++ b/tests/test_authorized_keys_service.py
@@ -1,0 +1,357 @@
+"""Tests for the authorized_keys service layer.
+
+Covers:
+- ``LocalAuthorizedKeysService`` against a real tmp filesystem (load, save,
+  backup-on-first-save, no-double-backup, atomic write, chmod 0600 / 0700).
+- ``AuthorizedKeysService`` against a fake paramiko SFTP/SSH client that
+  records calls, so we can assert backup, atomic posix_rename, chmod, and the
+  ``mkdir -p && chmod 700`` exec_command without needing a real host.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import stat
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+import pytest
+
+# Some sshpilot modules import paramiko at import time. The service module
+# itself does not, so import directly.
+from sshpilot.authorized_keys_parser import AuthorizedKeyEntry, parse_file
+from sshpilot.authorized_keys_service import (
+    AuthorizedKeysService,
+    LocalAuthorizedKeysService,
+    _shell_quote,
+)
+
+
+KEY_BLOB = (
+    "AAAAC3NzaC1lZDI1NTE5AAAAIK1eKZmcG3zP7Q9XzYx0sLh9G6mP6Q3OwPgkqJx6r1Pq"
+)
+
+SAMPLE = (
+    f"ssh-ed25519 {KEY_BLOB} alice\n"
+    f'command="/bin/true",from="10.0.0.0/8" ssh-ed25519 {KEY_BLOB} bob\n'
+    f'weird-future-option="x,y" ssh-ed25519 {KEY_BLOB} carol\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# LocalAuthorizedKeysService
+# ---------------------------------------------------------------------------
+
+
+def _mode(path: str) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_local_load_returns_empty_when_ssh_dir_missing(tmp_path):
+    path = tmp_path / "no-ssh" / "authorized_keys"
+    svc = LocalAuthorizedKeysService(str(path))
+    items = svc.load().result(timeout=2)
+    assert items == []
+
+
+def test_local_load_returns_empty_when_file_missing(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir()
+    svc = LocalAuthorizedKeysService(str(ssh / "authorized_keys"))
+    assert svc.load().result(timeout=2) == []
+
+
+def test_local_load_parses_existing_file(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir()
+    ak = ssh / "authorized_keys"
+    ak.write_text(SAMPLE, encoding="utf-8")
+    svc = LocalAuthorizedKeysService(str(ak))
+    items = svc.load().result(timeout=2)
+    entries = [it for it in items if isinstance(it, AuthorizedKeyEntry)]
+    assert len(entries) == 3
+    assert entries[1].get_option("command") == "/bin/true"
+    assert entries[2].unknown_options == ['weird-future-option="x,y"']
+
+
+def test_local_save_creates_ssh_dir_and_writes_file(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ak = ssh / "authorized_keys"
+    svc = LocalAuthorizedKeysService(str(ak))
+    items = parse_file(SAMPLE)
+    svc.save(items, make_backup=True).result(timeout=2)
+
+    assert ak.exists()
+    assert ak.read_text(encoding="utf-8") == SAMPLE
+    assert _mode(str(ak)) == 0o600
+    assert _mode(str(ssh)) == 0o700
+
+
+def test_local_save_backs_up_existing_file_once_per_session(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir(mode=0o700)
+    ak = ssh / "authorized_keys"
+    original = "ssh-ed25519 AAAA original\n"
+    ak.write_text(original, encoding="utf-8")
+
+    svc = LocalAuthorizedKeysService(str(ak))
+    items = parse_file(SAMPLE)
+    svc.save(items, make_backup=True).result(timeout=2)
+
+    # Exactly one backup file exists with the original content.
+    backups = list(ssh.glob("authorized_keys.bak-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == original
+
+    # Save again — no second backup, file updated in place.
+    items[0] = (
+        items[0] if not isinstance(items[0], AuthorizedKeyEntry) else items[0]
+    )
+    svc.save(items, make_backup=True).result(timeout=2)
+    backups_after = list(ssh.glob("authorized_keys.bak-*"))
+    assert len(backups_after) == 1, "second save should not create another backup"
+
+
+def test_local_save_no_backup_when_target_missing(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ak = ssh / "authorized_keys"
+    svc = LocalAuthorizedKeysService(str(ak))
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+    assert not list(ssh.glob("authorized_keys.bak-*"))
+
+
+def test_local_save_leaves_no_tmp_file(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir(mode=0o700)
+    ak = ssh / "authorized_keys"
+    svc = LocalAuthorizedKeysService(str(ak))
+    svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
+    assert not list(ssh.glob("*.sshpilot.tmp"))
+
+
+def test_local_load_propagates_unexpected_errors(tmp_path):
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir()
+    ak = ssh / "authorized_keys"
+    ak.write_text("ok\n", encoding="utf-8")
+    ak.chmod(0o000)  # unreadable
+    try:
+        svc = LocalAuthorizedKeysService(str(ak))
+        fut = svc.load()
+        # PermissionError should surface via the Future.
+        if os.geteuid() == 0:
+            pytest.skip("root can read unreadable files; cannot test perms")
+        with pytest.raises(PermissionError):
+            fut.result(timeout=2)
+    finally:
+        ak.chmod(0o600)
+
+
+# ---------------------------------------------------------------------------
+# AuthorizedKeysService (SFTP) with mocks
+# ---------------------------------------------------------------------------
+
+
+class _FakeSFTPFile(io.BytesIO):
+    """Mimics paramiko's SFTPFile context manager surface."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.close()
+        return False
+
+
+class FakeSFTP:
+    """In-memory paramiko.SFTPClient stand-in for service-layer tests."""
+
+    def __init__(self, home="/home/test"):
+        self._home = home
+        # filename -> bytes
+        self.files: dict[str, bytes] = {}
+        # filename -> mode
+        self.modes: dict[str, int] = {}
+        # directories that exist
+        self.dirs = {home}
+        self.calls: list[tuple[str, tuple]] = []
+
+    def _record(self, name, *args):
+        self.calls.append((name, args))
+
+    def normalize(self, _path):
+        self._record("normalize", _path)
+        return self._home
+
+    def stat(self, path):
+        self._record("stat", path)
+        if path in self.dirs or path in self.files:
+            return MagicMock(st_mode=0)
+        raise IOError(f"missing: {path}")
+
+    def file(self, path, mode):
+        self._record("file", path, mode)
+        if "r" in mode:
+            if path not in self.files:
+                raise IOError(f"missing: {path}")
+            return _FakeSFTPFile(self.files[path])
+
+        # Write mode: capture bytes back to dict on close.
+        outer = self
+
+        class _WriteHandle(_FakeSFTPFile):
+            def close(self_inner):
+                outer.files[path] = self_inner.getvalue()
+                super().close()
+
+        return _WriteHandle()
+
+    def posix_rename(self, src, dst):
+        self._record("posix_rename", src, dst)
+        if src not in self.files:
+            raise IOError(f"missing rename src: {src}")
+        self.files[dst] = self.files.pop(src)
+        if src in self.modes:
+            self.modes[dst] = self.modes.pop(src)
+
+    def chmod(self, path, mode):
+        self._record("chmod", path, mode)
+        self.modes[path] = mode
+
+
+class FakeStdout:
+    def __init__(self, status=0):
+        self.channel = MagicMock()
+        self.channel.recv_exit_status = MagicMock(return_value=status)
+
+
+class FakeStderr:
+    def read(self):
+        return b""
+
+
+class FakeSSH:
+    """Minimal paramiko.SSHClient stand-in."""
+
+    def __init__(self, exit_status=0):
+        self.exit_status = exit_status
+        self.commands: list[str] = []
+
+    def exec_command(self, cmd):
+        self.commands.append(cmd)
+        return None, FakeStdout(self.exit_status), FakeStderr()
+
+
+class FakeManager:
+    """AsyncSFTPManager surface needed by AuthorizedKeysService."""
+
+    def __init__(self, sftp: FakeSFTP, ssh: FakeSSH):
+        self._sftp = sftp
+        self._client = ssh
+
+    def _submit(self, func, *, on_success=None, on_error=None):
+        fut: Future = Future()
+        try:
+            fut.set_result(func())
+        except Exception as exc:
+            fut.set_exception(exc)
+        return fut
+
+
+def test_sftp_load_returns_empty_when_ssh_dir_missing():
+    sftp = FakeSFTP()
+    sftp.dirs.discard(sftp._home)  # nothing exists
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+    items = svc.load().result(timeout=2)
+    assert items == []
+
+
+def test_sftp_load_returns_empty_when_file_missing():
+    sftp = FakeSFTP()
+    sftp.dirs.add("/home/test/.ssh")
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+    assert svc.load().result(timeout=2) == []
+
+
+def test_sftp_load_parses_existing_file():
+    sftp = FakeSFTP()
+    sftp.dirs.add("/home/test/.ssh")
+    sftp.files["/home/test/.ssh/authorized_keys"] = SAMPLE.encode("utf-8")
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+    items = svc.load().result(timeout=2)
+    entries = [it for it in items if isinstance(it, AuthorizedKeyEntry)]
+    assert len(entries) == 3
+
+
+def test_sftp_save_writes_via_atomic_rename_and_chmods_600():
+    sftp = FakeSFTP()
+    ssh = FakeSSH()
+    svc = AuthorizedKeysService(FakeManager(sftp, ssh))
+    svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
+
+    ak = "/home/test/.ssh/authorized_keys"
+    tmp = ak + ".sshpilot.tmp"
+    # Target file present, tmp gone.
+    assert ak in sftp.files
+    assert tmp not in sftp.files
+    # 600 enforced on the final file.
+    assert sftp.modes.get(ak) == 0o600
+    # Content matches.
+    assert sftp.files[ak].decode("utf-8") == SAMPLE
+    # mkdir -p && chmod 700 was issued.
+    assert any("mkdir -p" in c and "chmod 700" in c for c in ssh.commands)
+    # posix_rename was called (atomic move from tmp to target).
+    rename_calls = [c for c in sftp.calls if c[0] == "posix_rename"]
+    assert any(args == (tmp, ak) for _, args in rename_calls)
+
+
+def test_sftp_save_backs_up_existing_file_once_per_session():
+    sftp = FakeSFTP()
+    ak = "/home/test/.ssh/authorized_keys"
+    sftp.dirs.add("/home/test/.ssh")
+    sftp.files[ak] = b"ssh-ed25519 AAAA original\n"
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+    backups = [k for k in sftp.files if k.startswith(ak + ".bak-")]
+    assert len(backups) == 1
+    assert sftp.files[backups[0]] == b"ssh-ed25519 AAAA original\n"
+
+    # Subsequent save with make_backup=True must NOT create a second backup
+    # because _backup_done flips after the first successful save.
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+    backups_after = [k for k in sftp.files if k.startswith(ak + ".bak-")]
+    assert len(backups_after) == 1
+
+
+def test_sftp_save_raises_when_mkdir_fails():
+    sftp = FakeSFTP()
+    ssh = FakeSSH(exit_status=1)
+    svc = AuthorizedKeysService(FakeManager(sftp, ssh))
+    fut = svc.save(parse_file(SAMPLE), make_backup=False)
+    with pytest.raises(IOError):
+        fut.result(timeout=2)
+
+
+def test_sftp_save_raises_when_not_connected():
+    class _Disconnected:
+        _sftp = None
+        _client = None
+
+        def _submit(self, func, **_kw):
+            fut: Future = Future()
+            try:
+                fut.set_result(func())
+            except Exception as exc:
+                fut.set_exception(exc)
+            return fut
+
+    svc = AuthorizedKeysService(_Disconnected())
+    with pytest.raises(RuntimeError):
+        svc.save([], make_backup=False).result(timeout=2)
+
+
+def test_shell_quote_escapes_single_quotes():
+    assert _shell_quote("/tmp/safe") == "'/tmp/safe'"
+    assert _shell_quote("o'malley") == "'o'\\''malley'"

--- a/tests/test_authorized_keys_service.py
+++ b/tests/test_authorized_keys_service.py
@@ -24,7 +24,6 @@ from sshpilot.authorized_keys_parser import AuthorizedKeyEntry, parse_file
 from sshpilot.authorized_keys_service import (
     AuthorizedKeysService,
     LocalAuthorizedKeysService,
-    _shell_quote,
 )
 
 
@@ -105,12 +104,33 @@ def test_local_save_backs_up_existing_file_once_per_session(tmp_path):
     assert backups[0].read_text(encoding="utf-8") == original
 
     # Save again — no second backup, file updated in place.
-    items[0] = (
-        items[0] if not isinstance(items[0], AuthorizedKeyEntry) else items[0]
-    )
     svc.save(items, make_backup=True).result(timeout=2)
     backups_after = list(ssh.glob("authorized_keys.bak-*"))
     assert len(backups_after) == 1, "second save should not create another backup"
+
+
+def test_local_save_backup_is_copy_not_rename(tmp_path):
+    """The live authorized_keys must stay in place during backup; only
+    the final atomic replace should swap it out."""
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir(mode=0o700)
+    ak = ssh / "authorized_keys"
+    original_ino = None
+    ak.write_text("original\n", encoding="utf-8")
+    original_ino = ak.stat().st_ino
+
+    svc = LocalAuthorizedKeysService(str(ak))
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+
+    # The target was atomically replaced with a new file (different inode),
+    # but the backup is a *new* file too — not the old inode renamed.
+    backups = list(ssh.glob("authorized_keys.bak-*"))
+    assert len(backups) == 1
+    assert backups[0].stat().st_ino != original_ino
+    # And the new live file has the new content + 600 mode.
+    assert ak.read_text(encoding="utf-8") == SAMPLE
+    assert _mode(str(ak)) == 0o600
+    assert _mode(str(backups[0])) == 0o600
 
 
 def test_local_save_no_backup_when_target_missing(tmp_path):
@@ -190,6 +210,13 @@ class FakeSFTP:
             return MagicMock(st_mode=0)
         raise IOError(f"missing: {path}")
 
+    def mkdir(self, path, mode=0o777):
+        self._record("mkdir", path, mode)
+        if path in self.dirs:
+            raise IOError(f"already exists: {path}")
+        self.dirs.add(path)
+        self.modes[path] = mode
+
     def file(self, path, mode):
         self._record("file", path, mode)
         if "r" in mode:
@@ -197,8 +224,10 @@ class FakeSFTP:
                 raise IOError(f"missing: {path}")
             return _FakeSFTPFile(self.files[path])
 
-        # Write mode: capture bytes back to dict on close.
+        # Write mode: create the file empty on open so chmod-before-write
+        # has something to chmod. Capture bytes back to dict on close.
         outer = self
+        outer.files.setdefault(path, b"")
 
         class _WriteHandle(_FakeSFTPFile):
             def close(self_inner):
@@ -212,11 +241,14 @@ class FakeSFTP:
         if src not in self.files:
             raise IOError(f"missing rename src: {src}")
         self.files[dst] = self.files.pop(src)
+        # posix_rename preserves source mode.
         if src in self.modes:
             self.modes[dst] = self.modes.pop(src)
 
     def chmod(self, path, mode):
         self._record("chmod", path, mode)
+        if path not in self.files and path not in self.dirs:
+            raise IOError(f"chmod missing: {path}")
         self.modes[path] = mode
 
 
@@ -286,8 +318,7 @@ def test_sftp_load_parses_existing_file():
 
 def test_sftp_save_writes_via_atomic_rename_and_chmods_600():
     sftp = FakeSFTP()
-    ssh = FakeSSH()
-    svc = AuthorizedKeysService(FakeManager(sftp, ssh))
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
     svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
 
     ak = "/home/test/.ssh/authorized_keys"
@@ -295,18 +326,59 @@ def test_sftp_save_writes_via_atomic_rename_and_chmods_600():
     # Target file present, tmp gone.
     assert ak in sftp.files
     assert tmp not in sftp.files
-    # 600 enforced on the final file.
+    # 600 was set on the tmp before the rename, and posix_rename preserves
+    # source mode — so the live file ends up 0600 without a final chmod.
     assert sftp.modes.get(ak) == 0o600
     # Content matches.
     assert sftp.files[ak].decode("utf-8") == SAMPLE
-    # mkdir -p && chmod 700 was issued.
-    assert any("mkdir -p" in c and "chmod 700" in c for c in ssh.commands)
+    # mkdir over SFTP was attempted with mode 0700 (not via exec_command).
+    mkdir_calls = [c for c in sftp.calls if c[0] == "mkdir"]
+    assert any(args == ("/home/test/.ssh", 0o700) for _, args in mkdir_calls)
     # posix_rename was called (atomic move from tmp to target).
     rename_calls = [c for c in sftp.calls if c[0] == "posix_rename"]
     assert any(args == (tmp, ak) for _, args in rename_calls)
 
 
-def test_sftp_save_backs_up_existing_file_once_per_session():
+def test_sftp_save_does_not_use_shell_exec():
+    """Regression: must not depend on a POSIX login shell on the remote."""
+    sftp = FakeSFTP()
+    ssh = FakeSSH()
+    svc = AuthorizedKeysService(FakeManager(sftp, ssh))
+    svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
+    assert ssh.commands == [], "save() must not invoke exec_command"
+
+
+def test_sftp_save_chmod_happens_before_write():
+    """The tmp file must be 0600 BEFORE its content is written, so the
+    keys are never readable by other users on the remote."""
+    sftp = FakeSFTP()
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+    svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
+
+    tmp = "/home/test/.ssh/authorized_keys.sshpilot.tmp"
+    ak = "/home/test/.ssh/authorized_keys"
+
+    # Find the chmod of the tmp file and the file-open in write mode.
+    open_idx = next(
+        i for i, c in enumerate(sftp.calls)
+        if c[0] == "file" and c[1][0] == tmp and "w" in c[1][1]
+    )
+    chmod_idx = next(
+        i for i, c in enumerate(sftp.calls)
+        if c[0] == "chmod" and c[1][0] == tmp and c[1][1] == 0o600
+    )
+    rename_idx = next(
+        i for i, c in enumerate(sftp.calls)
+        if c[0] == "posix_rename" and c[1] == (tmp, ak)
+    )
+    # chmod must come after open (you can't chmod a non-existent file) but
+    # before the final rename — i.e. during the empty-file window.
+    assert open_idx < chmod_idx < rename_idx
+
+
+def test_sftp_save_backs_up_via_copy_not_rename():
+    """Backup must be a copy: the live authorized_keys must never be
+    absent between backup and final install (lockout safety)."""
     sftp = FakeSFTP()
     ak = "/home/test/.ssh/authorized_keys"
     sftp.dirs.add("/home/test/.ssh")
@@ -314,24 +386,41 @@ def test_sftp_save_backs_up_existing_file_once_per_session():
     svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
 
     svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+
     backups = [k for k in sftp.files if k.startswith(ak + ".bak-")]
     assert len(backups) == 1
     assert sftp.files[backups[0]] == b"ssh-ed25519 AAAA original\n"
+    # No posix_rename from ak to bak — only the tmp→ak swap.
+    rename_calls = [c for c in sftp.calls if c[0] == "posix_rename"]
+    rename_args = [args for _, args in rename_calls]
+    assert all(args[0] != ak for args in rename_args), (
+        "live authorized_keys must not be renamed away during save"
+    )
+    # Backup got mode 0600 too.
+    assert sftp.modes.get(backups[0]) == 0o600
 
-    # Subsequent save with make_backup=True must NOT create a second backup
-    # because _backup_done flips after the first successful save.
-    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
-    backups_after = [k for k in sftp.files if k.startswith(ak + ".bak-")]
-    assert len(backups_after) == 1
 
-
-def test_sftp_save_raises_when_mkdir_fails():
+def test_sftp_save_backup_only_once_per_session():
     sftp = FakeSFTP()
-    ssh = FakeSSH(exit_status=1)
-    svc = AuthorizedKeysService(FakeManager(sftp, ssh))
-    fut = svc.save(parse_file(SAMPLE), make_backup=False)
-    with pytest.raises(IOError):
-        fut.result(timeout=2)
+    ak = "/home/test/.ssh/authorized_keys"
+    sftp.dirs.add("/home/test/.ssh")
+    sftp.files[ak] = b"original\n"
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+    svc.save(parse_file(SAMPLE), make_backup=True).result(timeout=2)
+    backups = [k for k in sftp.files if k.startswith(ak + ".bak-")]
+    assert len(backups) == 1
+
+
+def test_sftp_save_succeeds_when_ssh_dir_already_exists():
+    """mkdir over SFTP raises IOError if the dir exists; save must
+    swallow that and continue (host with pre-existing ~/.ssh)."""
+    sftp = FakeSFTP()
+    sftp.dirs.add("/home/test/.ssh")  # already there
+    svc = AuthorizedKeysService(FakeManager(sftp, FakeSSH()))
+    svc.save(parse_file(SAMPLE), make_backup=False).result(timeout=2)
+    assert sftp.files["/home/test/.ssh/authorized_keys"].decode("utf-8") == SAMPLE
 
 
 def test_sftp_save_raises_when_not_connected():
@@ -352,6 +441,3 @@ def test_sftp_save_raises_when_not_connected():
         svc.save([], make_backup=False).result(timeout=2)
 
 
-def test_shell_quote_escapes_single_quotes():
-    assert _shell_quote("/tmp/safe") == "'/tmp/safe'"
-    assert _shell_quote("o'malley") == "'o'\\''malley'"


### PR DESCRIPTION
Closes mfat/sshpilot#966.

## Summary

Adds a structured UI to manage `~/.ssh/authorized_keys` — both on a remote host (per-connection right-click → "Manage authorized_keys…") and on this machine (hamburger menu → "Manage Local authorized_keys…").

- **Parser/serialiser** (`sshpilot/authorized_keys_parser.py`) — round-trips byte-identically; **unknown options are preserved verbatim** (silent option drop would be a security regression).
- **Service layer** (`sshpilot/authorized_keys_service.py`) — atomic write via `posix_rename` / `os.replace` over a `.tmp` sibling, timestamped backup on first save per session, `chmod 600` on the file, `chmod 700` on `~/.ssh`. SFTP and local-filesystem variants share the same interface.
- **Editor window** (`sshpilot/authorized_keys_window.py`) — list view + per-entry edit dialog covering all OpenSSH option families: restrictions (`restrict` + opt-ins, `no-*` opt-outs, `cert-authority`), source/identity (`from=`, `principals=`), command/expiry/environment, tunneling (`permitopen=`, `permitlisten=`, `tunnel=`), FIDO (`verify-required`, `no-touch-required` for `sk-*` keys), plus a preserved list for unknown options. Raw-edit fallback reuses `RemoteFileEditorWindow`. Unsaved-changes guard on close. `Ctrl+S` to save.
- **Reuse, no parallel paths** — the SFTP variant uses the existing `AsyncSFTPManager` (paramiko, the project's documented exception to the single ssh-command path). The raw editor reuses `RemoteFileEditorWindow`. The local-keys "Add" path reuses `KeyManager.discover_keys()`.

Scope: v1 edits the login user's `~/.ssh/authorized_keys` only. "Edit as another user via sudo" is intentionally deferred.

## Test plan

- [x] `pytest tests/test_authorized_keys_parser.py` — 12 tests, including round-trip on a corpus with every option family, unknown-option preservation, quoted-escape, disabled entries, blank lines, cert keytypes, repeatables.
- [x] Live SFTP load against a real host (vps00) — parsed 4 entries from an 862-byte file and verified `serialize(parse(raw)) == raw` (byte-identical).
- [x] Live UI: editor window opens and renders real entries from the remote host's `authorized_keys` with correct keytype, SHA256 fingerprint and options summary.
- [x] Live UI: editor window opens against the local user's `~/.ssh/authorized_keys` via the hamburger menu.
- [ ] **Not yet exercised**: the save path against a live host. A reviewer with a throwaway host should:
  - Seed `authorized_keys` with `command=…`, `from=…`, an unknown option, and a `#`-disabled line.
  - Toggle/edit something, click Save.
  - On the host, confirm: changed content, unknown-option line byte-identical, mode `0600`, `~/.ssh/authorized_keys.bak-<ts>` exists.
  - SSH back in to confirm the new forced command runs.