### PR TITLE
Secret storage: KDBX enumeration, shared session timeout, agent UI hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,14 +123,14 @@ Backend specifics:
   selection-independent). When a saved password exists, `prompt_unlock` auto-unlocks with
   it but still shows the "Unlocking…" spinner; a stale saved password is dropped and the
   manual prompt shown.
-- **`agent`** means *don't store secrets at all*: an `authoritative` null backend.
-  When selected, `store`/`lookup` consult only it (no fallback/fallthrough) so
-  nothing is written to or read from other stores; the user relies on ssh-agent
-  (the existing key-preload path) and ssh's own prompts. `delete` is a no-op on
-  other stores — switch to `auto` or the backend that holds the secret to purge it.
-- New session/null behavior rests on optional `SecretBackend` hooks
-  (`session_backed`, `authoritative`, `is_unlocked`/`unlock`/`lock`) that default
-  to no-ops, so `libsecret`/`keyring`/`pass` are unchanged.
+- **`agent`** means *don't store secrets at all*: a null backend. When explicitly
+  selected, `SecretManager` consults only it (no fallback/fallthrough) so nothing
+  is written to or read from other stores; the user relies on ssh-agent (the existing
+  key-preload path) and ssh's own prompts. `store` returns success as a no-op;
+  `delete` is a no-op on other stores — switch to `auto` or the backend that holds
+  the secret to purge it.
+- Session-backed backends set `session_backed=True` on `SecretBackend` and implement
+  `is_unlocked`/`unlock`/`lock`; passive stores leave these as no-ops.
 
 ### Advanced SSH options (Preferences → command)
 Preferences ▸ SSH Settings persists each advanced option under the `ssh.*`

--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -401,6 +401,13 @@ def _run_askpass_dialog(key_path: str, log_fn) -> "str | None":
         store_row.set_title("Store passphrase")
         store_row.set_active(False)
 
+        persists_secrets = True
+        try:
+            from .secret_storage import get_secret_manager
+            persists_secrets = get_secret_manager().persists_secrets()
+        except Exception:
+            persists_secrets = True
+
         cancel_btn = Gtk.Button(label="Cancel")
         ok_btn = Gtk.Button(label="Unlock")
         ok_btn.add_css_class("suggested-action")
@@ -440,7 +447,19 @@ def _run_askpass_dialog(key_path: str, log_fn) -> "str | None":
 
         group = Adw.PreferencesGroup()
         group.add(password_row)
-        group.add(store_row)
+        if persists_secrets:
+            group.add(store_row)
+        else:
+            no_store = Gtk.Label(
+                label=(
+                    "Secret storage is set to SSH Agent Only — passphrases are not "
+                    "saved by sshPilot."
+                ),
+            )
+            no_store.set_wrap(True)
+            no_store.set_xalign(0.0)
+            no_store.add_css_class("dim-label")
+            group.add(no_store)
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18)
         content.set_margin_top(18)

--- a/sshpilot/credential_adapters.py
+++ b/sshpilot/credential_adapters.py
@@ -4,7 +4,8 @@ Each adapter presents one secret store as :class:`Credential` operations:
 
 - :class:`SecretBackendAdapter` wraps a registered ``SecretBackend`` (spec-keyed
   store/lookup/delete) and adds enumeration where the backend supports it (its
-  ``iter_credentials`` hook). keyring/agent have no hook → ``can_enumerate=False``.
+  ``iter_credentials`` hook). keyring/agent have no hook; ``keepassxc`` enumerates
+  the dedicated ``sshPilot`` group when unlocked.
 - :class:`KdbxAdapter` is a standalone pykeepass-backed export/import target (a ``.kdbx``
   file), **not** a connect-time backend in this phase.
 

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -1657,6 +1657,14 @@ class PreferencesWindow(Adw.Window):
             self._forget_master_btn = forget_btn
             secrets_group.add(self.forget_master_row)
 
