### PR TITLE
Fix private key backup restore semantics

### DIFF
--- a/sshpilot/backup_manager.py
+++ b/sshpilot/backup_manager.py
@@ -375,9 +375,9 @@ class BackupManager:
                 raw = item.get('content_b64')
                 if not path or not raw:
                     continue
-                restored_any = False
                 if mode == 'merge' and os.path.isfile(path):
                     logger.info("Skipping existing private key at %s (merge mode)", path)
+                    continue
                 else:
                     os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
                     with open(path, 'wb') as f:
@@ -385,7 +385,6 @@ class BackupManager:
                     private_mode = int(item.get('mode') or 0o600) & 0o777
                     # Private keys must never be restored with group/other access.
                     os.chmod(path, (private_mode & 0o600) or 0o600)
-                    restored_any = True
 
                 public_path = os.path.expanduser(str(item.get('public_path') or ''))
                 public_raw = item.get('public_content_b64')
@@ -397,9 +396,7 @@ class BackupManager:
                         with open(public_path, 'wb') as f:
                             f.write(base64.b64decode(public_raw.encode('ascii')))
                         os.chmod(public_path, int(item.get('public_mode') or 0o644) & 0o777)
-                        restored_any = True
-                if restored_any:
-                    restored += 1
+                restored += 1
             except Exception:
                 logger.warning("Failed to restore a private key", exc_info=True)
         return restored

--- a/sshpilot/backup_manager.py
+++ b/sshpilot/backup_manager.py
@@ -375,13 +375,17 @@ class BackupManager:
                 raw = item.get('content_b64')
                 if not path or not raw:
                     continue
+                restored_any = False
                 if mode == 'merge' and os.path.isfile(path):
                     logger.info("Skipping existing private key at %s (merge mode)", path)
-                    continue
-                os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
-                with open(path, 'wb') as f:
-                    f.write(base64.b64decode(raw.encode('ascii')))
-                os.chmod(path, int(item.get('mode') or 0o600) & 0o777)
+                else:
+                    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+                    with open(path, 'wb') as f:
+                        f.write(base64.b64decode(raw.encode('ascii')))
+                    private_mode = int(item.get('mode') or 0o600) & 0o777
+                    # Private keys must never be restored with group/other access.
+                    os.chmod(path, (private_mode & 0o600) or 0o600)
+                    restored_any = True
 
                 public_path = os.path.expanduser(str(item.get('public_path') or ''))
                 public_raw = item.get('public_content_b64')
@@ -393,7 +397,9 @@ class BackupManager:
                         with open(public_path, 'wb') as f:
                             f.write(base64.b64decode(public_raw.encode('ascii')))
                         os.chmod(public_path, int(item.get('public_mode') or 0o644) & 0o777)
-                restored += 1
+                        restored_any = True
+                if restored_any:
+                    restored += 1
             except Exception:
                 logger.warning("Failed to restore a private key", exc_info=True)
         return restored

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -307,8 +307,8 @@ def test_spbk_private_key_merge_skips_existing(monkeypatch, tmp_path):
     assert pub_path.read_bytes() == b"EXISTING PUBLIC\n"
 
 
-def test_spbk_private_key_merge_restores_missing_public_sidecar(monkeypatch, tmp_path):
-    """Merge mode should still restore a missing .pub file beside an existing private key."""
+def test_spbk_private_key_merge_skips_public_when_private_exists(monkeypatch, tmp_path):
+    """Merge mode treats a private key and its .pub file as one skipped key-pair entry."""
     monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
     key_path = tmp_path / "id_ed25519"
     pub_path = tmp_path / "id_ed25519.pub"
@@ -351,9 +351,9 @@ def test_spbk_private_key_merge_restores_missing_public_sidecar(monkeypatch, tmp
     )
     assert success, error
     assert restored == 0
-    assert restored_keys == 1
+    assert restored_keys == 0
     assert key_path.read_bytes() == b"EXISTING PRIVATE\n"
