### PR TITLE
Fix TLS certificate verification in frozen/relocated builds

### DIFF
--- a/.github/workflows/macos-pyinstaller-x86.yml
+++ b/.github/workflows/macos-pyinstaller-x86.yml
@@ -53,7 +53,7 @@ jobs:
           "$PYTHON_PATH" -m venv .venv-homebrew --system-site-packages
           source .venv-homebrew/bin/activate
           python -m pip install --upgrade pip wheel
-          python -m pip install paramiko cryptography keyring psutil PyInstaller
+          python -m pip install paramiko cryptography keyring psutil certifi PyInstaller
 
       - name: Build application bundle with PyInstaller
         run: |

--- a/.github/workflows/macos-pyinstaller.yml
+++ b/.github/workflows/macos-pyinstaller.yml
@@ -61,9 +61,9 @@ jobs:
           echo "=== DEBUG: Upgrading pip and wheel ==="
           python -m pip install --upgrade pip wheel
           echo "=== DEBUG: Installing Python packages ==="
-          python -m pip install paramiko cryptography keyring psutil PyInstaller
+          python -m pip install paramiko cryptography keyring psutil certifi PyInstaller
           echo "=== DEBUG: Verifying Python package installations ==="
-          pip list | grep -E "(paramiko|cryptography|keyring|psutil|PyInstaller)"
+          pip list | grep -E "(paramiko|cryptography|keyring|psutil|certifi|PyInstaller)"
           echo "=== DEBUG: Virtual environment setup completed ==="
 
       - name: Build application bundle with PyInstaller

--- a/packaging/pyinstaller/sshpilot.spec
+++ b/packaging/pyinstaller/sshpilot.spec
@@ -163,6 +163,9 @@ hiddenimports += ["gi._gi_cairo", "gi.repository.cairo", "cairo"]
 hiddenimports += ["keyring"]
 # Add all keyring backends
 hiddenimports += ["keyring.backends", "keyring.backends.macOS", "keyring.backends.libsecret", "keyring.backends.SecretService"]
+# Ship certifi so the HTTPS update check can verify TLS certs inside the bundle
+# (PyInstaller's certifi hook collects cacert.pem once certifi is importable).
+hiddenimports += ["certifi"]
 
 block_cipher = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "cryptography>=42.0",
     "keyring>=24.3",
     "psutil>=5.9.0",
+    "certifi>=2023.7.22",
 ]
 # Note: This package also requires system dependencies that must be installed separately:
 # - GTK4, libadwaita, VTE (for terminal backend)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,12 @@ psutil>=5.9.0
 # Wake-on-LAN
 wakeonlan>=3.0.0
 
+# Networking / TLS
+# Provides a CA bundle so HTTPS (the GitHub update check) can verify
+# certificates in frozen/relocated builds that ship no system CA store
+# (notably the macOS PyInstaller bundle).
+certifi
+
 
 
 

--- a/sshpilot/update_checker.py
+++ b/sshpilot/update_checker.py
@@ -5,6 +5,7 @@ Checks GitHub releases for newer versions
 
 import logging
 import json
+import ssl
 from typing import Optional, Tuple
 from urllib.request import urlopen, Request
 from urllib.error import URLError, HTTPError
@@ -18,6 +19,21 @@ logger = logging.getLogger(__name__)
 GITHUB_API_URL = "https://api.github.com/repos/mfat/sshpilot/releases/latest"
 GITHUB_RELEASES_URL = "https://github.com/mfat/sshpilot/releases"
 FLATHUB_URL = "https://flathub.org/apps/io.github.mfat.sshpilot"
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """Build an SSL context for HTTPS requests.
+
+    Prefers certifi's CA bundle when available so that frozen/relocated
+    builds (notably the macOS PyInstaller bundle, which ships no system CA
+    store) can verify TLS certificates. Falls back to the stdlib default
+    context, which is correct on Linux/system-Python installs.
+    """
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
 
 
 def parse_version(version_str: str) -> Tuple[int, ...]:
@@ -71,7 +87,7 @@ def get_latest_version() -> Optional[str]:
         
         request = Request(GITHUB_API_URL, headers=headers)
         
-        with urlopen(request, timeout=5) as response:
+        with urlopen(request, timeout=5, context=_ssl_context()) as response:
             data = json.loads(response.read().decode('utf-8'))
             
             # Get tag_name (e.g., "v4.4.1")
@@ -84,10 +100,12 @@ def get_latest_version() -> Optional[str]:
             return version
             
     except (URLError, HTTPError, json.JSONDecodeError, KeyError) as e:
-        logger.warning(f"Failed to check for updates: {e}")
+        # Include the exception type: some errors (e.g. a URLError wrapping an
+        # SSL failure with no reason text) render as a blank string otherwise.
+        logger.warning(f"Failed to check for updates: {type(e).__name__}: {e}")
         return None
     except Exception as e:
-        logger.error(f"Unexpected error checking for updates: {e}")
+        logger.error(f"Unexpected error checking for updates: {type(e).__name__}: {e}")
         return None
 
 


### PR DESCRIPTION
## Summary
Adds support for TLS certificate verification in frozen and relocated builds (notably the macOS PyInstaller bundle) by integrating the `certifi` CA bundle. The update checker now uses an SSL context that prefers certifi's CA bundle when available, falling back to the system default for standard installations.

## Changes
- **SSL context builder** (`_ssl_context()` in `update_checker.py`): New function that creates an SSL context preferring certifi's CA bundle when available, with fallback to stdlib default for system Python installs
- **HTTPS request update**: Modified `get_latest_version()` to pass the SSL context to `urlopen()`, enabling certificate verification in bundled builds
- **Error logging improvement**: Enhanced exception logging to include exception type names, improving debuggability when errors render as blank strings (e.g., SSL failures)
- **Dependency addition**: Added `certifi>=2023.7.22` to `pyproject.toml` and `requirements.txt`
- **Build configuration**: Updated macOS PyInstaller workflows and spec file to include certifi in the bundle, ensuring the CA bundle is available at runtime

## Implementation Details
The `_ssl_context()` function gracefully handles the case where certifi is not available by catching all exceptions and returning the stdlib default context. This ensures compatibility across different installation methods:
- **Frozen builds** (PyInstaller): certifi is bundled and used for certificate verification
- **System Python/Linux**: Falls back to the system's default CA store
- **Development**: Works with either certifi or system defaults

The update checker's HTTPS requests now reliably verify GitHub API certificates in all deployment scenarios.

https://claude.ai/code/session_01ApTk14bWfvysTUvcVJAtNV