### PR TITLE
Extract SSH key fingerprint helpers to ssh_key_fingerprint.py

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -44,6 +44,10 @@ except (ImportError, AttributeError):  # pragma: no cover - used in tests withou
     GObject.SignalFlags = types.SimpleNamespace(RUN_FIRST=None)
 from .port_utils import get_port_checker
 from .platform_utils import is_macos, get_ssh_dir, get_config_dir
+from .ssh_key_fingerprint import (
+    _fingerprint_for_path,
+    _fingerprint_for_pub_line,
+)
 from .path_list import PathList
 from . import wol
 from .plugins.registry import protocol_registry
@@ -882,54 +886,6 @@ def _ensure_key_badge_css():
         display, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
     )
     _KEY_BADGE_CSS_REGISTERED = True
-
-
-# --- SSH key fingerprint helpers (type · SHA256 · comment) -------------------
-_FINGERPRINT_CACHE: Dict[str, tuple] = {}
-
-
-def _parse_keygen_line(line: str) -> tuple:
-    """Parse an ``ssh-keygen -l`` line into (type_label, "SHA256:…", comment).
-
-    Example line: ``256 SHA256:abc… user@host (ED25519)``.
-    """
-    parts = (line or "").strip().split()
-    if len(parts) < 2:
-        return ("", "", "")
-    fingerprint = parts[1]
-    key_type = parts[-1].strip("()") if parts[-1].startswith("(") else ""
-    comment = " ".join(parts[2:-1]) if len(parts) > 3 else (parts[2] if len(parts) > 2 else "")
-    return (key_type, fingerprint, comment)
-
-
-def _fingerprint_for_path(path: str) -> tuple:
-    """(type_label, fingerprint, comment) for a key file, via ``ssh-keygen -lf``."""
-    expanded = os.path.expanduser(path or "")
-    if expanded in _FINGERPRINT_CACHE:
-        return _FINGERPRINT_CACHE[expanded]
-    result = ("", "", "")
-    try:
-        proc = subprocess.run(["ssh-keygen", "-lf", expanded],
-                              capture_output=True, text=True, timeout=5)
-        if proc.returncode == 0:
-            result = _parse_keygen_line(proc.stdout)
-    except Exception:
-        logger.debug("ssh-keygen fingerprint failed for %s", path, exc_info=True)
-    _FINGERPRINT_CACHE[expanded] = result
-    return result
-
-
-def _fingerprint_for_pub_line(pub_line: str) -> tuple:
-    """(type_label, fingerprint, comment) for a public-key line (e.g. ssh-add -L)."""
-    try:
-        proc = subprocess.run(["ssh-keygen", "-lf", "-"],
-                              input=(pub_line or "") + "\n",
-                              capture_output=True, text=True, timeout=5)
-        if proc.returncode == 0:
-            return _parse_keygen_line(proc.stdout)
-    except Exception:
-        logger.debug("ssh-keygen fingerprint (stdin) failed", exc_info=True)
-    return ("", "", "")
 
 
 def _accent_hex():

--- a/sshpilot/ssh_key_fingerprint.py
+++ b/sshpilot/ssh_key_fingerprint.py
@@ -1,0 +1,60 @@
+"""SSH key fingerprint helpers (type · SHA256 · comment).
+
+Extracted verbatim from connection_dialog.py into a leaf module so the parsing
+and fingerprint lookup can be imported and tested without the GTK dialog. These
+use ``ssh-keygen -l`` for *local* key fingerprinting only — they never open an
+SSH connection, so they are unrelated to the single connection/auth path.
+"""
+
+import os
+import logging
+import subprocess
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_FINGERPRINT_CACHE: Dict[str, tuple] = {}
+
+
+def _parse_keygen_line(line: str) -> tuple:
+    """Parse an ``ssh-keygen -l`` line into (type_label, "SHA256:…", comment).
+
+    Example line: ``256 SHA256:abc… user@host (ED25519)``.
+    """
+    parts = (line or "").strip().split()
+    if len(parts) < 2:
+        return ("", "", "")
+    fingerprint = parts[1]
+    key_type = parts[-1].strip("()") if parts[-1].startswith("(") else ""
+    comment = " ".join(parts[2:-1]) if len(parts) > 3 else (parts[2] if len(parts) > 2 else "")
+    return (key_type, fingerprint, comment)
+
+
+def _fingerprint_for_path(path: str) -> tuple:
+    """(type_label, fingerprint, comment) for a key file, via ``ssh-keygen -lf``."""
+    expanded = os.path.expanduser(path or "")
+    if expanded in _FINGERPRINT_CACHE:
+        return _FINGERPRINT_CACHE[expanded]
+    result = ("", "", "")
+    try:
+        proc = subprocess.run(["ssh-keygen", "-lf", expanded],
+                              capture_output=True, text=True, timeout=5)
+        if proc.returncode == 0:
+            result = _parse_keygen_line(proc.stdout)
+    except Exception:
+        logger.debug("ssh-keygen fingerprint failed for %s", path, exc_info=True)
+    _FINGERPRINT_CACHE[expanded] = result
+    return result
+
+
+def _fingerprint_for_pub_line(pub_line: str) -> tuple:
+    """(type_label, fingerprint, comment) for a public-key line (e.g. ssh-add -L)."""
+    try:
+        proc = subprocess.run(["ssh-keygen", "-lf", "-"],
+                              input=(pub_line or "") + "\n",
+                              capture_output=True, text=True, timeout=5)
+        if proc.returncode == 0:
+            return _parse_keygen_line(proc.stdout)
+    except Exception:
+        logger.debug("ssh-keygen fingerprint (stdin) failed", exc_info=True)
+    return ("", "", "")

