### PR TITLE
fix(file-manager): import icon-level constants in pane_controls

### DIFF
--- a/sshpilot/file_manager/icon_levels.py
+++ b/sshpilot/file_manager/icon_levels.py
@@ -1,0 +1,14 @@
+"""Icon-size level constants shared by file-manager pane and pane controls.
+
+Kept as a leaf module (no intra-package imports) so both ``pane`` and
+``pane_controls`` can import it without forming an import cycle.
+"""
+
+# Both tuples are indexed by the same level; level 0 = smallest,
+# len-1 = largest. Defaults match the GNOME Files / Adwaita HIG for
+# rich list rows (24 px) and grid cells (72 px).
+_LIST_ICON_SIZES = (16, 24, 32, 48, 64)
+_GRID_ICON_SIZES = (48, 72, 96, 128, 192)
+_DEFAULT_ICON_LEVEL = 1
+_MIN_ICON_LEVEL = 0
+_MAX_ICON_LEVEL = len(_LIST_ICON_SIZES) - 1

--- a/sshpilot/file_manager/pane.py
+++ b/sshpilot/file_manager/pane.py
@@ -39,14 +39,13 @@ if TYPE_CHECKING:
     from ..file_manager_window import FileManagerWindow
 
 
-# Icon size steps for the SFTP file manager. Both tuples are indexed by the
-# same level; level 0 = smallest, len-1 = largest. Defaults match the GNOME
-# Files / Adwaita HIG for rich list rows (24 px) and grid cells (72 px).
-_LIST_ICON_SIZES = (16, 24, 32, 48, 64)
-_GRID_ICON_SIZES = (48, 72, 96, 128, 192)
-_DEFAULT_ICON_LEVEL = 1
-_MIN_ICON_LEVEL = 0
-_MAX_ICON_LEVEL = len(_LIST_ICON_SIZES) - 1
+from .icon_levels import (
+    _DEFAULT_ICON_LEVEL,
+    _GRID_ICON_SIZES,
+    _LIST_ICON_SIZES,
+    _MAX_ICON_LEVEL,
+    _MIN_ICON_LEVEL,
+)
 
 
 def _file_manager_window_cls():

--- a/sshpilot/file_manager/pane_controls.py
+++ b/sshpilot/file_manager/pane_controls.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from gi.repository import Adw, Gio, GLib, GObject, Gtk
 
+from .icon_levels import _DEFAULT_ICON_LEVEL, _MAX_ICON_LEVEL, _MIN_ICON_LEVEL
+
 
 class PathEntry(Gtk.Entry):
     """Simple entry used for the editable pathbar."""

