### PR TITLE
feat(logging): capture traceback when embedded file manager fails

### DIFF
--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -7789,7 +7789,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                         ssh_config=ssh_config,
                     )
                 except Exception as exc:  # pragma: no cover - defensive
-                    logger.error("Embedded file manager failed: %s", exc)
+                    logger.error("Embedded file manager failed: %s", exc, exc_info=True)
                     self._handle_file_manager_placeholder_error(
                         placeholder_info,
                         str(nickname or host_value or _('Remote Host')),
@@ -7822,7 +7822,7 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     ssh_config=ssh_config,
                 )
             except Exception as exc:
-                logger.error("Embedded file manager failed: %s", exc)
+                logger.error("Embedded file manager failed: %s", exc, exc_info=True)
                 self._handle_file_manager_placeholder_error(
                     fallback_placeholder,
                     str(nickname or host_value or _('Remote Host')),


### PR DESCRIPTION
## Summary

Adds `exc_info=True` to both `logger.error("Embedded file manager failed: %s", exc)` call sites in `sshpilot/window.py::open_file_manager`.

Without this, field-side logs show bare messages like:

```
ERROR window: Embedded file manager failed: name '_MIN_ICON_LEVEL' is not defined
```

…with no file, no line number, and no traceback — see #981, which needed source-reading to localize even though the traceback would have pointed straight at `pane_controls.py`.

The user-facing error toast is produced separately in `_handle_file_manager_placeholder_error` and is unchanged.

## Test plan
- Force a failure in the embedded file-manager path (e.g. monkeypatch `create_internal_file_manager_tab` to raise) and confirm the application log now contains a full traceback under the `Embedded file manager failed:` line.
- Confirm the toast text shown to the user is unchanged.

Closes #982