### PR TITLE
feat: Add Catppuccin themes (Latte, Frappé, Macchiato, Mocha)

### DIFF
--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -482,6 +482,62 @@ class Config(GObject.Object):
                     '#9893a5', '#b4637a', '#286983', '#ea9d34',
                     '#56949f', '#907aa9', '#d7827e', '#464261'
                 ]
+            },
+            'catppuccin_latte': {
+                'name': 'Catppuccin Latte',
+                'foreground': '#4c4f69',
+                'background': '#eff1f5',
+                'cursor_color': '#dc8a78',
+                'highlight_background': '#ccd0da',
+                'highlight_foreground': '#4c4f69',
+                'palette': [
+                    '#5c5f77', '#d20f39', '#40a02b', '#df8e1d',
+                    '#1e66f5', '#8839ef', '#179299', '#acb0be',
+                    '#6c6f85', '#d20f39', '#40a02b', '#df8e1d',
+                    '#1e66f5', '#8839ef', '#179299', '#bcc0cc'
+                ]
+            },
+            'catppuccin_frappe': {
+                'name': 'Catppuccin Frappé',
+                'foreground': '#c6d0f5',
+                'background': '#303446',
+                'cursor_color': '#f2d5cf',
+                'highlight_background': '#414559',
+                'highlight_foreground': '#c6d0f5',
+                'palette': [
+                    '#51576d', '#e78284', '#a6d189', '#e5c890',
+                    '#8caaee', '#ca9ee6', '#81c8be', '#b5bfe2',
+                    '#626880', '#e78284', '#a6d189', '#e5c890',
+                    '#8caaee', '#ca9ee6', '#81c8be', '#a5adce'
+                ]
+            },
+            'catppuccin_macchiato': {
+                'name': 'Catppuccin Macchiato',
+                'foreground': '#cad3f5',
+                'background': '#24273a',
+                'cursor_color': '#f4dbd6',
+                'highlight_background': '#363a4f',
+                'highlight_foreground': '#cad3f5',
+                'palette': [
+                    '#494d64', '#ed8796', '#a6da95', '#eed49f',
+                    '#8aadf4', '#c6a0f6', '#8bd5ca', '#b8c0e0',
+                    '#5b6078', '#ed8796', '#a6da95', '#eed49f',
+                    '#8aadf4', '#c6a0f6', '#8bd5ca', '#a5adcb'
+                ]
+            },
+            'catppuccin_mocha': {
+                'name': 'Catppuccin Mocha',
+                'foreground': '#cdd6f4',
+                'background': '#1e1e2e',
+                'cursor_color': '#f5e0dc',
+                'highlight_background': '#313244',
+                'highlight_foreground': '#cdd6f4',
+                'palette': [
+                    '#45475a', '#f38ba8', '#a6e3a1', '#f9e2af',
+                    '#89b4fa', '#cba6f7', '#94e2d5', '#bac2de',
+                    '#585b70', '#f38ba8', '#a6e3a1', '#f9e2af',
+                    '#89b4fa', '#cba6f7', '#94e2d5', '#a6adc8'
+                ]
             }
         }
 
@@ -739,7 +795,7 @@ class Config(GObject.Object):
 
     def remove_custom_theme(self, name: str):
         """Remove a custom theme"""
-        if name in self.terminal_themes and name not in ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark', 'rose_pine', 'rose_pine_moon', 'rose_pine_dawn']:
+        if name in self.terminal_themes and name not in ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark', 'rose_pine', 'rose_pine_moon', 'rose_pine_dawn', 'catppuccin_latte', 'catppuccin_frappe', 'catppuccin_macchiato', 'catppuccin_mocha']:
             del self.terminal_themes[name]
             
             # Remove from config
@@ -972,7 +1028,7 @@ class Config(GObject.Object):
                 config_data = self.config_data.copy()
             
             # Add custom themes
-            builtin = ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark', 'rose_pine', 'rose_pine_moon', 'rose_pine_dawn']
+            builtin = ['default', 'dark', 'light', 'black_on_white', 'solarized_dark', 'solarized_light', 'monokai', 'dracula', 'nord', 'gruvbox_dark', 'one_dark', 'tomorrow_night', 'material_dark', 'rose_pine', 'rose_pine_moon', 'rose_pine_dawn', 'catppuccin_latte', 'catppuccin_frappe', 'catppuccin_macchiato', 'catppuccin_mocha']
             config_data['custom_themes'] = {name: theme for name, theme in self.terminal_themes.items() if name not in builtin}
             
             with open(file_path, 'w') as f:

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -776,6 +776,10 @@ class PreferencesWindow(Adw.Window):
             color_schemes.append("Rosé Pine")
             color_schemes.append("Rosé Pine Moon")
             color_schemes.append("Rosé Pine Dawn")
+            color_schemes.append("Catppuccin Latte")
+            color_schemes.append("Catppuccin Frappé")
+            color_schemes.append("Catppuccin Macchiato")
+            color_schemes.append("Catppuccin Mocha")
             self.color_scheme_row.set_model(color_schemes)
             
             # Set current color scheme from config
