### PR TITLE
Credential manager improvements: canonical host keys, export API, docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,9 @@ identically. Modes:
   ssh prompts natively on the TTY.
 
 Credentials are stored/retrieved through a **pluggable secret backend**
-(`secret_storage.py`): `connection_manager.get_password` /
-`askpass_utils.lookup_passphrase` delegate to `SecretManager`. The backend is
+(`secret_storage.py`): `connection_manager.get_connection_password` /
+`get_password` and `askpass_utils.lookup_passphrase` delegate to `SecretManager`.
+The backend is
 selectable via the `secrets.backend` setting — `auto` (platform default:
 libsecret then keyring on Linux, keyring on macOS), or an explicit `libsecret` /
 `keyring` / `pass` (passwordstore.org) / `bitwarden` / `keepassxc` / `agent`, or
@@ -131,6 +132,33 @@ Backend specifics:
   the secret to purge it.
 - Session-backed backends set `session_backed=True` on `SecretBackend` and implement
   `is_unlocked`/`unlock`/`lock`; passive stores leave these as no-ops.
+
+### Credential manager (export / backup layer)
+
+Connect-time storage uses `SecretManager` directly. For a **normalized list** of
+every sshPilot-managed secret (backup `.spbk`, future vault migration), use the
+credential manager stack — see `docs/CREDENTIAL_MANAGER.md`.
+
+- **`credential_model.py`** — `Credential` dataclass; `canonical_password_host` /
+  `password_host_candidates` (canonical SSH password key =
+  `hostname` → `host` → `nickname`).
+- **`credential_manager.py`** — `CredentialManager.list_credentials()` gathers
+  passwords, sudo passwords, and key passphrases (including `resolved_identity_files`
+  from `ssh -G`). Read-only; never prompts; locked vaults contribute nothing.
+- **`credential_adapters.py`** — `SecretBackendAdapter` / `KdbxAdapter` for
+  credential-centric `load_all` / `save` / `delete` (export targets).
+
+**SSH password API (connect-time):**
+
+- **Store:** `ConnectionManager.store_connection_password(connection, password)`
+  — always under the canonical host; clears legacy alias copies.
+- **Lookup:** `ConnectionManager.get_connection_password(connection)` — probes
+  legacy aliases and **migrates** on hit.
+- **Low-level:** `store_password(host, user)` / `get_password(host, user)` for
+  callers that already know the exact key (plugin secrets, etc.).
+
+`SecretManager.lookup_everywhere` and `all_available_backends()` support export;
+normal `lookup` / `delete` honor backend selection.
 
 ### Advanced SSH options (Preferences → command)
 Preferences ▸ SSH Settings persists each advanced option under the `ssh.*`
@@ -257,7 +285,10 @@ to askpass for a password.
   command for external processes), `_build_base_ssh_command` (shared option
   builder used by explicit-command callers like SCP).
 - `connection_manager.py`: `Connection.native_connect()`/`connect()`,
-  persistence of connections to `~/.ssh/config`, credential storage.
+  persistence of connections to `~/.ssh/config`, credential storage
+  (`store_connection_password`, `get_connection_password`, …).
+- `credential_manager.py` / `credential_model.py` / `credential_adapters.py`:
+  normalized credential listing and export (see `docs/CREDENTIAL_MANAGER.md`).
 - `askpass_utils.py`: the askpass helper, keyring lookup, and GTK prompt.
 - `window.py`: `show_ssh_password_dialog`, `resolve_app_modal_parent`,
   `present_for_modal_dialog` — in-app SSH password prompts and Wayland-safe modal

--- a/IDENTITY_PROVIDERS.md
+++ b/IDENTITY_PROVIDERS.md
@@ -5,7 +5,8 @@ small `IdentityProvider` interface, the identity-side parallel of the credential
 backends in `secret_storage.py`.
 
 - **Credential backends** (`secret_storage.py`) answer *"what password/passphrase
-  do we use?"*
+  do we use?"* See `docs/CREDENTIAL_MANAGER.md` for the export/backup layer
+  (`credential_manager.py`) and canonical SSH password host keys.
 - **Identity providers** (`identity.py`) answer *"which SSH key or agent
   authenticates the connection, and what does the spawned process need in its
   environment for that to work?"*

