### PR TITLE
Respect merge mode when restoring private keys from backups

### DIFF
--- a/sshpilot/backup_manager.py
+++ b/sshpilot/backup_manager.py
@@ -363,8 +363,11 @@ class BackupManager:
                 logger.warning("Failed to restore a credential", exc_info=True)
         return restored
 
-    def _restore_private_keys(self, manifest: Dict[str, Any]) -> int:
-        """Restore private keys embedded in a backup to their original paths."""
+    def _restore_private_keys(self, manifest: Dict[str, Any], mode: str = 'replace') -> int:
+        """Restore private keys embedded in a backup to their original paths.
+
+        In ``merge`` mode, existing key files at the target paths are left untouched.
+        """
         restored = 0
         for item in manifest.get('private_keys') or []:
             try:
@@ -372,18 +375,24 @@ class BackupManager:
                 raw = item.get('content_b64')
                 if not path or not raw:
                     continue
+                if mode == 'merge' and os.path.isfile(path):
+                    logger.info("Skipping existing private key at %s (merge mode)", path)
+                    continue
                 os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
                 with open(path, 'wb') as f:
                     f.write(base64.b64decode(raw.encode('ascii')))
-                os.chmod(path, 0o600)
+                os.chmod(path, int(item.get('mode') or 0o600) & 0o777)
 
                 public_path = os.path.expanduser(str(item.get('public_path') or ''))
                 public_raw = item.get('public_content_b64')
                 if public_path and public_raw:
-                    os.makedirs(os.path.dirname(public_path) or '.', exist_ok=True)
-                    with open(public_path, 'wb') as f:
-                        f.write(base64.b64decode(public_raw.encode('ascii')))
-                    os.chmod(public_path, int(item.get('public_mode') or 0o644) & 0o777)
+                    if mode == 'merge' and os.path.isfile(public_path):
+                        logger.info("Skipping existing public key at %s (merge mode)", public_path)
+                    else:
+                        os.makedirs(os.path.dirname(public_path) or '.', exist_ok=True)
+                        with open(public_path, 'wb') as f:
+                            f.write(base64.b64decode(public_raw.encode('ascii')))
+                        os.chmod(public_path, int(item.get('public_mode') or 0o644) & 0o777)
                 restored += 1
             except Exception:
                 logger.warning("Failed to restore a private key", exc_info=True)
@@ -403,7 +412,7 @@ class BackupManager:
             if success and effective_options['secrets'] else 0
         )
         restored_keys = (
-            self._restore_private_keys(manifest)
+            self._restore_private_keys(manifest, mode)
             if success and effective_options['private_keys'] else 0
         )
         return success, error, restored, restored_keys

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -219,6 +219,100 @@ def test_spbk_private_key_roundtrip_is_opt_in(monkeypatch, tmp_path):
     assert oct(key_path.stat().st_mode & 0o777) == "0o600"
 
 
+def test_spbk_private_key_merge_skips_existing(monkeypatch, tmp_path):
+    """Merge mode must not overwrite private keys that already exist on disk."""
+    monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
+    key_path = tmp_path / "id_ed25519"
+    pub_path = tmp_path / "id_ed25519.pub"
+    key_path.write_bytes(b"EXISTING PRIVATE\n")
+    pub_path.write_bytes(b"EXISTING PUBLIC\n")
+
+    selected = FakeConn("A", "h.example", "alice")
+    selected.keyfile = str(key_path)
+    mgr = bm.BackupManager(FakeConfig(), FakeConnMgr([selected]))
+    path = str(tmp_path / "keys.spbk")
+    ok, err = mgr.export_backup(
+        path,
+        connections=[selected],
+        passphrase="secret",
+        options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert ok, err
+    manifest = read_spbk(path, "secret")
+
+    success, error, restored, restored_keys = mgr.apply_imported_manifest(
+        manifest,
+        mode="merge",
+        create_backup=False,
+        restore_options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert success, error
+    assert restored == 0
+    assert restored_keys == 0
+    assert key_path.read_bytes() == b"EXISTING PRIVATE\n"
+    assert pub_path.read_bytes() == b"EXISTING PUBLIC\n"
+
+
+def test_spbk_private_key_merge_restores_missing(monkeypatch, tmp_path):
+    """Merge mode still restores keys whose paths do not yet exist."""
+    monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
+    key_path = tmp_path / "id_ed25519"
+    pub_path = tmp_path / "id_ed25519.pub"
+    key_path.write_bytes(b"PRIVATE KEY\n")
+    pub_path.write_bytes(b"PUBLIC KEY\n")
+
+    selected = FakeConn("A", "h.example", "alice")
+    selected.keyfile = str(key_path)
+    mgr = bm.BackupManager(FakeConfig(), FakeConnMgr([selected]))
+    path = str(tmp_path / "keys.spbk")
+    ok, err = mgr.export_backup(
+        path,
+        connections=[selected],
+        passphrase="secret",
+        options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert ok, err
+    manifest = read_spbk(path, "secret")
+    key_path.unlink()
+    pub_path.unlink()
+
+    success, error, restored, restored_keys = mgr.apply_imported_manifest(
+        manifest,
+        mode="merge",
+        create_backup=False,
+        restore_options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert success, error
+    assert restored == 0
+    assert restored_keys == 1
+    assert key_path.read_bytes() == b"PRIVATE KEY\n"
+    assert pub_path.read_bytes() == b"PUBLIC KEY\n"
+
+
 def test_spbk_restore_honors_secret_option(monkeypatch, tmp_path):
     monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path))
     fake = FakeMgr()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When restoring a `.spbk` backup, config categories (SSH config, known_hosts, app settings) honor the user's **Merge** vs **Replace** choice. Private keys did not: `_restore_private_keys()` always overwrote files at the stored paths, so choosing **Merge** could still clobber an existing `~/.ssh/id_ed25519`.

## Solution

- Pass the import `mode` from `apply_imported_manifest()` into `_restore_private_keys()`.
- In **merge** mode, skip restoring a key when the private key file already exists; likewise skip the `.pub` file if it already exists.
- **Replace** mode behavior is unchanged.
- Use the exported `mode` field when setting private key permissions (was hardcoded to `0o600`).

## Tests

Added two unit tests in `tests/test_backup_manager.py`:

- `test_spbk_private_key_merge_skips_existing` — merge does not overwrite existing key files
- `test_spbk_private_key_merge_restores_missing` — merge still writes keys whose paths are absent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bb27576-5117-431b-91b4-103ad16c6190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bb27576-5117-431b-91b4-103ad16c6190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