+            self.agent_no_store_row = Adw.ActionRow()
+            self.agent_no_store_row.set_title(_("No secret storage"))
+            self.agent_no_store_row.set_subtitle(_(
+                "Passwords and passphrases are not saved by sshPilot. Use ssh-agent "
+                "and SSH's own prompts instead."
+            ))
+            secrets_group.add(self.agent_no_store_row)
+
             # Show the bw/timeout/forget rows only when they apply to the
             # currently-selected backend.
             self._update_secret_rows_visibility(current_backend)
@@ -2210,10 +2218,17 @@ class PreferencesWindow(Adw.Window):
             if hasattr(self, 'forget_master_row'):
                 self.forget_master_row.set_visible(session)
                 self._refresh_forget_master_row()
+            if hasattr(self, 'agent_no_store_row'):
+                self.agent_no_store_row.set_visible(name == 'agent')
             # Tell the user how to set up the bw CLI for the selected backend.
             # (Plain text only — no '<' or '&' — Adw rows parse Pango markup.)
             if hasattr(self, 'secret_backend_row'):
-                if name == 'bitwarden':
+                if name == 'agent':
+                    hint = _(
+                        "Credentials are not persisted — ssh-agent and SSH handle "
+                        "authentication."
+                    )
+                elif name == 'bitwarden':
                     hint = _("Uses the bw CLI. Run “bw login” in a terminal first "
                              "(for a self-hosted Vaultwarden, run “bw config server” first).")
                 else:

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -290,6 +290,38 @@ def selected_master_spec(manager: Optional["SecretManager"] = None) -> SecretSpe
 
 
 # ---------------------------------------------------------------------------
+# Session idle timeout (shared by session-backed backends)
+# ---------------------------------------------------------------------------
+
+
+class _SessionIdleTimeout:
+    """Sliding idle window for session-backed backends.
+
+    Driven by ``SSHPILOT_SECRET_SESSION_TIMEOUT`` (seconds; ``0`` = no timeout).
+    """
+
+    def __init__(self) -> None:
+        self._deadline: Optional[float] = None
+
+    @staticmethod
+    def timeout_seconds() -> int:
+        try:
+            return int(os.environ.get("SSHPILOT_SECRET_SESSION_TIMEOUT", "0") or 0)
+        except Exception:
+            return 0
+
+    def touch(self) -> None:
+        secs = self.timeout_seconds()
+        self._deadline = (time.monotonic() + secs) if secs > 0 else None
+
+    def expired(self) -> bool:
+        return self._deadline is not None and time.monotonic() > self._deadline
+
+    def reset(self) -> None:
+        self._deadline = None
+
+
+# ---------------------------------------------------------------------------
 # Backends
 # ---------------------------------------------------------------------------
 
@@ -602,7 +634,7 @@ class BitwardenBackend(SecretBackend):
         self._argv_override: Optional[List[str]] = None
         self._token: Optional[str] = None                # session token (this process)
         self._unlocked = False                           # we unlocked it this session
-        self._deadline: Optional[float] = None           # monotonic; None = no timeout
+        self._idle = _SessionIdleTimeout()
         self._items: Optional[Dict[str, dict]] = None    # name→item; None = not loaded
         self._cache_complete = False                     # _items holds the whole vault
         self._lock = threading.RLock()