--- a/docs/CREDENTIAL_MANAGER.md
+++ b/docs/CREDENTIAL_MANAGER.md
@@ -1,0 +1,93 @@
+# Credential manager
+
+sshPilot stores SSH login passwords, sudo passwords, and key passphrases through
+the pluggable backends in `secret_storage.py`. The **credential manager** is a
+GTK-free normalization layer on top of that storage — it does not replace
+`SecretManager` for connect-time store/lookup.
+
+Use it when you need a **flat list of credentials** (backup export, future
+vault-to-vault migration), not when opening a connection.
+
+## Layers
+
+| Layer | Module | Role |
+| --- | --- | --- |
+| Storage | `secret_storage.py` | `SecretManager`, backends, `SecretSpec` builders |
+| Model | `credential_model.py` | `Credential` dataclass, spec ↔ credential translation, host-key helpers |
+| Orchestrator | `credential_manager.py` | `CredentialManager.list_credentials()` |
+| Adapters | `credential_adapters.py` | `SecretBackendAdapter`, `KdbxAdapter` — credential-centric load/save/delete |
+| Connect-time API | `connection_manager.py` | `store_connection_password`, `get_connection_password`, … |
+
+See also `IDENTITY_PROVIDERS.md` for the parallel **identity** side (which key /
+agent authenticates a connection).
+
+## Connect-time password keys
+
+SSH login passwords are keyed in the backend by `user@host`. The **canonical host**
+is always `hostname` → `host` → `nickname` (same as `Connection.get_effective_host()`).
+
+- **Store:** `ConnectionManager.store_connection_password(connection, password)`
+  writes under the canonical host and deletes legacy copies stored under older
+  aliases.
+- **Lookup:** `ConnectionManager.get_connection_password(connection)` probes
+  legacy aliases; on hit it **migrates** the secret to the canonical key.
+- **Low-level:** `store_password(host, user)` / `get_password(host, user)` remain
+  for callers that already know the exact key (plugin secrets, sudo passwords, …).
+
+Host helpers live in `credential_model.py`:
+
+- `canonical_password_host(conn)`
+- `password_host_candidates(conn)`
+
+## CredentialManager
+
+```python
+from sshpilot.credential_manager import CredentialManager
+
+creds = CredentialManager(connection_manager).list_credentials(
+    include_orphans=True,   # default: also enumerate backend orphans
+)
+```
+
+**Pass 1 — connection-derived:** for each connection, resolve password, sudo
+password, and passphrases for `keyfile`, `identity_files`, and
+`resolved_identity_files` (from `ssh -G`). Uses `SecretManager.lookup_everywhere`
+so secrets are found even if the user switched backends since storing.
+
+**Pass 2 — enumeration** (`include_orphans=True`): backends that implement
+`iter_credentials` (libsecret, pass, bitwarden, keepassxc) surface stored secrets
+with no matching connection; tagged `metadata['orphan']=True`.
+
+Dedup key: `(id, type)`. Connection-derived entries win over enumerated orphans.
+
+**Never prompts.** A locked session vault contributes nothing.
+
+### Backup (`.spbk`)
+
+`BackupManager._gather_credentials` calls
+`list_credentials(include_orphans=False)` for the selected connections only.
+Restore uses `credential_to_spec` + `SecretManager.store` (current backend).
+
+## SecretManager public API
+
+- `store` / `lookup` / `delete` — honor backend selection (`auto` vs explicit).
+- `lookup_everywhere(spec)` — scan all available backends; used by export.
+- `all_available_backends()` — public list for enumeration (credential manager).
+
+## Adapters
+
+`SecretBackendAdapter` wraps any `SecretBackend` with `load_all` / `save` /
+`delete` on `Credential` objects. Enumeration requires `iter_credentials` on the
+backend (keyring/agent have none).
+
+`KdbxAdapter` is a **standalone** `.kdbx` import/export target (not the
+connect-time `KdbxBackend`). Both scope enumeration to the dedicated `sshPilot`
+KeePass group.
+
+`watch_changes()` is currently a no-op on all adapters (future work).
+
+## Plugin secrets
+
+Plugin tokens use `connection_manager.store_plugin_secret` under host
+`sshpilot-plugin/<plugin_id>`. They are **not** included in `CredentialManager`
+today.

--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -2273,15 +2273,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 try:
                     mgr = getattr(self.parent_window, 'connection_manager', None)
                     if mgr and hasattr(self.connection, 'username'):
-                        lookup_host = (
-                            getattr(self.connection, 'hostname', '')
-                            or getattr(self.connection, 'host', '')
-                            or getattr(self.connection, 'nickname', '')
-                        )
-                        if lookup_host:
-                            pw = mgr.get_password(lookup_host, self.connection.username)
-                        else:
-                            pw = None
+                        pw = mgr.get_connection_password(self.connection)
                         if pw:
                             self.password_row.set_text(pw)
                 except Exception:

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1871,10 +1871,49 @@ class ConnectionManager(GObject.Object):
             logger.warning("No secure storage backend available; password not stored")
         return stored
 
+    def store_connection_password(self, connection, password: str,
+                                  username: Optional[str] = None) -> bool:
+        """Store a connection's SSH password under the canonical host key.
+
+        Clears legacy copies stored under older host aliases (nickname, etc.).
+        """
+        from .credential_model import canonical_password_host, password_host_candidates
+
+        user = (username or getattr(connection, 'username', '') or '').strip()
+        canonical = canonical_password_host(connection)
+        if not canonical or not user or not password:
+            return False
+        stored = self.store_password(canonical, user, password)
+        if stored:
+            for host in password_host_candidates(connection):
+                if host and host != canonical:
+                    self.delete_password(host, user)
+        return stored
+
     def get_password(self, host: str, username: str) -> Optional[str]:
         """Retrieve a password via the selected secret backend."""
         from .secret_storage import get_secret_manager, password_spec
         return get_secret_manager().lookup(password_spec(host, username))