@@ -791,7 +795,8 @@ class PreferencesWindow(Adw.Window):
                 "Default", "Black on White", "Solarized Dark", "Solarized Light",
                 "Monokai", "Dracula", "Nord",
                 "Gruvbox Dark", "One Dark", "Tomorrow Night", "Material Dark",
-                "Rosé Pine", "Rosé Pine Moon", "Rosé Pine Dawn"
+                "Rosé Pine", "Rosé Pine Moon", "Rosé Pine Dawn",
+                "Catppuccin Latte", "Catppuccin Frappé", "Catppuccin Macchiato", "Catppuccin Mocha"
             ]
             try:
                 current_index = scheme_names.index(current_scheme_display)
@@ -3052,6 +3057,10 @@ class PreferencesWindow(Adw.Window):
             "Rosé Pine": "rose_pine",
             "Rosé Pine Moon": "rose_pine_moon",
             "Rosé Pine Dawn": "rose_pine_dawn",
+            "Catppuccin Latte": "catppuccin_latte",
+            "Catppuccin Frappé": "catppuccin_frappe",
+            "Catppuccin Macchiato": "catppuccin_macchiato",
+            "Catppuccin Mocha": "catppuccin_mocha",
         }
     
     def get_reverse_theme_mapping(self):
@@ -3466,7 +3475,8 @@ class PreferencesWindow(Adw.Window):
             "Default", "Black on White", "Solarized Dark", "Solarized Light",
             "Monokai", "Dracula", "Nord",
             "Gruvbox Dark", "One Dark", "Tomorrow Night", "Material Dark",
-            "Rosé Pine", "Rosé Pine Moon", "Rosé Pine Dawn"
+            "Rosé Pine", "Rosé Pine Moon", "Rosé Pine Dawn",
+            "Catppuccin Latte", "Catppuccin Frappé", "Catppuccin Macchiato", "Catppuccin Mocha"
         ]
         selected_scheme = scheme_names[selected] if selected < len(scheme_names) else "Default"
         
@@ -3689,6 +3699,46 @@ class PreferencesWindow(Adw.Window):
                 'yellow': '#ea9d34',
                 'magenta': '#907aa9',
                 'cyan': '#d7827e'
+            },
+            'catppuccin_latte': {
+                'background': '#eff1f5',
+                'foreground': '#4c4f69',
+                'blue': '#1e66f5',
+                'green': '#40a02b',
+                'red': '#d20f39',
+                'yellow': '#df8e1d',
+                'magenta': '#8839ef',
+                'cyan': '#179299'
+            },
+            'catppuccin_frappe': {
+                'background': '#303446',
+                'foreground': '#c6d0f5',
+                'blue': '#8caaee',
+                'green': '#a6d189',
+                'red': '#e78284',
+                'yellow': '#e5c890',
+                'magenta': '#ca9ee6',
+                'cyan': '#81c8be'
+            },
+            'catppuccin_macchiato': {
+                'background': '#24273a',
+                'foreground': '#cad3f5',
+                'blue': '#8aadf4',
+                'green': '#a6da95',
+                'red': '#ed8796',
+                'yellow': '#eed49f',
+                'magenta': '#c6a0f6',
+                'cyan': '#8bd5ca'
+            },
+            'catppuccin_mocha': {
+                'background': '#1e1e2e',
+                'foreground': '#cdd6f4',
+                'blue': '#89b4fa',
+                'green': '#a6e3a1',
+                'red': '#f38ba8',
+                'yellow': '#f9e2af',
+                'magenta': '#cba6f7',
+                'cyan': '#94e2d5'
             }
         }
         return schemes.get(scheme_key, schemes['default'])


### PR DESCRIPTION
|  | Latte | Frappé | Macchiato | Mocha |
|--------|--------|--------|--------|--------|
| Settings | <img width="992" height="695" alt="image" src="https://github.com/user-attachments/assets/9b9a5663-f91c-4805-9289-41893bc055ce" /> | <img width="992" height="695" alt="image" src="https://github.com/user-attachments/assets/c2695aba-7480-40d0-8ed2-ec34d1bce1c5" /> | <img width="992" height="695" alt="image" src="https://github.com/user-attachments/assets/b3116ebe-6d73-4b5b-89aa-05e2f9d440fb" /> | <img width="992" height="695" alt="image" src="https://github.com/user-attachments/assets/e31048ed-6a77-4c78-83be-de6003fbbc8c" /> |
| In-terminal | <img width="743" height="644" alt="image" src="https://github.com/user-attachments/assets/e8c94c69-5ab4-4b14-a1de-324aac60087a" /> | <img width="743" height="644" alt="image" src="https://github.com/user-attachments/assets/5899bb48-602a-42c0-bda3-c64a26b8c734" /> | <img width="743" height="644" alt="image" src="https://github.com/user-attachments/assets/9c671c14-cc4e-48af-94ef-91ed60c3de9e" /> | <img width="743" height="644" alt="image" src="https://github.com/user-attachments/assets/8e770308-79e4-4b6f-8836-2a3b7b20fe12" /> |