--- a/tests/test_ssh_key_fingerprint.py
+++ b/tests/test_ssh_key_fingerprint.py
@@ -1,0 +1,86 @@
+"""Unit tests for the SSH key fingerprint helpers.
+
+These were extracted verbatim from connection_dialog.py into the leaf module
+sshpilot/ssh_key_fingerprint.py so they can be imported and tested without the
+GTK dialog. They had no direct coverage before. The subprocess-backed lookups
+are tested with a monkeypatched ssh-keygen so the tests are hermetic.
+"""
+
+import subprocess
+
+from sshpilot import ssh_key_fingerprint as skf
+from sshpilot.ssh_key_fingerprint import (
+    _parse_keygen_line,
+    _fingerprint_for_path,
+    _fingerprint_for_pub_line,
+)
+
+
+class TestParseKeygenLine:
+    def test_full_line_with_type_and_comment(self):
+        line = "256 SHA256:abc123 user@host (ED25519)"
+        assert _parse_keygen_line(line) == ("ED25519", "SHA256:abc123", "user@host")
+
+    def test_multiword_comment(self):
+        line = "3072 SHA256:deadbeef my laptop key (RSA)"
+        assert _parse_keygen_line(line) == ("RSA", "SHA256:deadbeef", "my laptop key")
+
+    def test_no_type_parenthesis(self):
+        # parts[-1] does not start with "(" -> no type label
+        line = "256 SHA256:xyz user@host"
+        assert _parse_keygen_line(line) == ("", "SHA256:xyz", "user@host")
+
+    def test_empty_and_too_short(self):
+        assert _parse_keygen_line("") == ("", "", "")
+        assert _parse_keygen_line("256") == ("", "", "")
+        assert _parse_keygen_line(None) == ("", "", "")
+
+
+class TestFingerprintForPath:
+    def setup_method(self):
+        skf._FINGERPRINT_CACHE.clear()
+
+    def test_success_parses_and_caches(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="256 SHA256:abc user@host (ED25519)", stderr="")
+
+        monkeypatch.setattr(skf.subprocess, "run", fake_run)
+        result = _fingerprint_for_path("~/key")
+        assert result == ("ED25519", "SHA256:abc", "user@host")
+        # Second call is served from cache (ssh-keygen not invoked again).
+        assert _fingerprint_for_path("~/key") == result
+        assert len(calls) == 1
+
+    def test_nonzero_returncode_yields_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            skf.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, stdout="", stderr="nope"))
+        assert _fingerprint_for_path("/missing") == ("", "", "")
+
+    def test_exception_is_swallowed(self, monkeypatch):
+        def boom(cmd, **kw):
+            raise OSError("ssh-keygen not found")
+
+        monkeypatch.setattr(skf.subprocess, "run", boom)
+        assert _fingerprint_for_path("/x") == ("", "", "")
+
+
+class TestFingerprintForPubLine:
+    def test_success(self, monkeypatch):
+        monkeypatch.setattr(
+            skf.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(
+                cmd, 0, stdout="256 SHA256:pub comment (ED25519)", stderr=""))
+        assert _fingerprint_for_pub_line("ssh-ed25519 AAAA...") == (
+            "ED25519", "SHA256:pub", "comment")
+
+    def test_failure_yields_empty(self, monkeypatch):
+        def boom(cmd, **kw):
+            raise OSError()
+
+        monkeypatch.setattr(skf.subprocess, "run", boom)
+        assert _fingerprint_for_pub_line("bad") == ("", "", "")


### PR DESCRIPTION
> **📚 Stacked PRs — base of the stack.** This is the first of 5 stacked refactor PRs (#1029 → #1030 → #1031 → #1032 → #1033). Please **merge this one first**; the others build on it and should be merged in order to avoid conflicts.

---

## What

Small Phase-2 extraction — move the pure SSH key **fingerprint** cluster out of the `connection_dialog.py` god-object into a new leaf module `sshpilot/ssh_key_fingerprint.py`:
`_parse_keygen_line`, `_fingerprint_for_path`, `_fingerprint_for_pub_line`, and the `_FINGERPRINT_CACHE` backing them.

## Why

- These run `ssh-keygen -l` for **local** key fingerprinting only (type · SHA256 · comment) — they never open an SSH connection, so they are unrelated to the single connection/auth path.
- No GTK dependency → a leaf module is their natural home and makes them testable in isolation.
- The GTK-specific helpers (`_accent_hex`, `_type_tag_markup`, `_ensure_key_badge_css`) stay in `connection_dialog.py`, which now imports the two functions it calls directly.

## Verification
- Pure code move, no behaviour change
- `ruff` (full config) clean
- All **105** submodules import
- Full unit suite: **1052 passed, 0 failed** (1043 + 9 new tests; `ssh-keygen` is monkeypatched so they're hermetic). This logic had no direct coverage before.

Based on dev.