### PR TITLE
Re-land #1021 (F841 + max_width fix) — rebased on current dev, crash fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,5 @@ extend-exclude = [
 #   F7   — misc pyflakes bug checks (e.g. break/return outside loop/function)
 #   F811 — redefinition of an unused name (dead, shadowed defs)
 #   F821 — undefined name (real NameError at runtime)
-select = ["E9", "F63", "F7", "F601", "F811", "F821"]
+#   F841 — local variable assigned but never used (dead code / latent bugs)
+select = ["E9", "F63", "F7", "F601", "F811", "F821", "F841"]

--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -2325,7 +2325,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             return
 
         try:
-            keyfile_path = None
             # Load basic connection data
             if hasattr(self.connection, 'nickname'):
                 self.nickname_row.set_text(self.connection.nickname or "")
@@ -3992,7 +3991,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             conn = getattr(row, '_conn', None)
             if conn is None:
                 return
-            host_str = getattr(conn, 'host', '') or getattr(conn, 'hostname', '')
             jump_target = conn.nickname
             current = self.proxy_jump_row.get_text().strip()
             if current:

--- a/sshpilot/file_manager/portal_docs.py
+++ b/sshpilot/file_manager/portal_docs.py
@@ -118,7 +118,6 @@ def _grant_persistent_access(gfile):
                 flags |= 8  # export-directory
 
             app_id = os.environ.get("FLATPAK_ID", "")
-            basename = gfile.get_basename() or os.path.basename(path)
 
             permissions: List[str] = ["read"]
             if os.access(path, os.W_OK):

--- a/sshpilot/file_manager/properties_dialog.py
+++ b/sshpilot/file_manager/properties_dialog.py
@@ -37,20 +37,8 @@ class PropertiesDialog(Adw.Window):
         self.set_modal(True)
         self.set_transient_for(parent)
         
-        # Position window relative to parent
-        if parent:
-            try:
-                # Get parent window position and size
-                parent_alloc = parent.get_allocation()
-                parent_width = parent_alloc.width
-                parent_height = parent_alloc.height
-                
-                # Center the dialog on the parent window
-                # For GTK4, we'll let the window manager handle positioning
-                # The modal and transient_for properties should handle this
-            except Exception:
-                # Fallback: let window manager handle positioning
-                pass
+        # Positioning is delegated to the window manager via the modal /
+        # transient_for properties; GTK4 has no manual window placement.
 
         # Build the dialog content
         self._build_dialog()

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -3625,7 +3625,6 @@ class PreferencesWindow(Adw.Window):
     def save_advanced_ssh_settings(self):
         """Persist advanced SSH settings from the preferences UI"""
         try:
-            native_value = False
             connect_timeout = None
             connection_attempts = None
             keepalive_interval = None

