### PR TITLE
Consolidate SSH command building across SCP, ssh-copy-id, and terminal

### DIFF
--- a/sshpilot/scp_window.py
+++ b/sshpilot/scp_window.py
@@ -22,9 +22,11 @@ from .connection_display import (
     get_connection_host as _get_connection_host,
 )
 from .scp_utils import (
+    _build_scp_argv_prefix,
     assemble_scp_transfer_args,
     classify_sftp_error,
     download_file,
+    insert_legacy_scp_flag,
     upload_file,
 )
 
@@ -255,28 +257,13 @@ class ScpWindowController:
         combined_auth = (auth_method == 0 and has_saved_password)
         use_publickey_with_password = combined_auth and not getattr(connection, 'pubkey_auth_no', False)
 
+        # Only auth-specific and connection-attribute options live here; the
+        # shared option builder (_build_scp_argv_prefix / _build_base_ssh_command)
+        # supplies app-level overrides, strict-host policy, port and the
+        # explicit keyfile, so they must not be duplicated in this list.
         ssh_options: List[str] = []
-        try:
-            cfg = self.window.config if hasattr(self.window, 'config') else Config()
-            ssh_cfg = cfg.get_ssh_config() if hasattr(cfg, 'get_ssh_config') else {}
-        except Exception:
-            ssh_cfg = {}
-
-        strict_val = str(ssh_cfg.get('strict_host_key_checking', '') or '').strip()
-        auto_add = bool(ssh_cfg.get('auto_add_host_keys', True))
-
-        if strict_val:
-            ssh_options += ['-o', f'StrictHostKeyChecking={strict_val}']
-        elif auto_add and not has_saved_password:
-            ssh_options += ['-o', 'StrictHostKeyChecking=accept-new']
-
         if getattr(connection, 'pubkey_auth_no', False):
             ssh_options += ['-o', 'PubkeyAuthentication=no']
-
-        if keyfile_ok and key_mode in (1, 2):
-            ssh_options += ['-i', expanded_keyfile]
-            if key_mode == 1:
-                ssh_options += ['-o', 'IdentitiesOnly=yes']
 
         self._extend_scp_options_from_connection(connection, ssh_options)
 
@@ -1290,29 +1277,6 @@ class ScpWindowController:
                         )
             except Exception:
                 pass
-        port = profile.port
-        ssh_extra_opts = list(profile.ssh_options)
-
-        if known_hosts_path:
-            ssh_extra_opts += ['-o', f'UserKnownHostsFile={known_hosts_path}']
-
-        argv = ['scp', '-v']
-        # Legacy SCP/rcp protocol (-O) does not require a remote sftp-server.
-        if legacy:
-            argv.append('-O')
-        try:
-            if direction == 'upload' and any(os.path.isdir(path) for path in transfer_sources):
-                argv.append('-r')
-        except Exception:
-            # If any path check fails (e.g. non-string items), continue without recursion.
-            logger.debug('SCP: Failed to inspect sources for recursion; continuing without -r')
-        if port and port != 22:
-            argv += ['-P', str(port)]
-        argv += ssh_extra_opts
-        # Port forwards are useless for file transfers and can fail when
-        # ExitOnForwardFailure=yes is set and a port is already in use.
-        argv += ['-o', 'ClearAllForwardings=yes']
-
         # Resolve auth via the single shared resolver (same as terminal + ssh-copy-id):
         # askpass for a saved passphrase, sshpass for a saved password, or bare TTY
         # prompts when nothing is saved. Stash it for _show_scp_terminal_window to
@@ -1325,16 +1289,41 @@ class ScpWindowController:
             getattr(self.window, 'config', None),
         )
         self._scp_auth = auth
-        if auth.extra_opts:
-            argv += list(auth.extra_opts)
-        if auth.use_sshpass and auth.password:
-            argv, _sshpass_cleanup = wrap_argv_with_sshpass(argv, auth.password)
-            import atexit
-            atexit.register(_sshpass_cleanup)
         logger.debug(
             "SCP: auth resolved (askpass=%s, sshpass=%s)",
             auth.use_askpass, auth.use_sshpass,
         )