+
+    def get_connection_password(self, connection,
+                                username: Optional[str] = None) -> Optional[str]:
+        """Look up a connection's SSH password, migrating legacy host aliases on hit."""
+        from .credential_model import canonical_password_host, password_host_candidates
+
+        user = (username or getattr(connection, 'username', '') or '').strip()
+        if not user:
+            return None
+        canonical = canonical_password_host(connection)
+        for host in password_host_candidates(connection) or ([canonical] if canonical else []):
+            if not host:
+                continue
+            value = self.get_password(host, user)
+            if value:
+                if canonical and host != canonical:
+                    if self.store_password(canonical, user, value):
+                        self.delete_password(host, user)
+                return value
+        return None
 
     def delete_password(self, host: str, username: str) -> bool:
         """Delete a stored password from all available secret backends."""
@@ -1883,6 +1922,18 @@ class ConnectionManager(GObject.Object):
         if removed_any:
             logger.debug(f"Deleted stored password for {username}@{host}")
         return removed_any
+
+    def delete_connection_passwords(self, connection,
+                                    username: Optional[str] = None) -> bool:
+        """Delete a connection's SSH password from every host alias and backend."""
+        from .credential_model import password_host_candidates
+
+        user = (username or getattr(connection, 'username', '') or '').strip()
+        removed = False
+        for host in password_host_candidates(connection):
+            if host and user and self.delete_password(host, user):
+                removed = True
+        return removed
 
     # --- Plugin secrets ----------------------------------------------------
     #
@@ -2579,12 +2630,6 @@ class ConnectionManager(GObject.Object):
                 target_path,
                 len(new_data.get('forwarding_rules', []) or [])
             )
-            # Capture previous identifiers for credential cleanup
-            prev_host = (
-                getattr(connection, 'hostname', '')
-                or getattr(connection, 'host', '')
-                or getattr(connection, 'nickname', '')
-            )
             prev_user = getattr(connection, 'username', '')
             original_nickname = getattr(connection, 'nickname', '')
 
@@ -2626,29 +2671,19 @@ class ConnectionManager(GObject.Object):
             # Handle password storage/removal
             if 'password' in new_data:
                 pwd = new_data.get('password') or ''
-                # Determine current identifiers after update
-                curr_host = (
-                    new_data.get('hostname')
-                    or new_data.get('host')
-                    or getattr(connection, 'hostname', '')
-                    or getattr(connection, 'host', '')
-                    or getattr(connection, 'nickname', '')
-                )
                 curr_user = new_data.get('username') or getattr(connection, 'username', prev_user)
-                if pwd and curr_host:
-                    self.store_password(curr_host, curr_user, pwd)
+                if pwd:
+                    self.store_connection_password(connection, pwd, username=curr_user)
                 else:
-                    # Remove any stored passwords for both previous and current identifiers
                     try:
-                        if prev_host and prev_user:
-                            self.delete_password(prev_host, prev_user)
+                        self.delete_connection_passwords(connection, username=prev_user)
                     except Exception:
                         pass
-                    try:
-                        if curr_host and curr_user and (curr_host != prev_host or curr_user != prev_user):
-                            self.delete_password(curr_host, curr_user)
-                    except Exception:
-                        pass
+                    if curr_user != prev_user:
+                        try:
+                            self.delete_connection_passwords(connection, username=curr_user)
+                        except Exception:
+                            pass
             
             # DO NOT call load_ssh_config() here - it breaks object references
             
@@ -2669,15 +2704,9 @@ class ConnectionManager(GObject.Object):
             if connection in self.connections:
                 self.connections.remove(connection)
             
-            # Remove password from secure storage
+            # Remove password from secure storage (all host aliases)
             try:
-                host_identifier = (
-                    connection.get_effective_host()
-                    if hasattr(connection, 'get_effective_host')
-                    else connection.hostname
-                )
-                self.delete_password(host_identifier, connection.username)
-
+                self.delete_connection_passwords(connection)
             except Exception as e:
                 logger.warning(f"Failed to remove password from storage: {e}")
             

--- a/sshpilot/credential_adapters.py
+++ b/sshpilot/credential_adapters.py
@@ -112,9 +112,10 @@ class KdbxAdapter(BackendAdapter):
     """Standalone KeePass (``.kdbx``) export/import target via ``pykeepass``.
 
     Constructed with a database path + master password (+ optional key file); opens lazily.
-    ``load_all()`` enumerates every entry (mapped to a Credential; the sshPilot type is
-    preserved via a custom property when we wrote it, else defaults to a password).
-    ``save``/``delete`` write to a dedicated group (default ``sshPilot``) and persist the file.
+    ``load_all()`` enumerates entries in the dedicated ``sshPilot`` group (same scope as
+    :class:`~sshpilot.secret_storage.KdbxBackend`); the sshPilot type is preserved via a
+    custom property when we wrote it, else defaults to a password.
+    ``save``/``delete`` write to that group and persist the file.
     """
 
     name = "keepassxc"
