### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,3 +270,36 @@ sudo dnf install python3-gobject gtk4 libadwaita vte291-gtk4 gtksourceview5 libs
 - Do not add/remove features without user's confirmation
 - User prefers no UI files; define all interfaces in code
 - User requires explicit permission before modifying/deploying codebase
+
+## Cursor Cloud specific instructions
+
+These notes cover non-obvious caveats for this VM. Standard commands live in
+**Setup Commands** / **Development Environment** above and in `README.md`.
+
+- **Python deps live in the system interpreter, not a venv.** The app uses the
+  system `python3-gi` (PyGObject) + GTK/VTE/libadwaita GObject-introspection
+  packages, which a fresh virtualenv cannot see. Install pip deps with
+  `pip install --break-system-packages -r requirements.txt` (the startup update
+  script does this). A plain `python3 -m venv` will fail to import `gi`.
+- **`pytest` is required to run the suite** but is not in `requirements.txt`; the
+  update script installs it.
+- **GUI runs headed on `DISPLAY=:1`** (X11 is already available). Launch with
+  `python3 run.py --verbose`; it is a long-running process, so run it in a tmux
+  session. `libEGL ... DRI3` warnings are harmless (software rendering).
+- **SVG icons need `librsvg2-common`** (provides the gdk-pixbuf SVG loader). It
+  is installed in the snapshot; without it the app logs many
+  `Failed to load icon ... Unrecognized image file format` warnings (cosmetic
+  only — the app still runs).
+- **`pytest` runs headless against a stubbed `gi`** (see `tests/conftest.py`,
+  which injects dummy GTK modules when `gi` is not already imported). The
+  default `pytest` collects only `tests/`. There are **pre-existing** failures
+  and collection errors on `main` (mostly terminal/window test modules whose
+  needs exceed the stub, plus a few tests referencing methods not on
+  `Connection`); ~498 tests pass. These are not caused by the environment. CI
+  does not run the test suite (only packaging workflows exist).
+- **Nickname field forbids whitespace.** When creating a connection in the GUI,
+  the Save button silently stays disabled if the nickname contains a space
+  ("no whitespaces allowed"); use e.g. `DemoServer`, not `Demo Server`.
+- **The GResource bundle (`sshpilot/resources/sshpilot.gresource`) is committed**
+  and loaded at startup (the app exits if it cannot load it). Only rebuild it
+  with `./build_gresource.sh` if you change files under `sshpilot/resources/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for sshPilot in Cursor Cloud and records durable, non-obvious caveats for future cloud agents under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## What was set up

- **System packages** (captured in the VM snapshot): GTK4/libadwaita/VTE-GTK4/GtkSourceView5/libsecret/WebKit6 GObject-introspection packages, `sshpass`, `ssh-askpass`, and `librsvg2-common` (SVG icon loader).
- **Python deps** (the startup update script): `pip install --break-system-packages -r requirements.txt` + `pytest`. Installed into the system interpreter because the app relies on system `python3-gi` that a venv can't see.

## Verification

- ✅ `python3 -m py_compile run.py sshpilot/*.py` (no configured linter exists; compile check used as lint)
- ✅ `python3 -m pytest -q` — 498 passed (pre-existing failures/collection errors on `main`, unrelated to env)
- ✅ `python3 run.py --verbose` — GUI launches on `DISPLAY=:1`
- ✅ Hello-world: created an SSH connection (`DemoServer`) entirely through the GUI; the app persisted it to `~/.ssh/config` and it appears in the sidebar.

[sshpilot_create_connection_demo.mp4](https://cursor.com/agents/bc-65f502dc-dc78-40e6-b7f7-6208916925fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsshpilot_create_connection_demo.mp4)

[DemoServer connection in sidebar](https://cursor.com/agents/bc-65f502dc-dc78-40e6-b7f7-6208916925fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsshpilot_connection_in_sidebar.webp)

## Notable caveat documented

The connection dialog's nickname field forbids whitespace, so the Save button stays silently disabled for names like `Demo Server` (use `DemoServer`).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65f502dc-dc78-40e6-b7f7-6208916925fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65f502dc-dc78-40e6-b7f7-6208916925fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