@@ -689,30 +721,19 @@ class BitwardenBackend(SecretBackend):
         cannot succeed. Only called in the unlock-decision flow."""
         return self._status() == "unauthenticated"
 
-    # -- idle timeout ----------------------------------------------------
-    @staticmethod
-    def _session_timeout_seconds() -> int:
-        """Idle seconds before the session is dropped (0 = never). Driven by the
-        ``SSHPILOT_SECRET_SESSION_TIMEOUT`` env var set from ``secrets.session_timeout``."""
-        try:
-            return int(os.environ.get("SSHPILOT_SECRET_SESSION_TIMEOUT", "0") or 0)
-        except Exception:
-            return 0
-
     def _touch_deadline(self) -> None:
         """Refresh the idle deadline (sliding window). Caller holds ``self._lock``."""
-        secs = self._session_timeout_seconds()
-        self._deadline = (time.monotonic() + secs) if secs > 0 else None
+        self._idle.touch()
 
     def _expired(self) -> bool:
         """Caller holds ``self._lock``."""
-        return self._deadline is not None and time.monotonic() > self._deadline
+        return self._idle.expired()
 
     def _drop_session(self) -> None:
         """Forget the in-process session + cache (re-lock). Caller holds ``self._lock``."""
         self._token = None
         self._unlocked = False
-        self._deadline = None
+        self._idle.reset()
         self._items = None
         self._cache_complete = False
         os.environ.pop("BW_SESSION", None)
@@ -1017,7 +1038,7 @@ class KdbxBackend(SecretBackend):
     def __init__(self) -> None:
         self._kp = None
         self._cache: Optional[Dict[str, Optional[str]]] = None   # title -> password
-        self._deadline: Optional[float] = None
+        self._idle = _SessionIdleTimeout()
         self._lock = threading.RLock()
 
     # -- config (paths come from env, set by connection_manager / preferences) ----
@@ -1035,26 +1056,17 @@ class KdbxBackend(SecretBackend):
         db = self._database()
         return PyKeePass is not None and bool(db) and os.path.exists(db)
 
-    # -- idle timeout (mirrors BitwardenBackend) ----
-    @staticmethod
-    def _session_timeout_seconds() -> int:
-        try:
-            return int(os.environ.get("SSHPILOT_SECRET_SESSION_TIMEOUT", "0") or 0)
-        except Exception:
-            return 0
-
     def _touch_deadline(self) -> None:
-        secs = self._session_timeout_seconds()
-        self._deadline = (time.monotonic() + secs) if secs > 0 else None
+        self._idle.touch()
 
     def _expired(self) -> bool:
-        return self._deadline is not None and time.monotonic() > self._deadline
+        return self._idle.expired()
 
     def _drop_session(self) -> None:
         """Forget the in-process DB + cache + derived key. Caller holds ``self._lock``."""
         self._kp = None
         self._cache = None
-        self._deadline = None
+        self._idle.reset()
         os.environ.pop(self._ENV_KEY, None)
 
     @staticmethod
@@ -1239,6 +1251,55 @@ class KdbxBackend(SecretBackend):
             logger.error("KDBX delete failed: %s", exc)
             return False
 
+    def iter_credentials(self) -> List[Tuple[Dict[str, str], Optional[str]]]:
+        """Enumerate entries in the dedicated ``sshPilot`` group as ``(attributes, secret)``.
+
+        Empty when locked. Type comes from the ``sshpilot_type`` custom property when set,
+        else from :func:`parse_account` on the entry title (``login.username`` is the hint
+        for email-style SSH usernames)."""
+        kp = self._db()
+        if kp is None:
+            return []
+        out: List[Tuple[Dict[str, str], Optional[str]]] = []
+        try:
+            grp = kp.find_groups(name=self._GROUP, first=True)
+            if grp is None:
+                return []
+            entries = kp.find_entries(group=grp) or []
+            for entry in entries:
+                title = entry.title or ""
+                if not title:
+                    continue
+                cred_type = ""
+                getter = getattr(entry, "get_custom_property", None)
+                if callable(getter):
+                    try:
+                        cred_type = getter(self._TYPE_PROP) or ""
+                    except Exception:
+                        cred_type = ""
+                username_hint = entry.username or None
+                if cred_type:
+                    attrs: Dict[str, str] = {"type": cred_type}
+                    if cred_type == "key_passphrase":
+                        attrs["key_path"] = title
+                    elif cred_type == "vault_master":
+                        attrs["key_path"] = title
+                    else:
+                        parsed = parse_account(title, username_hint=username_hint)
+                        attrs["host"] = parsed.get("host", "")
+                        attrs["username"] = parsed.get("username", "")
+                else:
+                    attrs = parse_account(title, username_hint=username_hint)
+                    if not attrs:
+                        continue
+                value = entry.password or None
+                if not value:
+                    continue
+                out.append((attrs, value))
+        except Exception as exc:
+            logger.debug("KDBX iter_credentials failed: %s", exc)
+        return out
+
 
 class SSHAgentBackend(SecretBackend):
     """The "don't store secrets at all" choice.