+
+        try:
+            recursive = direction == 'upload' and any(
+                os.path.isdir(path) for path in transfer_sources
+            )
+        except Exception:
+            # If any path check fails (e.g. non-string items), continue without recursion.
+            logger.debug('SCP: Failed to inspect sources for recursion; continuing without -r')
+            recursive = False
+
+        # Shared scp prefix (same builder as the programmatic download/upload
+        # path): app-level overrides, strict-host policy, port, explicit
+        # keyfile, ClearAllForwardings and auth options, plus the
+        # window-specific options carried by the profile.
+        argv = _build_scp_argv_prefix(
+            connection,
+            getattr(self.window, 'config', None),
+            recursive,
+            known_hosts_path,
+            list(profile.ssh_options),
+            auth,
+        )
+        argv.insert(1, '-v')
+        # Legacy SCP/rcp protocol (-O) does not require a remote sftp-server.
+        if legacy:
+            argv = insert_legacy_scp_flag(argv)
+
+        if auth.use_sshpass and auth.password:
+            argv, _sshpass_cleanup = wrap_argv_with_sshpass(argv, auth.password)
+            import atexit
+            atexit.register(_sshpass_cleanup)
 
         for path in transfer_sources:
             argv.append(path)

--- a/sshpilot/scp_window.py
+++ b/sshpilot/scp_window.py
@@ -1309,6 +1309,9 @@ class ScpWindowController:
         if port and port != 22:
             argv += ['-P', str(port)]
         argv += ssh_extra_opts
+        # Port forwards are useless for file transfers and can fail when
+        # ExitOnForwardFailure=yes is set and a port is already in use.
+        argv += ['-o', 'ClearAllForwardings=yes']
 
         # Resolve auth via the single shared resolver (same as terminal + ssh-copy-id):
         # askpass for a saved passphrase, sshpass for a saved password, or bare TTY