-    assert pub_path.read_bytes() == b"BACKUP PUBLIC\n"
+    assert not pub_path.exists()
 
 
 def test_spbk_private_key_merge_restores_missing(monkeypatch, tmp_path):

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -219,6 +219,48 @@ def test_spbk_private_key_roundtrip_is_opt_in(monkeypatch, tmp_path):
     assert oct(key_path.stat().st_mode & 0o777) == "0o600"
 
 
+def test_spbk_restore_clamps_private_key_permissions(monkeypatch, tmp_path):
+    """Backed-up private key modes must not restore group/other access."""
+    monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
+    key_path = tmp_path / "id_ed25519"
+    mgr = bm.BackupManager(FakeConfig(), FakeConnMgr([]))
+    manifest = {
+        "version": 1,
+        "format": "spbk",
+        "backup_options": {
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+        "app_config": {},
+        "private_keys": [{
+            "path": str(key_path),
+            "mode": 0o644,
+            "content_b64": "UFJJVkFURSBLRVkK",
+        }],
+    }
+
+    success, error, restored, restored_keys = mgr.apply_imported_manifest(
+        manifest,
+        mode="replace",
+        create_backup=False,
+        restore_options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert success, error
+    assert restored == 0
+    assert restored_keys == 1
+    assert key_path.read_bytes() == b"PRIVATE KEY\n"
+    assert oct(key_path.stat().st_mode & 0o777) == "0o600"
+
+
 def test_spbk_private_key_merge_skips_existing(monkeypatch, tmp_path):
     """Merge mode must not overwrite private keys that already exist on disk."""
     monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
@@ -263,6 +305,55 @@ def test_spbk_private_key_merge_skips_existing(monkeypatch, tmp_path):
     assert restored_keys == 0
     assert key_path.read_bytes() == b"EXISTING PRIVATE\n"
     assert pub_path.read_bytes() == b"EXISTING PUBLIC\n"
+
+
+def test_spbk_private_key_merge_restores_missing_public_sidecar(monkeypatch, tmp_path):
+    """Merge mode should still restore a missing .pub file beside an existing private key."""
+    monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "config"))
+    key_path = tmp_path / "id_ed25519"
+    pub_path = tmp_path / "id_ed25519.pub"
+    key_path.write_bytes(b"BACKUP PRIVATE\n")
+    pub_path.write_bytes(b"BACKUP PUBLIC\n")
+
+    selected = FakeConn("A", "h.example", "alice")
+    selected.keyfile = str(key_path)
+    mgr = bm.BackupManager(FakeConfig(), FakeConnMgr([selected]))
+    path = str(tmp_path / "keys.spbk")
+    ok, err = mgr.export_backup(
+        path,
+        connections=[selected],
+        passphrase="secret",
+        options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert ok, err
+    manifest = read_spbk(path, "secret")
+
+    key_path.write_bytes(b"EXISTING PRIVATE\n")
+    pub_path.unlink()
+
+    success, error, restored, restored_keys = mgr.apply_imported_manifest(
+        manifest,
+        mode="merge",
+        create_backup=False,
+        restore_options={
+            "app_settings": False,
+            "ssh_config": False,
+            "known_hosts": False,
+            "secrets": False,
+            "private_keys": True,
+        },
+    )
+    assert success, error
+    assert restored == 0
+    assert restored_keys == 1
+    assert key_path.read_bytes() == b"EXISTING PRIVATE\n"
+    assert pub_path.read_bytes() == b"BACKUP PUBLIC\n"
 
 
 def test_spbk_private_key_merge_restores_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Clamp restored private-key file permissions so archived group/other bits are not reapplied.
- Keep merge-mode restore as an all-or-nothing key-pair skip: when the private key already exists, skip its public sidecar too.
- Add regression tests for unsafe private-key modes and whole key-pair skip semantics.

### Testing
- `pytest tests/test_backup_manager.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7154f2af-2055-4b42-b1d5-6deb7f13b616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7154f2af-2055-4b42-b1d5-6deb7f13b616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

