### PR TITLE
Phase 0: CI/tooling safety net + two crash fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,5 +44,9 @@ jobs:
 
       # Unit suite only — the `integration` tests run the real tool binaries and
       # live in the containerized "Test environment" workflow.
+      # pytest-cov is already installed above; emit a coverage summary so the
+      # least-covered modules are visible (informational, does not fail the run).
       - name: Run pytest
-        run: pytest -ra -m "not integration"
+        run: >
+          pytest -ra -m "not integration"
+          --cov=sshpilot --cov-report=term-missing --cov-report=xml

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,28 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ty
+        run: pip install ty
+
+      # Non-blocking for now: PyGObject is dynamic and unstubbed, so a large
+      # share of findings are noise (the worst two categories are silenced in
+      # pyproject [tool.ty.rules]). This surfaces real type issues without
+      # gating merges; flip continue-on-error off once the tree is clean.
+      - name: ty check
+        continue-on-error: true
+        run: ty check sshpilot/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sshpilot"
-version = "3.8.5"
+# Single source of truth: sshpilot/__init__.py::__version__ (updated by the
+# release bump). setuptools reads it via AST (no package import at build time),
+# so the wheel version can never drift from the app version again.
+dynamic = ["version"]
 authors = [
   { name="mFat", email="newmfat@gmail.com" },
 ]
