### PR TITLE
fix: Support libadwaita < 1.6 in disk key browser button

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -995,7 +995,15 @@ class KeyChooserDialog(Adw.Window):
         if not disk_keys:
             group.add(self._placeholder_row(_("No private keys found in ~/.ssh")))
         if callable(self._on_browse):
-            browse = Adw.ButtonRow(title=_("Browse…"), start_icon_name="folder-symbolic")
+            try:
+                browse = Adw.ButtonRow(title=_("Browse…"), start_icon_name="folder-symbolic")
+            except AttributeError:
+                # Adw.ButtonRow requires libadwaita >= 1.6
+                browse = Adw.ActionRow(title=_("Browse…"))
+                try:
+                    browse.add_prefix(Gtk.Image.new_from_icon_name("folder-symbolic"))
+                except Exception:
+                    pass
             browse.connect("activated", self._on_browse_clicked)
             group.add(browse)
         return self._wrap_group(group)


### PR DESCRIPTION
## Summary
Add backward compatibility for libadwaita versions prior to 1.6 in the disk key browser button. The `Adw.ButtonRow` widget with `start_icon_name` parameter was introduced in libadwaita 1.6, causing AttributeError on older versions.

## Changes
- Wrapped `Adw.ButtonRow` instantiation in a try-except block to gracefully handle older libadwaita versions
- Fall back to `Adw.ActionRow` with a manually added `Gtk.Image` prefix when `Adw.ButtonRow` is unavailable
- Added exception handling for icon loading to prevent failures if the icon cannot be loaded

## Implementation Details
- The primary code path uses `Adw.ButtonRow` with the icon parameter for libadwaita >= 1.6
- On AttributeError (indicating older libadwaita), the code falls back to `Adw.ActionRow` and manually adds the folder icon as a prefix widget
- Icon loading failures are silently ignored to ensure the button remains functional even if the icon cannot be loaded
- The button's "activated" signal connection and group addition remain unchanged, ensuring consistent behavior across both code paths

https://claude.ai/code/session_015b3fWYNdtkmxuRYCXe5HR3