@@ -1276,13 +1337,23 @@ class SSHAgentBackend(SecretBackend):
 class SecretManager:
     """Selects and orchestrates secret backends.
 
-    - ``store`` — :meth:`_ordered_backends` only: first available backend in the
-      selected order, falling back on failure (mirrors the old libsecret→keyring
-      fallback).
-    - ``lookup`` / ``delete`` — :meth:`_all_available_backends`: selected order
-      first, then any other registered backend that is available, so secrets
-      stored under a non-selected backend (e.g. ``pass`` while on ``auto``) still
-      resolve and can be cleared.
+    **``auto``** (platform default: libsecret then keyring on Linux, keyring on macOS):
+
+    - ``store`` — first available backend in platform order, falling back on failure.
+    - ``lookup`` / ``delete`` — every available backend (selected order first, then any
+      other registered backend) so secrets stored under a previous backend still resolve
+      and can be cleared after switching.
+
+    **Explicit selection** (any named backend, including ``agent`` and session vaults):
+
+    - ``store`` / ``lookup`` / ``delete`` consult **only** that backend — no fallback on
+      store failure, no read-through to a stale copy elsewhere, and no cross-backend
+      delete. A locked session vault returns nothing/``False`` until unlocked.
+    - If the selected backend is **unavailable**, operations resolve to nothing/``False``
+      and a warning is logged (deduped).
+
+    :meth:`lookup_everywhere` deliberately ignores explicit selection and scans all
+    available backends (for export/migration); locked session vaults contribute nothing.
     """
 
     def __init__(self) -> None:
@@ -1395,6 +1466,11 @@ class SecretManager:
         """Whether the named backend has a lock lifecycle (Bitwarden/Vaultwarden)."""
         backend = self._backends.get((name or "").strip().lower())
         return bool(backend is not None and getattr(backend, "session_backed", False))