@@ -38,6 +41,9 @@ test = [
 #   Note: webkitgtk is Linux-only; PyXterm.js backend not available on macOS
 # - GtkSourceView 5.0, libsecret
 # See README.md or AGENTS.md for complete system dependency list.
+
+[tool.setuptools.dynamic]
+version = {attr = "sshpilot.__version__"}
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,16 @@ test = [
 [tool.setuptools.dynamic]
 version = {attr = "sshpilot.__version__"}
 
+[tool.ty.rules]
+# PyGObject is dynamic and ships no type stubs, so the type checker can't see
+# gi.repository members or attributes assigned in __init__/via GObject. These
+# two categories are pure noise here (700+ false positives) and would drown the
+# real findings — silence them so the typecheck gate surfaces genuine issues.
+# The gate runs non-blocking in CI (.github/workflows/typecheck.yml); tighten
+# module-by-module as real findings are cleared.
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+
 [tool.setuptools.packages.find]
 where = [""]
 include = ["sshpilot*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,11 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-# Conservative initial rule set: syntax errors, misused comparisons, and the
-# pyflakes checks that almost always flag runtime bugs. Broader rules can be
+# Conservative, growing rule set: syntax errors, misused comparisons, and the
+# pyflakes checks that almost always flag runtime bugs. Broader rules are
 # enabled incrementally as the tree is cleaned up.
-select = ["E9", "F63", "F7"]
+#   F601 — duplicate dict key literal (one value silently lost)
+#   F7   — misc pyflakes bug checks (e.g. break/return outside loop/function)
+#   F811 — redefinition of an unused name (dead, shadowed defs)
+#   F821 — undefined name (real NameError at runtime)
+select = ["E9", "F63", "F7", "F601", "F811", "F821"]

--- a/sshpilot/command_blocks.py
+++ b/sshpilot/command_blocks.py
@@ -14,6 +14,10 @@ from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango
 
 from .context_menu import IconContextMenu
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .config import Config
+
 logger = logging.getLogger(__name__)
 
 try:

--- a/sshpilot/config.py
+++ b/sshpilot/config.py
@@ -110,45 +110,9 @@ class Config(GObject.Object):
         except Exception as e:
             logger.error(f"Failed to save JSON config: {e}")
 
-    # --- Shortcut helpers -------------------------------------------------
-
-    def get_shortcut_overrides(self) -> Dict[str, Any]:
-        """Return the stored shortcut overrides mapping."""
-        try:
-            overrides = self.get_setting('shortcuts', {})
-            if isinstance(overrides, dict):
-                return overrides
-        except Exception:
-            pass
-        return {}
-
-    def get_shortcut_override(self, action_name: str):
-        """Return the stored shortcut override for an action.
-
-        Returns ``None`` when no override is stored, an empty list when the
-        shortcut is disabled, or the list of accelerator strings otherwise.
-        """
-        overrides = self.get_shortcut_overrides()
-        value = overrides.get(action_name)
-        if value is None:
-            return None
-        if isinstance(value, list):
-            return value
-        # Coerce malformed entries back to sane defaults
-        return None
-
-    def set_shortcut_override(self, action_name: str, accelerators: Optional[List[str]]):
-        """Persist a shortcut override.
-
-        ``None`` clears the override, an empty list disables the shortcut, and
-        any other list stores custom accelerators for the action.
-        """
-        overrides = self.get_shortcut_overrides().copy()
-        if accelerators is None:
-            overrides.pop(action_name, None)
-        else:
-            overrides[action_name] = accelerators
-        self.set_setting('shortcuts', overrides)
+    # Shortcut helpers (get_shortcut_overrides / get_shortcut_override /
+    # set_shortcut_override) live further down — the canonical versions read
+    # config_data directly and persist + emit change signals.
 
     def get_default_config(self) -> Dict[str, Any]:
         """Get default configuration values"""
@@ -207,7 +171,6 @@ class Config(GObject.Object):
                 'tile_color': None,  # None for default, or hex color for custom
             },
             'connections_meta': {},  # per-connection metadata
-            'shortcuts': {},  # action -> list of custom accelerators
             'ssh': {
                 'compression': False,
                 'auto_add_host_keys': True,

--- a/sshpilot/file_manager/properties_dialog.py
+++ b/sshpilot/file_manager/properties_dialog.py
@@ -468,8 +468,6 @@ class PropertiesDialog(Adw.Window):
 
     def _start_folder_size_calculation(self):
         """Start calculating folder size in background thread."""
-        import threading
-        
         folder_path = os.path.join(self._current_path, self._entry.name)
         
         # Create and start the background thread

--- a/sshpilot/port_utils.py
+++ b/sshpilot/port_utils.py
@@ -3,6 +3,7 @@ Port utilities for sshPilot
 Provides port information and availability checking functionality
 """
 
+import os
 import socket
 import subprocess
 import logging
@@ -397,7 +398,6 @@ class PortChecker:
     def _find_process_by_inode(self, inode: int) -> Tuple[Optional[int], Optional[str]]:
         """Find process PID and name by socket inode"""
         try:
-            import os
             import glob
             
             # Search through /proc/*/fd/* for the socket inode

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1281,7 +1281,7 @@ class TerminalWidget(Gtk.Box):
                 if "sshpass" in str(e) and "No such file or directory" in str(e):
                     logger.error("sshpass binary not found, falling back to askpass")
                     # Fall back to askpass method
-                    self._fallback_to_askpass(ssh_cmd, env_list)
+                    self._fallback_to_askpass(ssh_cmd, env_list, working_dir)
                 else:
                     self._on_connection_failed(str(e))
                 return
@@ -1320,7 +1320,7 @@ class TerminalWidget(Gtk.Box):
             logger.error(f"Failed to setup SSH terminal: {e}")
             self._on_connection_failed(str(e))
     
-    def _fallback_to_askpass(self, ssh_cmd, env_list):
+    def _fallback_to_askpass(self, ssh_cmd, env_list, working_dir=None):
         """Fallback when sshpass fails - allow interactive prompting"""
         try:
             logger.info("Falling back to interactive password prompt")

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -1812,14 +1812,6 @@ class TerminalWidget(Gtk.Box):
             logger.debug(f"Failed to present forwarding error dialog: {e}")
         return False
 
-    def set_group_color(self, color: Optional[str]):
-        """Update the stored group color and refresh the theme if needed."""
-        self.group_color = color if color else None
-        try:
-            self.apply_theme()
-        except Exception:
-            logger.debug("Failed to reapply theme after group color update", exc_info=True)
-
     @staticmethod
     def _mix_rgba(base: Gdk.RGBA, other: Gdk.RGBA, ratio: float) -> Gdk.RGBA:
         ratio = max(0.0, min(1.0, ratio))

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -1231,7 +1231,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
                     logger.error("Export diagnostics failed: %s", exc, exc_info=True)
                     GLib.idle_add(self._on_export_diagnostics_done, False, str(exc), path)
 
-            import threading
             threading.Thread(target=_work, daemon=True).start()
 
         file_dialog.save(self, None, _on_save)
@@ -1916,15 +1915,6 @@ class MainWindow(Adw.ApplicationWindow, WindowActions):
             pass
 
         # Tab navigation shortcuts are handled by application actions (see sshpilot/main.py)
-        
-    def on_window_size_changed(self, window, param):
-        """Handle window size changes and save the new dimensions"""
-        width = self.get_default_width()
-        height = self.get_default_height()
-        logger.debug(f"Window size changed to: {width}x{height}")
-        
-        # Save the new window geometry
-        self.config.set_window_geometry(width, height)
 
     def setup_ui(self):
         """Set up the user interface"""

--- a/tests/test_group_toggle_in_place.py
+++ b/tests/test_group_toggle_in_place.py
@@ -736,7 +736,7 @@ def test_tree_target_insert_before_nested_child():
     assert _tree_target_insert_before(manager, "y") == ("a", 1)
 
 
-def test_group_motion_shows_reorder_at_sibling_seam(monkeypatch):
+def test_group_motion_shows_reorder_in_gap_before_sibling(monkeypatch):
     """Dragging C into the gap before B shows reorder above B (tree index 1)."""
     shown = []
     monkeypatch.setattr(

--- a/tests/test_macos_terminal.py
+++ b/tests/test_macos_terminal.py
@@ -3,7 +3,6 @@ import subprocess
 import pytest
 
 import sys
-import types
 
 # Stub out gi modules so window.py can be imported without GTK
 gi_module = types.ModuleType("gi")


### PR DESCRIPTION
First slice of an engineering-health program (stability, tooling/CI, refactoring). This PR is the low-risk tooling safety net plus the bugs it surfaced. No behavior changes except the two crash fixes.

## What's here

**Tooling / CI**
- **Version drift fixed** — `pyproject.toml` carried a stale `3.8.5` that the release bump never touched (the real source of truth is `sshpilot/__init__.py`). Switched to setuptools dynamic version (`attr: sshpilot.__version__`, read via AST — no package import at build time), so the wheel version can't drift again. Resolves to `5.4.6`.
- **Coverage reporting** — `pytest-cov` was installed in CI but never invoked; now emits term-missing + xml (baseline ~23%, informational).
- **Pyflakes bug-catchers enabled** — added `F601`, `F811`, `F821` to the ruff lint set (incrementally; broader groups deferred because `I`/`E402` conflict with the `gi.require_version`-before-import pattern).
- **Non-blocking `ty` typecheck workflow** — runs over `sshpilot/` with `continue-on-error`. PyGObject is dynamic/unstubbed, so the two noise categories (`unresolved-import`/`unresolved-attribute`, 700+ false positives) are silenced in `[tool.ty.rules]`, leaving ~87 genuine findings visible.

**Bug fixes (surfaced by enabling pyflakes F821)**
- `port_utils.py`: `os` was imported only inside `_find_process_by_inode`, but `_get_process_name` called `os.path.basename` in its cmdline fallback → `NameError` whenever `/proc/<pid>/comm` couldn't be read. Now imported at module scope.
- `terminal.py`: `_fallback_to_askpass` referenced `working_dir`, a local of the spawn method → `NameError` on the sshpass→askpass fallback spawn. Threaded through as a parameter (defaults to `None`, preserving the existing home-dir fallback).
- `command_blocks.py`: added a `TYPE_CHECKING` import for the `'Config'` annotation (static-analysis only; harmless at runtime).

**Dead-code cleanup (behavior-preserving — Python already used the last definition)**
- Removed shadowed duplicate methods (`config.py` shortcut helpers, `terminal.py` `set_group_color`, `window.py` `on_window_size_changed`), a duplicate `'shortcuts'` default key, and redundant local imports.
- Two different tests shared one name so the first never ran — renamed the second, recovering a silently-shadowed test.

## Verification
- Unit suite: **980 passed**, 0 failed (was 979; +1 is the recovered test).
- `ruff check sshpilot/ tests/` green under the expanded ruleset.
- Dynamic version resolves to `5.4.6`; coverage report confirmed locally.