--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -564,11 +564,14 @@ def _build_base_ssh_command(
     if forward_agent in ('yes', 'true', '1'):
         cmd.append('-A')
         cmd.extend(['-o', 'ForwardAgent=yes'])
-    
-    # Apply other SSH config options that should be passed through
-    # (SSH config is primary source, so we trust it)
-    # Note: We don't override PreferredAuthentications here - let SSH config handle it
-    
+
+    # Port forwards are useless for file-transfer operations and harmful when
+    # ExitOnForwardFailure=yes is set (a port already in use by an active
+    # terminal session would kill the transfer). ClearAllForwardings only
+    # cancels Local/Remote/Dynamic forwards; X11 and agent forwarding are unaffected.
+    if command_type in ('scp', 'ssh-copy-id'):
+        cmd.extend(['-o', 'ClearAllForwardings=yes'])
+
     return cmd
 
 

--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -450,7 +450,13 @@ def _build_base_ssh_command(
         cmd = ['ssh-copy-id']
     else:
         cmd = ['ssh']
-    
+
+    # ssh-copy-id is a shell script with a restricted option set (-i/-p/-o/-f/
+    # -n/-s/-x): it rejects flags ssh/scp/sftp share (-v, -C, -A), its -i names
+    # the key being COPIED rather than an authentication identity, and BatchMode
+    # would defeat its interactive purpose (first login usually needs a prompt).
+    is_copy_id = (command_type == 'ssh-copy-id')
+
     # Get app-level SSH settings
     app_ssh_config = {}
     if app_config:
@@ -458,18 +464,18 @@ def _build_base_ssh_command(
             app_ssh_config = app_config.get_ssh_config() if hasattr(app_config, 'get_ssh_config') else {}
         except Exception:
             pass
-    
+
     # Apply app-level overrides (verbosity, compression, etc.)
     verbosity = int(app_ssh_config.get('verbosity', 0) or 0)
-    if verbosity > 0:
+    if verbosity > 0 and not is_copy_id:
         for _ in range(min(verbosity, 3)):
             cmd.append('-v')
-    
+
     compression = bool(app_ssh_config.get('compression', False))
-    if compression:
+    if compression and not is_copy_id:
         cmd.append('-C')
 
-    if bool(app_ssh_config.get('batch_mode', False)):
+    if bool(app_ssh_config.get('batch_mode', False)) and not is_copy_id:
         cmd.extend(['-o', 'BatchMode=yes'])
 
     # Apply connection timeout if specified
@@ -528,15 +534,18 @@ def _build_base_ssh_command(
         else:
             cmd.extend(['-p', str(port)])
     
-    # Apply IdentityFile from SSH config (SSH config is primary source)
-    identity_files = _get_ssh_config_list(config, 'identityfile')
-    for identity_file in identity_files:
-        if identity_file and os.path.isfile(os.path.expanduser(identity_file)):
-            cmd.extend(['-i', os.path.expanduser(identity_file)])
-            # If IdentitiesOnly is set, only use this key
-            if _get_ssh_config_value(config, 'identitiesonly', '').lower() in ('yes', 'true', '1'):
-                cmd.extend(['-o', 'IdentitiesOnly=yes'])
-                break  # Only first key when IdentitiesOnly is set
+    # Apply IdentityFile from SSH config (SSH config is primary source).
+    # Never for ssh-copy-id: there -i selects the key to install, and the
+    # operation must authenticate with the key being copied.
+    if not is_copy_id:
+        identity_files = _get_ssh_config_list(config, 'identityfile')
+        for identity_file in identity_files:
+            if identity_file and os.path.isfile(os.path.expanduser(identity_file)):
+                cmd.extend(['-i', os.path.expanduser(identity_file)])
+                # If IdentitiesOnly is set, only use this key
+                if _get_ssh_config_value(config, 'identitiesonly', '').lower() in ('yes', 'true', '1'):
+                    cmd.extend(['-o', 'IdentitiesOnly=yes'])
+                    break  # Only first key when IdentitiesOnly is set
     
     # Apply CertificateFile if specified
     cert_file = _get_ssh_config_value(config, 'certificatefile')
@@ -555,13 +564,15 @@ def _build_base_ssh_command(
         if proxy_jump_filtered:
             cmd.extend(['-o', f'ProxyJump={",".join(proxy_jump_filtered)}'])
     
-    # Apply X11 forwarding if enabled
+    # Apply X11 forwarding if enabled. Only for ssh: scp -X selects the
+    # transfer protocol and sftp -X sets an sftp option, so a bare -X there
+    # would swallow the next argument.
     forward_x11 = _get_ssh_config_value(config, 'forwardx11', '').lower()
-    if forward_x11 in ('yes', 'true', '1'):
+    if forward_x11 in ('yes', 'true', '1') and command_type == 'ssh':
         cmd.append('-X')
 
     forward_agent = _get_ssh_config_value(config, 'forwardagent', '').lower()
-    if forward_agent in ('yes', 'true', '1'):
+    if forward_agent in ('yes', 'true', '1') and not is_copy_id:
         cmd.append('-A')
         cmd.extend(['-o', 'ForwardAgent=yes'])
 

--- a/sshpilot/sshcopyid_window.py
+++ b/sshpilot/sshcopyid_window.py
@@ -1183,6 +1183,10 @@ class SshCopyIdRunner:
         if known_hosts_path:
             argv += ['-o', f'UserKnownHostsFile={known_hosts_path}']
 
+        # Port forwards are useless for key-copying and can cause failure when
+        # ExitOnForwardFailure=yes is set and a port is already in use.
+        argv += ['-o', 'ClearAllForwardings=yes']
+
         # Derive auth prefs. Prefer the resolved NativeAuth (single shared auth
         # decision); fall back to recomputing from the connection when not given.
         logger.debug("Main window: Determining authentication preferences")

--- a/sshpilot/sshcopyid_window.py
+++ b/sshpilot/sshcopyid_window.py
@@ -1142,50 +1142,34 @@ class SshCopyIdRunner:
             raise RuntimeError(f"Public key file not found: {ssh_key.public_path}")
         
         logger.debug(f"Main window: Public key file verified: {ssh_key.public_path}")
-        argv = ['ssh-copy-id']
-        
+
+        # Shared command prefix via the single option builder (same one the SCP
+        # paths use): app-level -o options, strict-host policy, port and
+        # ClearAllForwardings. The builder skips flags ssh-copy-id can't take
+        # (-v/-C/-A/BatchMode) and never injects IdentityFile for it, so the
+        # operation authenticates with the key being copied.
+        from .ssh_connection_builder import _build_base_ssh_command
+        from .ssh_config_utils import get_effective_ssh_config
+
+        try:
+            effective_config = get_effective_ssh_config(host_value) if host_value else {}
+        except Exception:
+            effective_config = {}
+        app_cfg = getattr(self.window, 'config', None)
+        if app_cfg is None:
+            app_cfg = Config()
+        argv = _build_base_ssh_command(connection, effective_config, app_cfg, 'ssh-copy-id')
+
         # Add force option if enabled
         if force:
             argv.append('-f')
             logger.debug("Main window: Added force option (-f) to ssh-copy-id")
-        
+
         argv.extend(['-i', ssh_key.public_path])
         logger.debug(f"Main window: Base command: {argv}")
-        try:
-            port = getattr(connection, 'port', 22)
-            logger.debug(f"Main window: Connection port: {port}")
-            if port and port != 22:
-                argv += ['-p', str(connection.port)]
-                logger.debug(f"Main window: Added port option: -p {connection.port}")
-        except Exception as e:
-            logger.debug(f"Main window: Error getting port: {e}")
-            pass
-        # Honor app SSH settings: strict host key checking / auto-add
-        logger.debug("Main window: Loading SSH configuration")
-        try:
-            cfg = Config()
-            ssh_cfg = cfg.get_ssh_config() if hasattr(cfg, 'get_ssh_config') else {}
-            logger.debug(f"Main window: SSH config: {ssh_cfg}")
-            strict_val = str(ssh_cfg.get('strict_host_key_checking', '') or '').strip()
-            auto_add = bool(ssh_cfg.get('auto_add_host_keys', True))
-            logger.debug(f"Main window: SSH settings - strict_val='{strict_val}', auto_add={auto_add}")
-            if strict_val:
-                argv += ['-o', f'StrictHostKeyChecking={strict_val}']
-                logger.debug(f"Main window: Added strict host key checking: {strict_val}")
-            elif auto_add:
-                argv += ['-o', 'StrictHostKeyChecking=accept-new']
-                logger.debug("Main window: Added auto-accept new host keys")
-        except Exception as e:
-            logger.debug(f"Main window: Error loading SSH config: {e}")
-            argv += ['-o', 'StrictHostKeyChecking=accept-new']
-            logger.debug("Main window: Using default strict host key checking: accept-new")
 
         if known_hosts_path:
             argv += ['-o', f'UserKnownHostsFile={known_hosts_path}']
-
-        # Port forwards are useless for key-copying and can cause failure when
-        # ExitOnForwardFailure=yes is set and a port is already in use.
-        argv += ['-o', 'ClearAllForwardings=yes']
 
         # Derive auth prefs. Prefer the resolved NativeAuth (single shared auth
         # decision); fall back to recomputing from the connection when not given.

--- a/tests/test_ssh_connection_builder_extended.py
+++ b/tests/test_ssh_connection_builder_extended.py
@@ -470,3 +470,60 @@ def test_connect_builds_native_command(tmp_path, monkeypatch):
     assert conn.ssh_cmd[-1] == 'khhost'
     # No known_hosts injected into the command.
     assert not any('UserKnownHostsFile' in part for part in conn.ssh_cmd)
+
+
+# --- _build_base_ssh_command: per-binary option guards ---
+
+
+def _base_cmd(command_type, effective_config=None, app_config=None, conn_data=None):
+    from sshpilot.ssh_connection_builder import _build_base_ssh_command
+
+    conn = Connection(conn_data or {'host': 'h', 'hostname': 'h'})
+    return _build_base_ssh_command(conn, effective_config or {}, app_config, command_type)
+
+
+def test_base_command_scp_and_copy_id_clear_forwardings():
+    assert _has_o_option(_base_cmd('scp'), 'ClearAllForwardings=yes')
+    assert _has_o_option(_base_cmd('ssh-copy-id'), 'ClearAllForwardings=yes')
+    assert not _has_o_option(_base_cmd('ssh'), 'ClearAllForwardings')
+    assert not _has_o_option(_base_cmd('sftp'), 'ClearAllForwardings')
+
+
+def test_base_command_copy_id_skips_unsupported_flags():
+    # ssh-copy-id rejects -v/-C/-A and BatchMode defeats its interactive purpose.
+    cfg = _ConfigStub({'verbosity': 2, 'compression': True, 'batch_mode': True})
+    cmd = _base_cmd('ssh-copy-id', app_config=cfg,
+                    effective_config={'forwardagent': 'yes', 'forwardx11': 'yes'})
+    assert '-v' not in cmd
+    assert '-C' not in cmd
+    assert '-A' not in cmd
+    assert '-X' not in cmd
+    assert not _has_o_option(cmd, 'BatchMode')
+    # ...while scp still honors the app-level flags.
+    scp_cmd = _base_cmd('scp', app_config=cfg)
+    assert '-v' in scp_cmd
+    assert '-C' in scp_cmd
+    assert _has_o_option(scp_cmd, 'BatchMode=yes')
+
+
+def test_base_command_copy_id_never_injects_identity(tmp_path):
+    # -i for ssh-copy-id selects the key to INSTALL; the config identity must
+    # not leak in or it would change which key gets copied.
+    key = tmp_path / 'id_test'
+    key.write_text('k')
+    effective = {'identityfile': [str(key)], 'identitiesonly': 'yes'}
+    cmd = _base_cmd('ssh-copy-id', effective_config=effective)
+    assert '-i' not in cmd
+    assert not _has_o_option(cmd, 'IdentitiesOnly')
+    scp_cmd = _base_cmd('scp', effective_config=effective)
+    assert '-i' in scp_cmd and str(key) in scp_cmd
+
+
+def test_base_command_x11_flag_only_for_ssh():
+    # scp -X selects the transfer protocol and sftp -X sets an sftp option, so
+    # a bare -X must only ever be emitted for ssh.
+    effective = {'forwardx11': 'yes'}
+    assert '-X' in _base_cmd('ssh', effective_config=effective)
+    assert '-X' not in _base_cmd('scp', effective_config=effective)
+    assert '-X' not in _base_cmd('sftp', effective_config=effective)
+    assert '-X' not in _base_cmd('ssh-copy-id', effective_config=effective)


### PR DESCRIPTION
## Summary
Refactor SSH command construction to use a single shared builder (`_build_base_ssh_command`) across all SSH-based operations (SCP, ssh-copy-id, terminal, and external commands). This eliminates duplicated option logic and ensures consistent handling of SSH config, app-level settings, and per-binary constraints.

## Key Changes

- **Extract shared SCP prefix builder:** New `_build_scp_argv_prefix()` in `scp_utils.py` and `insert_legacy_scp_flag()` helper consolidate the common SCP command prefix (port, identity files, strict host checking, ClearAllForwardings, auth options) that was previously hand-rolled in `_build_scp_argv()`.

- **Unify ssh-copy-id command building:** Replace hand-rolled port/strict-host-key logic in `sshcopyid_window.py::_build_argv()` with a call to `_build_base_ssh_command(..., 'ssh-copy-id')`, eliminating duplicate SSH config parsing and option assembly.

- **Add per-binary option guards in `_build_base_ssh_command()`:**
  - Skip `-v`, `-C`, `BatchMode` for ssh-copy-id (unsupported flags that would break the command).
  - Skip `-i` (IdentityFile) injection for ssh-copy-id (the `-i` flag there selects the key to *install*, not an auth identity; config identity must not leak in).
  - Skip `-X` (X11 forwarding) for scp and sftp (scp `-X` selects transfer protocol; sftp `-X` sets an sftp option; bare `-X` would swallow the next argument).
  - Skip `-A` (agent forwarding) for ssh-copy-id (unsupported).
  - Add `ClearAllForwardings=yes` for scp and ssh-copy-id (port forwards are useless for file transfer and harmful if `ExitOnForwardFailure=yes` is set).

- **Simplify SCP window profile building:** Remove duplicated strict-host-key-checking and identity-file logic from `_build_scp_connection_profile()` (now handled by the shared builder).

- **Add comprehensive test coverage:** New tests in `test_ssh_connection_builder_extended.py` verify per-binary option guards, ClearAllForwardings injection, and correct handling of identity files and X11 forwarding across ssh, scp, sftp, and ssh-copy-id.

## Implementation Details

- The shared builder respects the single-source-of-truth principle: SSH config (via `get_effective_ssh_config()`) is primary; app-level overrides are applied selectively per binary; no new hand-rolled option paths are introduced.
- SCP and ssh-copy-id both now use `resolve_native_auth()` for consistent auth handling (askpass/keyring or sshpass).
- All changes maintain backward compatibility: existing terminal, SCP, and ssh-copy-id workflows are unaffected; only the internal command construction is consolidated.

https://claude.ai/code/session_01TLPaY3a9b625Cq5pgZfTFZ