+
+    def persists_secrets(self) -> bool:
+        """Whether :meth:`store` would persist secrets (``False`` for explicit ``agent``)."""
+        backend = self.selected_backend()
+        return backend is None or backend.name != "agent"
 
     # -- selection helpers ------------------------------------------------
     def selected_backend(self) -> Optional[SecretBackend]:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -644,6 +644,29 @@ def _show_password_passphrase_dialog(
     store_checkbox = Gtk.CheckButton(label=store_label)
     store_checkbox.set_active(False)
     content_box.append(store_checkbox)
+
+    persists_secrets = True
+    try:
+        from .secret_storage import get_secret_manager
+        persists_secrets = get_secret_manager().persists_secrets()
+    except Exception:
+        persists_secrets = True
+    if not persists_secrets:
+        store_checkbox.set_visible(False)
+        no_store_label = Gtk.Label(
+            label=_(
+                "Secret storage is set to SSH Agent Only — passwords and passphrases "
+                "are not saved by sshPilot."
+            ),
+        )
+        no_store_label.set_wrap(True)
+        no_store_label.set_xalign(0)
+        for css in ("dim-label", "caption"):
+            try:
+                no_store_label.add_css_class(css)
+            except Exception:
+                pass
+        content_box.append(no_store_label)
     
     # Add container to dialog's extra child area
     dialog.set_extra_child(content_box)

--- a/tests/test_kdbx_backend.py
+++ b/tests/test_kdbx_backend.py
@@ -66,9 +66,13 @@ class FakePyKeePass:
     def root_group(self):
         return FakeGroup('root')
 
-    def find_entries(self, title=None, first=False):
-        matches = [e for e in self._b.entries if e.title == title]
-        return (matches[0] if matches else None) if first else matches
+    def find_entries(self, title=None, group=None, first=False):
+        entries = list(self._b.entries)
+        if title is not None:
+            entries = [e for e in entries if e.title == title]
+        if first:
+            return entries[0] if entries else None
+        return entries
 
     def find_groups(self, name=None, first=False):
         return FakeGroup(name)
@@ -174,7 +178,7 @@ def test_idle_timeout_drops_session(kdbx, monkeypatch):
     backend, _db = kdbx
     backend.unlock('correct')
     assert backend.is_unlocked() is True
-    backend._deadline = time.monotonic() - 1                # force expiry
+    backend._idle._deadline = time.monotonic() - 1          # force expiry
     assert backend.is_unlocked() is False
     assert os.environ.get('SSHPILOT_KDBX_KEY') is None
 
@@ -224,3 +228,22 @@ def test_selected_master_spec_keyed_by_db_path(monkeypatch):
     mgr = ss.SecretManager()
     mgr.set_selected('keepassxc')
     assert ss.selected_master_spec(mgr).keyring_account == 'keepassxc-master:/vaults/work.kdbx'
+
+
+def test_iter_credentials_enumerates_sshpilot_group(kdbx):
+    backend, _db = kdbx
+    backend.unlock('correct')
+    backend.store(password_spec('h.example', 'alice'), 'pw-a')
+    backend.store(sudo_password_spec('h.example', 'alice'), 'sudo-a')
+    backend.store(passphrase_spec('/home/u/.ssh/id_ed25519'), 'pass')
+    rows = backend.iter_credentials()
+    assert len(rows) == 3
+    by_type = {attrs.get('type'): secret for attrs, secret in rows}
+    assert by_type['ssh_password'] == 'pw-a'
+    assert by_type['sudo_password'] == 'sudo-a'
+    assert by_type['key_passphrase'] == 'pass'
+
+
+def test_iter_credentials_empty_when_locked(kdbx):
+    backend, _db = kdbx
+    assert backend.iter_credentials() == []

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -305,6 +305,16 @@ def test_ssh_agent_backend_is_null():
     assert a.delete(password_spec('h', 'u')) is False
 
 
+def test_persists_secrets_false_for_agent(manager):
+    mgr, *_ = manager
+    mgr.register_backend('agent', ss.SSHAgentBackend())
+    assert mgr.persists_secrets() is True
+    mgr.set_selected('agent')
+    assert mgr.persists_secrets() is False
+    mgr.set_selected('auto')
+    assert mgr.persists_secrets() is True
+
+
 def test_agent_selected_stores_nothing_and_blocks_fallback(manager):
     mgr, primary, fallback = manager
     mgr.register_backend('agent', ss.SSHAgentBackend())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up improvements to the pluggable secret storage layer based on architecture review.

## Changes

- **`KdbxBackend.iter_credentials`** — enumerates the dedicated `sshPilot` group when unlocked, using the `sshpilot_type` custom property (with `parse_account` fallback) so credential export/orphan detection works for the KeePass backend.
- **`_SessionIdleTimeout`** — shared sliding idle-window helper used by both `BitwardenBackend` and `KdbxBackend` (replaces duplicated timeout code).
- **Documentation alignment** — `SecretManager` class docstring and `AGENTS.md` now describe `auto` vs explicit selection semantics accurately (removed nonexistent `authoritative` hook).
- **Agent mode UI** — `SecretManager.persists_secrets()` drives:
  - Preferences ▸ Secret Storage info row + combo subtitle when SSH Agent Only is selected
  - Hidden "Store password/passphrase" checkbox with explanatory caption in password dialogs
  - Same treatment in the standalone askpass passphrase prompt

## Tests

- `test_iter_credentials_enumerates_sshpilot_group`
- `test_iter_credentials_empty_when_locked`
- `test_persists_secrets_false_for_agent`

All 72 tests in `test_secret_storage.py` and `test_kdbx_backend.py` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-866ec507-d83f-468b-b9c3-e19e82f2d9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-866ec507-d83f-468b-b9c3-e19e82f2d9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