--- a/tests/test_file_manager_pane_controls_imports.py
+++ b/tests/test_file_manager_pane_controls_imports.py
@@ -1,0 +1,121 @@
+"""Regression tests for ``sshpilot.file_manager.pane_controls``.
+
+Issue #981 (``NameError: name '_MIN_ICON_LEVEL' is not defined``) happened
+because ``pane_controls.py`` was extracted from the original
+``file_manager_window`` module and kept referencing three module-level
+constants (``_MIN_ICON_LEVEL``, ``_MAX_ICON_LEVEL``, ``_DEFAULT_ICON_LEVEL``)
+without bringing the imports along. The references live inside class
+methods, so the bug stayed hidden until the zoom-slider was actually built
+at runtime.
+
+These tests catch the class of mistake statically:
+
+* The three specific constants must be resolvable from ``pane_controls``.
+* No function or method in ``pane_controls`` may ``LOAD_GLOBAL`` a name
+  that isn't resolvable as a module attribute or a Python builtin.
+"""
+
+from __future__ import annotations
+
+import builtins
+import dis
+import importlib
+import inspect
+import sys
+import types
+
+
+def _ensure_paramiko_stub() -> None:
+    """Match the stub other file-manager tests install (see test_file_pane_typeahead)."""
+    if "paramiko" in sys.modules:
+        return
+
+    class _DummySSHClient:
+        def set_missing_host_key_policy(self, *args, **kwargs):
+            pass
+
+        def connect(self, *args, **kwargs):
+            pass
+
+        def open_sftp(self):
+            return types.SimpleNamespace(close=lambda: None)
+
+        def close(self):
+            pass
+
+    sys.modules["paramiko"] = types.SimpleNamespace(
+        SSHClient=_DummySSHClient,
+        AutoAddPolicy=type("AutoAddPolicy", (), {}),
+    )
+
+
+def _import_pane_controls():
+    _ensure_paramiko_stub()
+    return importlib.import_module("sshpilot.file_manager.pane_controls")
+
+
+def _iter_code_objects(module):
+    """Yield every code object reachable from ``module``'s top level."""
+    seen: set[int] = set()
+    stack = []
+    for value in vars(module).values():
+        if inspect.isfunction(value) or inspect.ismethod(value):
+            stack.append(value.__code__)
+        elif inspect.isclass(value) and value.__module__ == module.__name__:
+            for attr in vars(value).values():
+                if inspect.isfunction(attr):
+                    stack.append(attr.__code__)
+                elif isinstance(attr, (staticmethod, classmethod)):
+                    stack.append(attr.__func__.__code__)
+    while stack:
+        code = stack.pop()
+        if id(code) in seen:
+            continue
+        seen.add(id(code))
+        yield code
+        for const in code.co_consts:
+            if inspect.iscode(const):
+                stack.append(const)
+
+
+def test_icon_level_constants_are_importable():
+    """Issue #981: pane_controls must expose the three icon-level constants.
+
+    They don't need to be defined in this module, but they must be reachable
+    via module globals so the zoom-slider code can read them.
+    """
+    pane_controls = _import_pane_controls()
+
+    for name in ("_MIN_ICON_LEVEL", "_MAX_ICON_LEVEL", "_DEFAULT_ICON_LEVEL"):
+        assert hasattr(pane_controls, name), (
+            f"pane_controls must expose {name!r} so the zoom-slider code "
+            f"can resolve it at runtime (regression of #981)"
+        )
+
+
+def test_pane_controls_has_no_unresolved_global_names():
+    """Every LOAD_GLOBAL in pane_controls must resolve to a module attr or builtin.
+
+    This is the generic version of #981: any future extraction that forgets
+    to bring a constant or helper along will fail here instead of crashing
+    a user at runtime.
+    """
+    pane_controls = _import_pane_controls()
+
+    module_names = set(vars(pane_controls))
+    builtin_names = set(dir(builtins))
+
+    unresolved: dict[str, list[str]] = {}
+    for code in _iter_code_objects(pane_controls):
+        for instr in dis.get_instructions(code):
+            if instr.opname not in ("LOAD_GLOBAL", "LOAD_NAME"):
+                continue
+            name = instr.argval
+            if name in module_names or name in builtin_names:
+                continue
+            unresolved.setdefault(code.co_qualname, []).append(name)
+
+    assert not unresolved, (
+        "Unresolved global names in sshpilot.file_manager.pane_controls "
+        f"(regression of #981 class): {unresolved}"
+    )


### PR DESCRIPTION
## Summary

Fixes the `NameError: name '_MIN_ICON_LEVEL' is not defined` reported in #981.

- Extract `_MIN_ICON_LEVEL` / `_MAX_ICON_LEVEL` / `_DEFAULT_ICON_LEVEL` (and the related `_LIST_ICON_SIZES` / `_GRID_ICON_SIZES` tuples) into a new leaf module `sshpilot/file_manager/icon_levels.py`.
- `pane.py` and `pane_controls.py` both import from it; package `__init__` re-exports keep working unchanged.

## Why a new module rather than importing from `pane`

`pane.py` already imports `PaneToolbar` from `pane_controls`, so adding `from .pane import ...` inside `pane_controls.py` would form a cycle. A constants-only leaf module avoids that without restructuring the rest of the package.

## Verification

```sh
uv run python -c "from sshpilot.file_manager import pane, pane_controls, icon_levels; print(pane_controls._MIN_ICON_LEVEL, pane._MIN_ICON_LEVEL)"
# -> 0 0
```

Manual: open a host's embedded file manager and the view-toggle dropdown / icon-size slider; no `NameError`, slider renders with the expected tick marks.

Closes #981