### PR TITLE
Show progress while applying imported backups

### DIFF
--- a/sshpilot/window_dialogs.py
+++ b/sshpilot/window_dialogs.py
@@ -956,7 +956,9 @@ class WindowConfigDialogsMixin:
 
         If the manifest carries credentials and the selected secret backend is a **locked
         session vault** (e.g. Bitwarden), unlock it first — import is aborted if unlock fails
-        or the user cancels, so credentials are never silently skipped."""
+        or the user cancels, so credentials are never silently skipped.  Applying a manifest
+        may invoke the selected secret backend once per credential, so keep that work off the
+        GTK main thread and show progress until the result is ready."""
         restore_options = restore_options or {}
         total = (
             len([c for c in (manifest.get('credentials') or [])
@@ -969,27 +971,53 @@ class WindowConfigDialogsMixin:
         )
 
         def do_apply(*_args):
-            try:
-                from .backup_manager import BackupManager
-                backup_mgr = BackupManager(self.config, self.connection_manager)
-                success, error, restored, restored_keys = backup_mgr.apply_imported_manifest(
-                    manifest, mode=mode, create_backup=True, restore_options=restore_options)
-            except Exception as e:
-                logger.error(f"Backup import failed: {e}")
-                self._simple_dialog(_("Import Failed"), str(e))
-                return
-            if not success:
-                self._simple_dialog(_("Import Failed"), error or _("Unknown error"))
-                return
-            skipped_keys = getattr(backup_mgr, 'last_import_skipped_keys', 0)
-            secrets_persisted = getattr(backup_mgr, 'last_import_secrets_persisted', True)
-            skipped_creds = getattr(backup_mgr, 'last_import_skipped_credentials', 0)
-            merge_collisions = getattr(backup_mgr, 'last_merge_collisions', []) or []
-            dropped_globals = getattr(backup_mgr, 'last_merge_dropped_globals', 0)
-            self._show_import_success(restored, total, restored_keys, total_keys,
-                                      skipped_keys, secrets_persisted, skipped_creds,
-                                      merge_collisions=merge_collisions,
-                                      dropped_globals=dropped_globals)
+            from .bitwarden_backup_setup import progress_dialog
+
+            _set_status, close_spinner = progress_dialog(
+                self, _("Import Configuration"),
+                _("Applying backup — this may take a while…"))
+
+            def worker():
+                try:
+                    from .backup_manager import BackupManager
+                    backup_mgr = BackupManager(self.config, self.connection_manager)
+                    success, error, restored, restored_keys = (
+                        backup_mgr.apply_imported_manifest(
+                            manifest, mode=mode, create_backup=True,
+                            restore_options=restore_options)
+                    )
+                    payload = (
+                        'ok', success, error, restored, restored_keys,
+                        getattr(backup_mgr, 'last_import_skipped_keys', 0),
+                        getattr(backup_mgr, 'last_import_secrets_persisted', True),
+                        getattr(backup_mgr, 'last_import_skipped_credentials', 0),
+                        getattr(backup_mgr, 'last_merge_collisions', []) or [],
+                        getattr(backup_mgr, 'last_merge_dropped_globals', 0),
+                    )
+                except Exception as e:
+                    logger.error("Backup import failed: %s", e)
+                    payload = ('error', str(e))
+                GLib.idle_add(lambda: (_report(payload), False)[1])
+
+            def _report(payload):
+                close_spinner()
+                if payload[0] == 'error':
+                    self._simple_dialog(_("Import Failed"), payload[1])
+                    return
+                (_, success, error, restored, restored_keys, skipped_keys,
+                 secrets_persisted, skipped_creds, merge_collisions,
+                 dropped_globals) = payload
+                if not success:
+                    self._simple_dialog(
+                        _("Import Failed"), error or _("Unknown error"))
+                    return
+                self._show_import_success(
+                    restored, total, restored_keys, total_keys,
+                    skipped_keys, secrets_persisted, skipped_creds,
+                    merge_collisions=merge_collisions,
+                    dropped_globals=dropped_globals)
+
+            threading.Thread(target=worker, daemon=True).start()
 
         self._run_after_vault_unlock_for_secrets(
             do_apply,

--- a/tests/test_window_vault_unlock_gate.py
+++ b/tests/test_window_vault_unlock_gate.py
@@ -6,9 +6,15 @@ from sshpilot.window_dialogs import WindowConfigDialogsMixin
 class _Win(WindowConfigDialogsMixin):
     def __init__(self):
         self.dialogs = []
+        self.import_results = []
+        self.config = object()
+        self.connection_manager = object()
 
     def _simple_dialog(self, heading, body):
         self.dialogs.append((heading, body))
+
+    def _show_import_success(self, *args, **kwargs):
+        self.import_results.append((args, kwargs))
 
 
 def test_vault_unlock_gate_skips_when_not_needed():
@@ -82,3 +88,78 @@ def test_vault_unlock_gate_proceeds_after_successful_unlock(monkeypatch):
         lambda: calls.append(1), needed=True, cancelled_heading="X")
     assert calls == [1]
     assert win.dialogs == []
+
+
+def test_manifest_import_shows_progress_and_applies_in_worker(monkeypatch):
+    win = _Win()
+    events = []
+
+    class BackupManager:
+        last_import_skipped_keys = 1
+        last_import_secrets_persisted = True
+        last_import_skipped_credentials = 2
+        last_merge_collisions = ["duplicate"]
+        last_merge_dropped_globals = 3
+
+        def __init__(self, config, connection_manager):
+            assert config is win.config
+            assert connection_manager is win.connection_manager
+
+        def apply_imported_manifest(self, manifest, **kwargs):
+            events.append("apply")
+            assert manifest == {"credentials": [], "private_keys": []}
+            assert kwargs == {
+                "mode": "merge",
+                "create_backup": True,
+                "restore_options": {"secrets": False},
+            }
+            return True, None, 4, 5
+
+    class Thread:
+        def __init__(self, target, daemon):
+            assert daemon is True
+            self.target = target
+
+        def start(self):
+            events.append("thread")
+            self.target()
+
+    def progress_dialog(parent, heading, message):
+        assert parent is win
+        events.append(("progress", heading, message))
+        return lambda _text: None, lambda: events.append("close")
+
+    def idle_add(callback):
+        events.append("idle")
+        return callback()
+
+    monkeypatch.setattr("sshpilot.backup_manager.BackupManager", BackupManager)
+    monkeypatch.setattr(
+        "sshpilot.bitwarden_backup_setup.progress_dialog", progress_dialog)
+    monkeypatch.setattr("sshpilot.window_dialogs.threading.Thread", Thread)
+    monkeypatch.setattr("sshpilot.window_dialogs.GLib.idle_add", idle_add)
+
+    win._perform_spbk_import(
+        {"credentials": [], "private_keys": []},
+        mode="merge",
+        restore_options={"secrets": False},
+    )
+
+    assert events == [
+        ("progress", "Import Configuration",
+         "Applying backup — this may take a while…"),
+        "thread",
+        "apply",
+        "idle",
+        "close",
+    ]
+    assert win.dialogs == []
+    assert win.import_results == [
+        (
+            (4, 0, 5, 0, 1, True, 2),
+            {
+                "merge_collisions": ["duplicate"],
+                "dropped_globals": 3,
+            },
+        )
+    ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show an import progress dialog while a decrypted backup is applied
- run manifest application and credential restoration outside the GTK main thread
- return completion and failure UI updates through the GTK main loop
- cover progress, worker execution, and result propagation with a regression test

## Testing
- `pytest -q tests/test_window_vault_unlock_gate.py tests/test_backup_manager.py tests/test_backup_backends.py` — 44 passed
- `python3 -m py_compile sshpilot/window_dialogs.py tests/test_window_vault_unlock_gate.py` — passed
- `pytest -q` — 1381 passed, 29 skipped, 2 xpassed
- manually imported an unencrypted `.spbk` backup through From File → Merge and reached Import Successful with responsive UI

## Walkthrough
[backup_import_progress_and_success.mp4](https://cursor.com/agents/bc-88e7fa8f-dc8d-43a1-9b89-ac1c78838b76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackup_import_progress_and_success.mp4)

[Import successful after background apply](https://cursor.com/agents/bc-88e7fa8f-dc8d-43a1-9b89-ac1c78838b76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimport_success_after_background_apply.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88e7fa8f-dc8d-43a1-9b89-ac1c78838b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88e7fa8f-dc8d-43a1-9b89-ac1c78838b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