--- a/sshpilot/scp_utils.py
+++ b/sshpilot/scp_utils.py
@@ -255,12 +255,6 @@ def download_file(
 
     env = (inherit_env or os.environ).copy()
     
-    # Check if the inherited environment has askpass configured (e.g., when identity agent is disabled)
-    has_inherited_askpass = bool(
-        inherit_env
-        and str(inherit_env.get('SSH_ASKPASS_REQUIRE') or '').lower() == 'force'
-    )
-
     # Create connection object for ssh_connection_builder
     auth_method = 1 if password else 0
     connection = _create_connection_for_scp(
@@ -382,12 +376,6 @@ def upload_file(
         return False
 
     env = (inherit_env or os.environ).copy()
-    
-    # Check if the inherited environment has askpass configured
-    has_inherited_askpass = bool(
-        inherit_env
-        and str(inherit_env.get('SSH_ASKPASS_REQUIRE') or '').lower() == 'force'
-    )
 
     # Create connection object for ssh_connection_builder
     auth_method = 1 if password else 0

--- a/sshpilot/scp_window.py
+++ b/sshpilot/scp_window.py
@@ -335,8 +335,6 @@ class ScpWindowController:
                 msg.present()
                 return
 
-            alias_value = profile.alias
-            hostname_value = profile.hostname
             host_value = profile.host
             username = profile.username
             port = profile.port

--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -658,7 +658,6 @@ def build_ssh_connection(
     connection = ctx.connection
     connection_manager = ctx.connection_manager
     app_config = ctx.config
-    command_type = ctx.command_type
     extra_args = ctx.extra_args or []
     
     logger.debug(f"build_ssh_connection called: native_mode={ctx.native_mode}, connection_manager={'present' if connection_manager else 'None'}")

--- a/sshpilot/terminal.py
+++ b/sshpilot/terminal.py
@@ -3886,7 +3886,6 @@ class TerminalWidget(Gtk.Box):
         root = self.get_root() if hasattr(self, 'get_root') else None
         is_quitting = bool(getattr(root, '_is_quitting', False))
 
-        was_connected = self.is_connected
         if self.is_connected:
             logger.debug(f"Disconnecting SSH session {self.session_id}...")
             self.is_connected = False

--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -1946,10 +1946,6 @@ class PyXtermTerminalBackend:
             # Escape the search term for JavaScript string
             escaped_term = search_term.replace('\\', '\\\\').replace("'", "\\'").replace('"', '\\"').replace('\n', '\\n').replace('\r', '\\r')
             # Build search options according to ISearchOptions interface
-            search_options = {
-                'caseSensitive': case_sensitive,
-                'regex': is_regex
-            }
             options_json = f"caseSensitive: {str(case_sensitive).lower()}, regex: {str(is_regex).lower()}"
             search_js = f"""
             (function() {{

--- a/sshpilot/welcome_page.py
+++ b/sshpilot/welcome_page.py
@@ -112,10 +112,6 @@ class WelcomePage(Gtk.Overlay):
         
         # Edit SSH Config action row
         edit_config_accel = self._get_action_accel_display(current_shortcuts, 'edit-ssh-config')
-        if hasattr(self.config, 'isolated_mode') and self.config.isolated_mode:
-            config_location = '~/.config/sshpilot/config'
-        else:
-            config_location = '~/.ssh/config'
         edit_config_row = Adw.ActionRow()
         edit_config_row.set_title(_('View and Edit SSH Config'))
         edit_config_row.set_activatable(True)

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -826,6 +826,23 @@ _get_connection_host = get_connection_host
 _get_connection_alias = get_connection_alias
 _format_connection_host_display = format_connection_host_display
 
+
+def _effective_max_sidebar_width(saved_value, default: int = 400) -> int:
+    """Resolve the startup max sidebar width from a saved setting value.
+
+    Returns the saved width when it is a valid integer, otherwise ``default``.
+    Kept as a module-level pure function so the parsing/fallback logic is unit
+    testable without building the GTK window.
+    """
+    if saved_value is None:
+        return default
+    try:
+        return int(saved_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid ui.max-sidebar-width %r; using default %d", saved_value, default)
+        return default
+
+
 class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin, WindowHelpMixin, WindowFileManagerMixin, WindowTabsMixin, WindowConfigDialogsMixin, WindowActions):
     """Main application window"""
 
@@ -2059,23 +2076,19 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         if not (HAS_NAV_SPLIT or HAS_OVERLAY_SPLIT):
             main_box.append(self.header_bar)
         
-        # Create main layout (fallback if split view widgets are unavailable)
-        # Load saved max-sidebar-width or use defaults
+        # Honor the saved max-sidebar-width on startup (previously it was read but
+        # ignored here, so the saved width only took effect after being changed
+        # mid-session); fall back to 400 when unset/invalid.
         saved_max_width = self.config.get_setting('ui.max-sidebar-width', None)
-        default_nav_max = 280
-        default_overlay_max = 280
-        if saved_max_width is not None:
-            max_width = int(saved_max_width)
-        else:
-            max_width = None
-        
+        effective_max_width = _effective_max_sidebar_width(saved_max_width)
+
         # Try OverlaySplitView first as it's more reliable
         if HAS_OVERLAY_SPLIT:
             self.split_view = Adw.OverlaySplitView()
             try:
                 self.split_view.set_sidebar_width_fraction(0.25)
                 self.split_view.set_min_sidebar_width(180)
-                self.split_view.set_max_sidebar_width(400)
+                self.split_view.set_max_sidebar_width(effective_max_width)
             except Exception:
                 pass
             self.split_view.set_vexpand(True)
@@ -2086,7 +2099,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             try:
                 self.split_view.set_sidebar_width_fraction(0.25)
                 self.split_view.set_min_sidebar_width(200)
-                self.split_view.set_max_sidebar_width(400)
+                self.split_view.set_max_sidebar_width(effective_max_width)
             except Exception:
                 pass
             self.split_view.set_vexpand(True)
@@ -2240,7 +2253,6 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         show_user_hostname = self.config.get_setting('ui.sidebar_show_user_hostname', True)
         show_group_count = self.config.get_setting('ui.sidebar_show_group_count', True)
         show_status = self.config.get_setting('ui.sidebar_show_connection_status', True)
-        show_port_forwarding = self.config.get_setting('ui.sidebar_show_port_forwarding', True)
         show_connection_icon = self.config.get_setting('ui.sidebar_show_connection_icon', True)
         flat_rows = self.config.get_setting('ui.sidebar_flat_rows', False)
         
@@ -5861,12 +5873,10 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
     def on_delete_connection_response(self, dialog, response, payload):
         """Handle delete connection dialog response"""
         try:
-            neighbor_row = None
             connections: List[Connection]
 
             if isinstance(payload, dict):
                 connections = payload.get('connections', []) or []
-                neighbor_row = payload.get('neighbor_row')
             elif isinstance(payload, (list, tuple)):
                 connections = list(payload)
             else:
@@ -7749,45 +7759,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     'remote_command': _norm_str(getattr(old_connection, 'remote_command', '') or (getattr(old_connection, 'data', {}).get('remote_command') if hasattr(old_connection, 'data') else '')),
                     'extra_ssh_config': _norm_str(getattr(old_connection, 'extra_ssh_config', '') or (getattr(old_connection, 'data', {}).get('extra_ssh_config') if hasattr(old_connection, 'data') else '')),
                 }
-                incoming = {
-                    'nickname': _norm_str(connection_data.get('nickname')),
-                    'hostname': _norm_str(connection_data.get('hostname') or connection_data.get('host')),
-                    'username': _norm_str(connection_data.get('username')),
-                    'port': int(connection_data.get('port') or 22),
-                    'auth_method': int(connection_data.get('auth_method') or 0),
-                    'keyfile': _norm_str(connection_data.get('keyfile')),
-                    'certificate': _norm_str(connection_data.get('certificate')),
-                    'key_select_mode': int(connection_data.get('key_select_mode') or 0),
-                    'password': _norm_str(connection_data.get('password')),
-                    'key_passphrase': _norm_str(connection_data.get('key_passphrase')),
-                    'x11_forwarding': bool(connection_data.get('x11_forwarding', False)),
-                    'forwarding_rules': _norm_rules(connection_data.get('forwarding_rules')),
-                    'pre_command': _norm_str(connection_data.get('pre_command')),
-                    'local_command': _norm_str(connection_data.get('local_command')),
-                    'remote_command': _norm_str(connection_data.get('remote_command')),
-                    'extra_ssh_config': _norm_str(connection_data.get('extra_ssh_config')),
-                }
-                # Determine if anything meaningful changed by comparing canonical SSH config blocks
-                try:
-                    existing_block = self.connection_manager.format_ssh_config_entry(existing)
-                    incoming_block = self.connection_manager.format_ssh_config_entry(incoming)
-                    # Also include auth_method/password/key_select_mode delta in change detection
-                    pw_changed_flag = bool(connection_data.get('password_changed', False))
-                    ksm_changed = (existing.get('key_select_mode', 0) != incoming.get('key_select_mode', 0))
-                    changed = (existing_block != incoming_block) or (existing['auth_method'] != incoming['auth_method']) or pw_changed_flag or ksm_changed or (existing['password'] != incoming['password'])
-                except Exception:
-                    # Fallback to dict comparison if formatter fails
-                    changed = existing != incoming
-
-                # Extra guard: if key_select_mode or auth_method differs from the object's current value, force changed
-                try:
-                    if int(connection_data.get('key_select_mode', -1)) != int(getattr(old_connection, 'key_select_mode', -1)):
-                        changed = True
-                    if int(connection_data.get('auth_method', -1)) != int(getattr(old_connection, 'auth_method', -1)):
-                        changed = True
-                except Exception:
-                    pass
-
+                # Editing always forces an update so forwarding rules stay synced;
+                # change detection was intentionally removed (it could skip needed
+                # updates), so no diff between old and new values is computed here.
                 # Always force update when editing connections - skip change detection entirely for forwarding rules
                 logger.info("Editing connection '%s' - forcing update to ensure forwarding rules are synced", existing['nickname'])
 

--- a/sshpilot/wol.py
+++ b/sshpilot/wol.py
@@ -133,7 +133,7 @@ def _resolve_host_to_ip(host: str, port: int = 22) -> Optional[str]:
     host = host.strip()
     # If it's already an IPv4 address, return as-is
     try:
-        addr = socket.inet_pton(socket.AF_INET, host)
+        socket.inet_pton(socket.AF_INET, host)  # validates; raises OSError if not an IPv4 literal
         return host
     except OSError:
         pass

--- a/tests/test_openssh_backend.py
+++ b/tests/test_openssh_backend.py
@@ -124,7 +124,6 @@ class _FakeSFTPServer(threading.Thread):
                     names = state["children"]
                     body = p.pack_uint32(rid) + p.pack_uint32(len(names))
                     for name in names:
-                        full = handle  # unused
                         child_path = None
                         # reconstruct child path from any matching fs entry
                         for cand in self.fs:

--- a/tests/test_sidebar_max_width.py
+++ b/tests/test_sidebar_max_width.py
@@ -1,0 +1,48 @@
+"""Regression tests for the startup max-sidebar-width resolution.
+
+Previously the saved ``ui.max-sidebar-width`` setting was read while building
+the split view but then ignored — the code hard-coded ``set_max_sidebar_width(400)``
+and the saved value only took effect after the user changed it mid-session
+(via the settings-changed handler). The build path now routes the saved value
+through ``_effective_max_sidebar_width`` and applies it on startup.
+
+These tests cover the pure parsing/fallback logic. They do NOT prove the GTK
+widget is actually told to use the width (that requires a real GTK display and
+is covered by manual QA) — only that the value handed to the widget is correct.
+"""
+
+import sys
+import types
+
+
+def _window_module():
+    if 'cairo' not in sys.modules:
+        sys.modules['cairo'] = types.SimpleNamespace()
+    from sshpilot import window as window_module
+    return window_module
+
+
+def test_saved_int_is_used():
+    fn = _window_module()._effective_max_sidebar_width
+    assert fn(320) == 320
+
+
+def test_saved_numeric_string_is_coerced():
+    fn = _window_module()._effective_max_sidebar_width
+    assert fn("350") == 350
+
+
+def test_none_falls_back_to_default():
+    fn = _window_module()._effective_max_sidebar_width
+    assert fn(None) == 400
+
+
+def test_invalid_value_falls_back_to_default():
+    fn = _window_module()._effective_max_sidebar_width
+    assert fn("not-a-number") == 400
+    assert fn(object()) == 400
+
+
+def test_custom_default_is_honored_when_unset():
+    fn = _window_module()._effective_max_sidebar_width
+    assert fn(None, default=280) == 280

--- a/tests/test_terminal_encoding.py
+++ b/tests/test_terminal_encoding.py
@@ -478,7 +478,7 @@ class TestEncodingIntegration:
         import importlib
         
         # Import the module to get access to the method
-        terminal_backends = importlib.import_module('sshpilot.terminal_backends')
+        importlib.import_module('sshpilot.terminal_backends')
         
         # Create a minimal backend instance to test the method
         # We'll create a mock instance that has the method


### PR DESCRIPTION
## Why this exists

PR #1021 was merged into `dev` and then **reverted** (6bcff117) because it crashed at startup:

```
AttributeError: 'MainWindow' object has no attribute 'show_preferences'
  window.py: button.connect("clicked", lambda *_: self.show_preferences())
```

**The change itself wasn't at fault — the base was stale.** #1021 branched from `dev` at #1017, *before* #1019 moved `show_preferences` into `WindowConfigDialogsMixin` and added that mixin to `MainWindow`'s bases. When #1021 merged, the conflict resolution clobbered #1019's bases line (dropping `WindowConfigDialogsMixin`) while `show_preferences` was already gone from the `window.py` body → the method resolved to nothing → crash → revert. The revert was the right call.

## What's different now

This re-land is cherry-picked onto **current `dev`** and keeps dev's bases line intact (`WindowConfigDialogsMixin` stays). 

**Verified the crash is gone:**
```
MainWindow.show_preferences.__module__ == "sshpilot.window_dialogs"   # resolves, no AttributeError
```

## Contents (unchanged from #1021)

- Enable ruff **F841**; clean up the 23 violations it surfaced (each reviewed individually — dead vestigial locals removed; two keep the side-effecting call and drop only the unused binding).
- **Fixes #1020**: the saved `ui.max-sidebar-width` was read at window build but ignored (hard-coded 400), so a saved width only applied after a mid-session change. Now resolved via a testable `_effective_max_sidebar_width()` helper applied on startup. Also present on `main`/released.
- Adds `tests/test_sidebar_max_width.py`.

## Verification
- `MainWindow.show_preferences` resolves to the mixin (crash regression check)
- `ruff check sshpilot tests` (incl. F841): clean
- Full unit suite: **1024 passed, 0 failed**
- Smoke import of touched modules: OK