@@ -162,7 +163,9 @@ class KdbxAdapter(BackendAdapter):
     def load_all(self) -> List[Credential]:
         kp = self._db()
         out: List[Credential] = []
-        for entry in (kp.entries or []):
+        grp = kp.find_groups(name=self._group_name, first=True)
+        entries = (kp.find_entries(group=grp) or []) if grp is not None else []
+        for entry in entries:
             value = entry.password
             if not value:
                 continue

--- a/sshpilot/credential_manager.py
+++ b/sshpilot/credential_manager.py
@@ -10,6 +10,11 @@ It is GTK-free and dependency-injected (it never imports GTK or constructs app o
 is unit-testable: pass any connection source exposing ``get_connections()`` (or a plain list of
 connections), and optionally a :class:`SecretManager` and extra key paths.
 
+SSH password host keys are canonicalized at connect time via
+:meth:`ConnectionManager.store_connection_password` /
+:meth:`ConnectionManager.get_connection_password` (see ``credential_model.canonical_password_host``).
+This module still probes legacy host aliases when listing connection-derived passwords.
+
 Eager: :meth:`CredentialManager.list_credentials` resolves every secret value as it lists.
 It reads only what is currently available — a locked session vault (e.g. Bitwarden) simply
 contributes nothing; this never prompts or forces an unlock.
@@ -34,6 +39,7 @@ from .credential_model import (  # noqa: F401
     TYPE_PASSWORD,
     TYPE_SUDO,
     TYPE_KEY,
+    password_host_candidates,
     spec_to_credential,
 )
 from .credential_adapters import SecretBackendAdapter
@@ -91,7 +97,7 @@ class CredentialManager:
     def _merge_enumeration(self, out: Dict[Tuple[str, str], Credential]) -> None:
         """Add enumerated orphans from every available backend that can enumerate."""
         try:
-            backends = self._secrets._all_available_backends()
+            backends = self._secrets.all_available_backends()
         except Exception:
             logger.debug("listing available backends failed", exc_info=True)
             return
@@ -110,7 +116,7 @@ class CredentialManager:
     def _collect_connection_passwords(self, conn, out: Dict[Tuple[str, str], Credential]) -> None:
         username = getattr(conn, "username", "") or ""
         for builder in (password_spec, sudo_password_spec):
-            for host in self._host_candidates(conn):
+            for host in password_host_candidates(conn):
                 spec = builder(host, username)
                 found = self._lookup(spec)
                 if found is None:
@@ -119,27 +125,6 @@ class CredentialManager:
                 cred = spec_to_credential(spec, value, backend, connection=conn)
                 out.setdefault((cred.id, cred.type), cred)
                 break   # first host-variant hit wins for this (connection, kind)
-
-    @staticmethod
-    def _host_candidates(conn) -> List[str]:
-        # Secrets are stored inconsistently under hostname/host/nickname (the connection
-        # write path prefers hostname; read paths like sftp_utils probe all three) — so try
-        # them in that order and stop at the first that has the secret.
-        get_eff = getattr(conn, "get_effective_host", None)
-        raw = [
-            get_eff() if callable(get_eff) else "",
-            getattr(conn, "hostname", "") or "",
-            getattr(conn, "host", "") or "",
-            getattr(conn, "nickname", "") or "",
-        ]
-        seen: set = set()
-        ordered: List[str] = []
-        for h in raw:
-            h = (h or "").strip()
-            if h and h not in seen:
-                seen.add(h)
-                ordered.append(h)
-        return ordered
 
     # -- key passphrases --------------------------------------------------
     def _collect_key_passphrases(self, connections, out: Dict[Tuple[str, str], Credential]) -> None:
@@ -175,6 +160,9 @@ class CredentialManager:
             paths.append(kf)
         for p in (getattr(conn, "identity_files", None) or []):
             if p:
+                paths.append(p)
+        for p in (getattr(conn, "resolved_identity_files", None) or []):
+            if p and p not in paths:
                 paths.append(p)
         return paths
 

--- a/sshpilot/credential_model.py
+++ b/sshpilot/credential_model.py
@@ -16,7 +16,7 @@ backend-level ``SecretSpec`` (``secret_storage``):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .secret_storage import (
     SecretSpec,
@@ -36,6 +36,56 @@ _TYPE_FROM_SPEC = {
     "key_passphrase": TYPE_KEY,
 }
 _SPEC_FROM_TYPE = {v: k for k, v in _TYPE_FROM_SPEC.items()}
+
+
+def _conn_attr(conn, name: str, default: str = "") -> str:
+    """Read a string field from a Connection or a plain dict."""
+    if isinstance(conn, dict):
+        return str(conn.get(name) or default)
+    return str(getattr(conn, name, None) or default)
+
+
+def canonical_password_host(conn) -> str:
+    """Canonical keyring host for an SSH connection password.
+
+    Matches :meth:`Connection.get_effective_host`: ``hostname`` → ``host`` →
+    ``nickname``. New passwords are always stored under this key; legacy entries
+  under older aliases are migrated on read.
+    """
+    for key in ("hostname", "host", "nickname"):
+        value = _conn_attr(conn, key).strip()
+        if value:
+            return value
+    get_eff = getattr(conn, "get_effective_host", None)
+    if callable(get_eff):
+        try:
+            return str(get_eff() or "").strip()
+        except Exception:
+            pass
+    return ""
+
+
+def password_host_candidates(conn) -> List[str]:
+    """Host identifiers to probe when looking up a legacy SSH password.
+
+    Order: effective host, ``hostname``, ``host``, ``nickname`` — first hit wins;
+    a non-canonical hit is re-stored under :func:`canonical_password_host`.
+    """
+    get_eff = getattr(conn, "get_effective_host", None)
+    raw = [
+        get_eff() if callable(get_eff) else "",
+        _conn_attr(conn, "hostname"),
+        _conn_attr(conn, "host"),
+        _conn_attr(conn, "nickname"),
+    ]
+    seen: set = set()
+    ordered: List[str] = []
+    for h in raw:
+        h = (h or "").strip()
+        if h and h not in seen:
+            seen.add(h)
+            ordered.append(h)
+    return ordered
 
 
 @dataclass

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -381,27 +381,34 @@ class FileManagerWindow(Adw.Window):
             if not lookup_hosts:
                 lookup_hosts = [host]
             
-            # Try each identifier until we find a password
-            for lookup_host in lookup_hosts:
+            if connection is not None:
                 try:
-                    retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                    retrieved = connection_manager.get_connection_password(connection)
                     if retrieved:
+                        initial_password = retrieved
+                except Exception:
+                    pass
+            if initial_password is None:
+                for lookup_host in lookup_hosts:
+                    try:
+                        retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                        if retrieved:
+                            logger.debug(
+                                "Built-in file manager: Found password for %s@%s using identifier '%s'",
+                                lookup_user,
+                                lookup_host,
+                                lookup_host,
+                            )
+                            initial_password = retrieved
+                            break
+                    except Exception as exc:
                         logger.debug(
-                            "Built-in file manager: Found password for %s@%s using identifier '%s'",
+                            "Built-in file manager: Password lookup failed for %s@%s (identifier '%s'): %s",
                             lookup_user,
                             lookup_host,
-                            lookup_host
+                            lookup_host,
+                            exc,
                         )
-                        initial_password = retrieved
-                        break
-                except Exception as exc:
-                    logger.debug(
-                        "Built-in file manager: Password lookup failed for %s@%s (identifier '%s'): %s",
-                        lookup_user,
-                        lookup_host,
-                        lookup_host,
-                        exc
-                    )
 
         self._manager = create_file_manager_backend(
             host,

--- a/sshpilot/scp_window.py
+++ b/sshpilot/scp_window.py
@@ -243,7 +243,7 @@ class ScpWindowController:
         lookup_host = hostname_value or host_value
         if connection_manager:
             try:
-                saved_password = connection_manager.get_password(lookup_host, connection.username)
+                saved_password = connection_manager.get_connection_password(connection)
             except Exception:
                 saved_password = None
 

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -1454,6 +1454,10 @@ class SecretManager:
                 seen.add(name)
         return result
 
+    def all_available_backends(self) -> List[SecretBackend]:
+        """Public view of :meth:`_all_available_backends` for export/migration callers."""
+        return self._all_available_backends()
+
     def available_backends(self) -> List[str]:
         """Names of all registered backends that are currently usable."""
         return [n for n, b in self._backends.items() if b.is_available()]

--- a/sshpilot/sftp_utils.py
+++ b/sshpilot/sftp_utils.py
@@ -217,16 +217,25 @@ def open_remote_in_file_manager(
         lookup_user = user
         if connection is not None:
             lookup_user = getattr(connection, "username", None) or user
-        
-        for lookup_host in lookup_hosts:
+
+        if connection is not None:
             try:
-                retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                retrieved = connection_manager.get_connection_password(connection)
                 if retrieved:
                     logger.debug("External file manager: Found password, skipping SSH verification")
                     has_password = True
-                    break
             except Exception:
                 pass
+        if not has_password:
+            for lookup_host in lookup_hosts:
+                try:
+                    retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                    if retrieved:
+                        logger.debug("External file manager: Found password, skipping SSH verification")
+                        has_password = True
+                        break
+                except Exception:
+                    pass
 
     # If no password found and password auth is enabled, show password dialog before verification
     if not has_password and connection_manager is not None:
@@ -400,34 +409,42 @@ def _mount_and_open_sftp(
                 lookup_hosts
             )
             
-            # Try each identifier until we find a password
-            for lookup_host in lookup_hosts:
+            # Try connection-scoped lookup (migrates legacy host aliases), then each identifier
+            if connection is not None:
                 try:
-                    retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                    retrieved = connection_manager.get_connection_password(connection)
                     if retrieved:
-                        logger.debug(
-                            "External file manager: Password found for %s@%s using identifier '%s'",
-                            lookup_user,
-                            lookup_host,
-                            lookup_host
-                        )
                         password = retrieved
-                        break
-                    else:
+                except Exception:
+                    pass
+            if not password:
+                for lookup_host in lookup_hosts:
+                    try:
+                        retrieved = connection_manager.get_password(lookup_host, lookup_user)
+                        if retrieved:
+                            logger.debug(
+                                "External file manager: Password found for %s@%s using identifier '%s'",
+                                lookup_user,
+                                lookup_host,
+                                lookup_host,
+                            )
+                            password = retrieved
+                            break
+                        else:
+                            logger.debug(
+                                "External file manager: No password found for %s@%s using identifier '%s'",
+                                lookup_user,
+                                lookup_host,
+                                lookup_host,
+                            )
+                    except Exception as exc:
                         logger.debug(
-                            "External file manager: No password found for %s@%s using identifier '%s'",
+                            "Password lookup failed for %s@%s (identifier '%s'): %s",
                             lookup_user,
                             lookup_host,
-                            lookup_host
+                            lookup_host,
+                            exc,
                         )
-                except Exception as exc:
-                    logger.debug(
-                        "Password lookup failed for %s@%s (identifier '%s'): %s",
-                        lookup_user,
-                        lookup_host,
-                        lookup_host,
-                        exc
-                    )
 
         # If no password found and password auth is enabled, show password dialog before mounting
         if not password and connection_manager is not None:

--- a/sshpilot/ssh_connection_builder.py
+++ b/sshpilot/ssh_connection_builder.py
@@ -351,6 +351,10 @@ def _get_stored_password(
         return None
     
     try:
+        if connection_manager and hasattr(connection_manager, 'get_connection_password'):
+            stored = connection_manager.get_connection_password(connection)
+            if stored:
+                return stored
         host = getattr(connection, 'hostname', '') or getattr(connection, 'host', '')
         username = getattr(connection, 'username', '')
         if host and username:

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -542,6 +542,7 @@ def show_ssh_password_dialog(
         display_name=prompt_name,
         host=storage_host,
         username=storage_user,
+        connection=connection,
         connection_manager=connection_manager,
         heading=heading,
         body=body,
@@ -557,6 +558,7 @@ def _show_password_passphrase_dialog(
     key_path: Optional[str] = None,
     host: Optional[str] = None,
     username: Optional[str] = None,
+    connection: Optional[Any] = None,
     connection_manager: Optional[Any] = None,
     *,
     heading: Optional[str] = None,
@@ -729,10 +731,19 @@ def _show_password_passphrase_dialog(
                             store_passphrase(key_path, entered_password)
                         except Exception as e:
                             logger.debug(f"Failed to store passphrase: {e}")
-                    elif prompt_type == "password" and host and username and connection_manager:
-                        # Store password
+                    elif prompt_type == "password" and connection_manager:
                         try:
-                            connection_manager.store_password(host, username, entered_password)
+                            if connection is not None and hasattr(
+                                    connection_manager, 'store_connection_password'):
+                                connection_manager.store_connection_password(
+                                    connection, entered_password, username=username)
+                            elif host and username:
+                                from .credential_model import canonical_password_host
+                                canonical = canonical_password_host(
+                                    {'hostname': host, 'host': host, 'username': username})
+                                store_host = canonical or host
+                                connection_manager.store_password(
+                                    store_host, username, entered_password)
                         except Exception as e:
                             logger.debug(f"Failed to store password: {e}")
             else:

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -21,7 +21,7 @@ class FakeMgr:
         v = self.data.get(spec.keyring_account)
         return (v, "libsecret") if v else None
 
-    def _all_available_backends(self):
+    def all_available_backends(self):
         return []
 
 

--- a/tests/test_connection_passwords.py
+++ b/tests/test_connection_passwords.py
@@ -1,0 +1,92 @@
+"""Tests for canonical SSH password host keys and legacy alias migration."""
+
+import pytest
+
+import sshpilot.secret_storage as ss
+from sshpilot.credential_model import canonical_password_host, password_host_candidates
+from sshpilot.secret_storage import SecretManager, password_spec
+
+
+class FakeConn:
+    def __init__(self, nickname='', hostname='', host='', username=''):
+        self.nickname = nickname
+        self.hostname = hostname
+        self.host = host
+        self.username = username
+
+    def get_effective_host(self):
+        return self.hostname or self.host or self.nickname
+
+
+class FakeBackend(ss.SecretBackend):
+    def __init__(self, name):
+        self.name = name
+        self.data = {}
+
+    def is_available(self):
+        return True
+
+    def store(self, spec, secret):
+        self.data[spec.keyring_account] = secret
+        return True
+
+    def lookup(self, spec):
+        return self.data.get(spec.keyring_account)
+
+    def delete(self, spec):
+        return self.data.pop(spec.keyring_account, None) is not None
+
+
+@pytest.fixture
+def conn_mgr(monkeypatch):
+    monkeypatch.setattr(ss, 'is_macos', lambda: False)
+    from sshpilot.connection_manager import ConnectionManager
+
+    mgr = SecretManager()
+    backend = FakeBackend('libsecret')
+    mgr._backends = {'libsecret': backend, 'keyring': FakeBackend('keyring')}
+    monkeypatch.setattr(ss, 'get_secret_manager', lambda: mgr)
+
+    cm = ConnectionManager.__new__(ConnectionManager)
+    return cm, mgr, backend
+
+
+def test_canonical_password_host_order():
+    assert canonical_password_host(FakeConn('nick', hostname='host.example')) == 'host.example'
+    assert canonical_password_host(FakeConn('nick', host='alias')) == 'alias'
+    assert canonical_password_host(FakeConn('nick')) == 'nick'
+
+
+def test_password_host_candidates_dedupes():
+    conn = FakeConn('nick', hostname='host.example', host='alias')
+    assert password_host_candidates(conn) == ['host.example', 'alias', 'nick']
+
+
+def test_store_connection_password_uses_canonical_and_clears_aliases(conn_mgr):
+    cm, _mgr, backend = conn_mgr
+    conn = FakeConn('bnick', hostname='b.example', username='bob')
+    backend.data[password_spec('bnick', 'bob').keyring_account] = 'legacy'
+
+    assert cm.store_connection_password(conn, 'new-pw') is True
+    assert backend.data['bob@b.example'] == 'new-pw'
+    assert 'bob@bnick' not in backend.data
+
+
+def test_get_connection_password_migrates_legacy_alias(conn_mgr):
+    cm, _mgr, backend = conn_mgr
+    conn = FakeConn('bnick', hostname='b.example', username='bob')
+    backend.data[password_spec('bnick', 'bob').keyring_account] = 'legacy'
+
+    assert cm.get_connection_password(conn) == 'legacy'
+    assert backend.data['bob@b.example'] == 'legacy'
+    assert 'bob@bnick' not in backend.data
+
+
+def test_delete_connection_passwords_clears_all_aliases(conn_mgr):
+    cm, _mgr, backend = conn_mgr
+    conn = FakeConn('bnick', hostname='b.example', username='bob')
+    backend.data[password_spec('bnick', 'bob').keyring_account] = 'x'
+    backend.data[password_spec('b.example', 'bob').keyring_account] = 'y'
+
+    assert cm.delete_connection_passwords(conn) is True
+    assert backend.data == {}

--- a/tests/test_credential_adapters.py
+++ b/tests/test_credential_adapters.py
@@ -124,16 +124,22 @@ class FakePyKeePass:
         if FakePyKeePass.raise_on_open:
             raise ca.CredentialsError("bad password")
         self.path = path
-        self.entries = FakePyKeePass._stores.setdefault(path, [])
+        store = FakePyKeePass._stores.setdefault(path, {'all': [], 'group': []})
+        self.entries = store['all']
+        self._group_entries = store['group']
         self.root_group = FakeGroup('root')
+        self._group = FakeGroup('sshPilot')
         self.saved = 0
 
-    def find_entries(self, title=None, first=False):
-        matches = [e for e in self.entries if e.title == title]
+    def find_entries(self, title=None, first=False, group=None):
+        pool = self._group_entries if group is not None else self.entries
+        matches = [e for e in pool if (not title or e.title == title)]
         return (matches[0] if matches else None) if first else matches
 
     def find_groups(self, name=None, first=False):
-        return None
+        if name and name != 'sshPilot':
+            return None if first else []
+        return self._group if first else [self._group]
 
     def add_group(self, parent, name):
         return FakeGroup(name)
@@ -141,10 +147,14 @@ class FakePyKeePass:
     def add_entry(self, group, title, username, password):
         e = FakeEntry(title, username, password)
         self.entries.append(e)
+        if getattr(group, 'name', None) == 'sshPilot':
+            self._group_entries.append(e)
         return e
 
     def delete_entry(self, entry):
         self.entries.remove(entry)
+        if entry in self._group_entries:
+            self._group_entries.remove(entry)
 
     def save(self):
         self.saved += 1
@@ -157,7 +167,6 @@ def _reset_fake_kdbx():
     yield
     FakePyKeePass._stores = {}
     FakePyKeePass.raise_on_open = False
-
 
 def test_kdbx_save_load_roundtrip(monkeypatch):
     monkeypatch.setattr(ca, 'PyKeePass', FakePyKeePass)
@@ -178,6 +187,16 @@ def test_kdbx_save_load_roundtrip(monkeypatch):
     assert {c.id: c.secret for c in ad.load_all()}['u@h'] == 'pw2'
     assert ad.delete(Credential(id='u@h', type=TYPE_PASSWORD)) is True
     assert (TYPE_PASSWORD, 'u@h') not in {(c.type, c.id) for c in ad.load_all()}
+
+
+def test_kdbx_load_all_ignores_entries_outside_sshpilot_group(monkeypatch):
+    monkeypatch.setattr(ca, 'PyKeePass', FakePyKeePass)
+    ad = KdbxAdapter('/tmp/x.kdbx', password='pw')
+    store = FakePyKeePass._stores.setdefault('/tmp/x.kdbx', {'all': [], 'group': []})
+    store['all'].append(FakeEntry('other-user@host', 'u', 'outside'))   # not in sshPilot group
+    ad.save(Credential(id='u@h', type=TYPE_PASSWORD, host='h', username='u', secret='inside'))
+    creds = ad.load_all()
+    assert len(creds) == 1 and creds[0].secret == 'inside'
 
 
 def test_kdbx_wrong_password_raises(monkeypatch):

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -183,3 +183,14 @@ def test_accepts_plain_connection_iterable(secrets):
     cm = CredentialManager([FakeConn('h', hostname='h', username='u')], secret_manager=mgr)
     creds = cm.list_credentials()
     assert len(creds) == 1 and creds[0].secret == 'pw'
+
+
+def test_includes_resolved_identity_files(secrets):
+    mgr, libsecret, keyring = secrets
+    kp = os.path.realpath(os.path.expanduser('/home/u/.ssh/id_resolved'))
+    libsecret.store(passphrase_spec(kp), 'pass')
+    conn = FakeConn('A', hostname='a.example', username='alice')
+    conn.resolved_identity_files = ['/home/u/.ssh/id_resolved']
+    cm = CredentialManager(FakeConnManager([conn]), secret_manager=mgr)
+    creds = {c.id: c for c in cm.list_credentials() if c.type == TYPE_KEY}
+    assert kp in creds and creds[kp].secret == 'pass'

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -179,6 +179,11 @@ def test_lookup_and_delete_reach_nonselected_available_backend(manager):
     assert spec.keyring_account not in extra.data
 
 
+def test_all_available_backends_public_api(manager):
+    mgr, primary, fallback = manager
+    assert mgr.all_available_backends() == mgr._all_available_backends()
+
+
 def test_libsecret_iter_credentials_maps_search_results(monkeypatch):
     # iter_credentials enumerates via Secret.password_search and returns (attributes, secret).
     class FakeValue:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the follow-ups from the credential manager review: canonical SSH password host keys with legacy alias migration, a public backend-enumeration API, tighter export-layer consistency, and documentation.

## Changes

### Canonical SSH password keys
- Added `canonical_password_host()` and `password_host_candidates()` in `credential_model.py` (shared by storage and export layers).
- New connect-time APIs on `ConnectionManager`:
  - `store_connection_password()` — always stores under `hostname → host → nickname`; clears stale alias copies.
  - `get_connection_password()` — probes legacy aliases and migrates on hit.
  - `delete_connection_passwords()` — removes all alias variants.
- Updated connect-time callers (`ssh_connection_builder`, SFTP, SCP, file manager, connection dialog, password dialog) to use the new APIs.

### Export / credential manager layer
- `SecretManager.all_available_backends()` — public wrapper (replaces private `_all_available_backends()` usage in `CredentialManager`).
- `CredentialManager` now includes `resolved_identity_files` (from `ssh -G`) when gathering key passphrases for backup.
- `KdbxAdapter.load_all()` scopes to the `sshPilot` group, matching connect-time `KdbxBackend`.

### Documentation
- New `docs/CREDENTIAL_MANAGER.md` — architecture, APIs, backup behavior.
- `AGENTS.md` — new **Credential manager (export / backup layer)** section and updated key files list.
- `IDENTITY_PROVIDERS.md` — cross-reference to credential manager docs.

### Tests
- `tests/test_connection_passwords.py` — canonical store, legacy migration, multi-alias delete.
- Extended adapter/manager/secret_storage tests for Kdbx scope, `resolved_identity_files`, and public API.

## Testing

```
pytest tests/test_connection_passwords.py tests/test_credential_manager.py \
       tests/test_credential_adapters.py tests/test_secret_storage.py \
       tests/test_backup_manager.py
# 83 passed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66693c20-e741-4756-98f6-0af83053af69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66693c20-e741-4756-98f6-0af83053af69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

