### PR TITLE
feat(search): support multiple keywords for host selection

### DIFF
--- a/sshpilot/search_utils.py
+++ b/sshpilot/search_utils.py
@@ -8,16 +8,28 @@ def connection_matches(connection: Any, query: str) -> bool:
 
     The search checks the connection's nickname, host/IP address and tags in
     a case-insensitive manner.
+
+    The query may contain several whitespace-separated keywords. Every keyword
+    must match at least one field (logical AND across keywords, OR across
+    fields), so ``"prod web"`` selects a host tagged both ``production`` and
+    ``web``. A single keyword keeps the previous substring behaviour, so IPs
+    such as ``"10.0.0.5"`` still match as one term.
     """
     if not query:
         return True
-    text = query.lower()
+    keywords = query.lower().split()
+    if not keywords:
+        return True
     fields = [
         getattr(connection, "nickname", ""),
         getattr(connection, "host", ""),
         " ".join(getattr(connection, "tags", None) or []),
     ]
-    return any(text in (field or "").lower() for field in fields)
+    fields = [(field or "").lower() for field in fields]
+    return all(
+        any(keyword in field for field in fields)
+        for keyword in keywords
+    )
 
 
 __all__ = ["connection_matches"]

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -44,3 +44,32 @@ def test_missing_or_none_tags_do_not_crash():
     setattr(conn, "tags", None)
     assert connection_matches(conn, "server4")
     assert not connection_matches(conn, "prod")
+
+
+def test_multiple_keywords_all_must_match():
+    conn = make_connection("web-server", "10.0.0.8")
+    setattr(conn, "tags", ["production", "frontend"])
+    # Each keyword matches a different field (nickname, tag, host).
+    assert connection_matches(conn, "web prod")
+    assert connection_matches(conn, "server 10.0 frontend")
+    # One keyword absent -> no match.
+    assert not connection_matches(conn, "web staging")
+
+
+def test_multiple_keywords_order_independent():
+    conn = make_connection("alpha", "192.168.1.10")
+    setattr(conn, "tags", ["db"])
+    assert connection_matches(conn, "alpha db")
+    assert connection_matches(conn, "db alpha")
+
+
+def test_single_keyword_with_dots_still_matches():
+    conn = make_connection("server5", "10.0.0.5")
+    assert connection_matches(conn, "10.0.0.5")
+
+
+def test_extra_whitespace_is_ignored():
+    conn = make_connection("server6", "10.0.0.9")
+    setattr(conn, "tags", ["web"])
+    assert connection_matches(conn, "  server   web  ")
+    assert connection_matches(conn, "   ")


### PR DESCRIPTION
connection_matches now splits the query on whitespace and requires every keyword to match at least one field (AND across keywords, OR across nickname/host/tags). 

A single keyword keeps the previous substring behaviour, so IPs like "10.0.0.5" still match as one term.