### PR TITLE
feat: show full connection name as tooltip on hover

### DIFF
--- a/sshpilot/sidebar.py
+++ b/sshpilot/sidebar.py
@@ -663,6 +663,7 @@ class ConnectionRow(Gtk.ListBoxRow):
         self.nickname_label.set_ellipsize(Pango.EllipsizeMode.END)
         self.nickname_label.set_width_chars(10)  # Minimum width
         self.nickname_label.set_max_width_chars(25)  # Maximum natural width (prevents expansion)
+        self.nickname_label.set_tooltip_text(connection.nickname)
         info_box.append(self.nickname_label)
 
         self.host_label = Gtk.Label()
@@ -1237,6 +1238,7 @@ class ConnectionRow(Gtk.ListBoxRow):
 
         if hide:
             self.host_label.set_text("••••••••••")
+            self.host_label.set_tooltip_text('')
             return
 
         format_kwargs = {}
@@ -1245,6 +1247,7 @@ class ConnectionRow(Gtk.ListBoxRow):
 
         display = _format_connection_host_display(self.connection, **format_kwargs)
         self.host_label.set_text(display or '')
+        self.host_label.set_tooltip_text(display or '')
 
     def apply_hide_hosts(self, hide: bool):
         self._apply_host_label_text()

--- a/tests/test_connection_row_tooltip.py
+++ b/tests/test_connection_row_tooltip.py
@@ -1,0 +1,98 @@
+"""Tests for ConnectionRow tooltip behaviour (sidebar.py).
+
+Strategy: ConnectionRow.__init__ creates many GTK widgets and cannot run in the
+test environment without a full GTK stack.  We use __new__ to bypass __init__ and
+set only the attributes required by the methods under test.
+"""
+import importlib
+import inspect
+from unittest.mock import MagicMock
+
+from sshpilot.connection_manager import Connection
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _DummyConfig:
+    def get_setting(self, key, default=None):
+        return default
+
+
+class _FakeRoot:
+    """Minimal stand-in for the Gtk window returned by get_root()."""
+    def __init__(self, hide_hosts: bool = False):
+        self._hide_hosts = hide_hosts
+
+
+def _make_row(connection: Connection):
+    """Return a (row, sidebar_module) pair built via __new__ with minimal setup."""
+    sidebar_mod = importlib.import_module('sshpilot.sidebar')
+    row = sidebar_mod.ConnectionRow.__new__(sidebar_mod.ConnectionRow)
+    row.connection = connection
+    row.host_label = MagicMock()
+    row.config = _DummyConfig()
+    return row, sidebar_mod
+
+
+# ---------------------------------------------------------------------------
+# host_label tooltip — tested through _apply_host_label_text()
+# ---------------------------------------------------------------------------
+
+def test_host_label_tooltip_shows_formatted_host(monkeypatch):
+    """_apply_host_label_text sets host_label tooltip to the formatted host display."""
+    conn = Connection({'nickname': 'prod', 'host': 'prod.example.com', 'user': 'alice'})
+    row, sidebar_mod = _make_row(conn)
+    monkeypatch.setattr(
+        sidebar_mod, '_format_connection_host_display',
+        lambda c, **kw: 'alice@prod.example.com',
+    )
+    row.get_root = lambda: _FakeRoot(hide_hosts=False)
+
+    row._apply_host_label_text()
+
+    row.host_label.set_tooltip_text.assert_called_once_with('alice@prod.example.com')
+    row.host_label.set_text.assert_called_once_with('alice@prod.example.com')
+
+
+def test_host_label_tooltip_cleared_when_hide_hosts_active(monkeypatch):
+    """_apply_host_label_text clears host_label tooltip when the window is in hide-hosts mode."""
+    conn = Connection({'nickname': 'prod', 'host': 'prod.example.com'})
+    row, _ = _make_row(conn)
+    row.get_root = lambda: _FakeRoot(hide_hosts=True)
+
+    row._apply_host_label_text()
+
+    row.host_label.set_tooltip_text.assert_called_once_with('')
+    row.host_label.set_text.assert_called_once_with('••••••••••')
+
+
+def test_host_label_tooltip_empty_when_no_host_display(monkeypatch):
+    """_apply_host_label_text sets an empty tooltip when the host display string is empty."""
+    conn = Connection({'nickname': 'local', 'host': ''})
+    row, sidebar_mod = _make_row(conn)
+    monkeypatch.setattr(
+        sidebar_mod, '_format_connection_host_display',
+        lambda c, **kw: '',
+    )
+    row.get_root = lambda: _FakeRoot(hide_hosts=False)
+
+    row._apply_host_label_text()
+
+    row.host_label.set_tooltip_text.assert_called_once_with('')
+
+
+# ---------------------------------------------------------------------------
+# nickname_label tooltip — verified via source inspection
+#
+# ConnectionRow.__init__ constructs too many GTK widgets to run headlessly.
+# The source-inspection test ensures the tooltip line survives future edits.
+# ---------------------------------------------------------------------------
+
+def test_nickname_label_tooltip_set_in_init():
+    """ConnectionRow.__init__ configures nickname_label tooltip with connection.nickname."""
+    sidebar_mod = importlib.import_module('sshpilot.sidebar')
+    source = inspect.getsource(sidebar_mod.ConnectionRow.__init__)
+    assert 'nickname_label.set_tooltip_text' in source
+    assert 'connection.nickname' in source


### PR DESCRIPTION
## Summary

- Add `set_tooltip_text()` on `nickname_label` so the full connection name is visible on hover even when the sidebar label is ellipsized
- Add `set_tooltip_text()` on `host_label` (updated in `_apply_host_label_text()`) with the formatted `user@host:port` display
- Clear the `host_label` tooltip when hide-hosts mode is active to avoid leaking the real hostname

## Tests

New test file `tests/test_connection_row_tooltip.py` covering:
- `_apply_host_label_text()` sets tooltip to formatted host display (normal case)
- `_apply_host_label_text()` clears tooltip when hide-hosts is active
- `_apply_host_label_text()` sets empty tooltip when host display is empty
- `ConnectionRow.__init__` configures `nickname_label` tooltip with `connection.nickname`

## Test plan
- [ ] Hover a connection row in the sidebar — full name appears as tooltip
- [ ] Hover the host label — `user@host` appears as tooltip
- [ ] Enable hide-hosts mode — host tooltip is empty
- [ ] Run `pytest tests/test_connection_row_tooltip.py` — 4 passed
