### PR TITLE
Add opt-out to disconnect confirmations

### DIFF
--- a/sshpilot/window_tabs.py
+++ b/sshpilot/window_tabs.py
@@ -668,9 +668,23 @@ class WindowTabsMixin:
         finally:
             self._suppress_close_confirmation = False
 
-    def _on_bulk_close_response(self, dialog, response_id, close_fn):
+    def _add_disconnect_opt_out(self, dialog):
+        """Add the shared opt-out control to a disconnect confirmation."""
+        checkbox = Gtk.CheckButton(label=_("Don't ask me again"))
+        checkbox.set_halign(Gtk.Align.START)
+        checkbox.set_margin_top(6)
+        dialog.set_extra_child(checkbox)
+        return checkbox
+
+    def _persist_disconnect_opt_out(self, checkbox):
+        """Disable future disconnect confirmations when explicitly requested."""
+        if checkbox.get_active():
+            self.config.set_setting('confirm-disconnect', False)
+
+    def _on_bulk_close_response(self, dialog, response_id, close_fn, checkbox):
         """Handle the single confirmation dialog for a bulk tab close."""
         if response_id == 'close':
+            self._persist_disconnect_opt_out(checkbox)
             self._run_suppressed_close(close_fn)
         dialog.destroy()
 
@@ -705,7 +719,13 @@ class WindowTabsMixin:
             dialog.set_response_appearance('close', Adw.ResponseAppearance.DESTRUCTIVE)
             dialog.set_default_response('close')
             dialog.set_close_response('cancel')
-            dialog.connect('response', self._on_bulk_close_response, close_fn)
+            checkbox = self._add_disconnect_opt_out(dialog)
+            dialog.connect(
+                'response',
+                self._on_bulk_close_response,
+                close_fn,
+                checkbox,
+            )
             dialog.present()
         else:
             # Toggle off, or nothing with a live session to disconnect: close
@@ -747,7 +767,12 @@ class WindowTabsMixin:
                     dialog.set_response_appearance('close', Adw.ResponseAppearance.DESTRUCTIVE)
                     dialog.set_default_response('close')
                     dialog.set_close_response('cancel')
-                    dialog.connect('response', self._on_split_tab_close_response)
+                    checkbox = self._add_disconnect_opt_out(dialog)
+                    dialog.connect(
+                        'response',
+                        self._on_split_tab_close_response,
+                        checkbox,
+                    )
                     dialog.present()
                     return True  # Prevent immediate close; dialog handles it
                 child.cleanup_all()
@@ -789,9 +814,10 @@ class WindowTabsMixin:
             dialog.set_response_appearance('close', Adw.ResponseAppearance.DESTRUCTIVE)
             dialog.set_default_response('close')
             dialog.set_close_response('cancel')
+            checkbox = self._add_disconnect_opt_out(dialog)
             
             # Connect to response signal before showing the dialog
-            dialog.connect('response', self._on_tab_close_response)
+            dialog.connect('response', self._on_tab_close_response, checkbox)
             dialog.present()
             
             # Prevent the default close behavior while we show confirmation
@@ -804,7 +830,7 @@ class WindowTabsMixin:
                 terminal.disconnect()
             return False
 
-    def _on_tab_close_response(self, dialog, response_id):
+    def _on_tab_close_response(self, dialog, response_id, checkbox):
         """Handle the response from the close confirmation dialog."""
         # Retrieve the pending tab info
         tab_view = self._pending_close_tab_view
@@ -812,6 +838,7 @@ class WindowTabsMixin:
         terminal = self._pending_close_terminal
 
         if response_id == 'close':
+            self._persist_disconnect_opt_out(checkbox)
             # User confirmed, disconnect the terminal. The tab will be removed
             # by the AdwTabView once we finish the close operation.
             if terminal and hasattr(terminal, 'disconnect'):
@@ -837,12 +864,13 @@ class WindowTabsMixin:
         self._pending_close_connection = None
         self._pending_close_terminal = None
 
-    def _on_split_tab_close_response(self, dialog, response_id):
+    def _on_split_tab_close_response(self, dialog, response_id, checkbox):
         """Handle the confirmation dialog for closing an entire SplitViewTab."""
         tab_view = getattr(self, '_pending_close_split_tab_view', None)
         page = getattr(self, '_pending_close_split_page', None)
         child = getattr(self, '_pending_close_split_child', None)
         if response_id == 'close':
+            self._persist_disconnect_opt_out(checkbox)
             if child is not None:
                 child.cleanup_all()
             if tab_view is not None and page is not None:

--- a/tests/test_gui_tab_close.py
+++ b/tests/test_gui_tab_close.py
@@ -22,6 +22,13 @@ def _enable_confirm(gui, on=True):
     gui.window.config.set_setting('confirm-disconnect', on)
 
 
+def _opt_out_checkbox(dialog):
+    checkbox = dialog.get_extra_child()
+    assert checkbox is not None
+    assert checkbox.get_label() == "Don't ask me again"
+    return checkbox
+
+
 def test_close_others_one_dialog_then_confirm(gui):
     gui.open_local_tabs(3)
     _enable_confirm(gui, True)
@@ -95,3 +102,47 @@ def test_single_close_still_confirms(gui):
 
     gui.respond('cancel')
     assert len(gui.user_pages()) == 2  # cancelled, still open
+
+
+def test_single_close_opt_out_disables_future_confirmations(gui):
+    gui.open_local_tabs(3)
+    _enable_confirm(gui, True)
+
+    gui.activate_action('tabmenu-close', target_page=gui.user_pages()[0])
+    dialog = gui.message_dialogs()[0]
+    _opt_out_checkbox(dialog).set_active(True)
+    gui.respond('close')
+
+    assert gui.window.config.get_setting('confirm-disconnect', True) is False
+    assert len(gui.user_pages()) == 2
+
+    gui.activate_action('tabmenu-close', target_page=gui.user_pages()[0])
+    assert gui.message_dialogs() == []
+    assert len(gui.user_pages()) == 1
+
+
+def test_close_others_opt_out_disables_future_confirmations(gui):
+    gui.open_local_tabs(3)
+    _enable_confirm(gui, True)
+    target = gui.user_pages()[1]
+
+    gui.activate_action('tabmenu-close-others', target_page=target)
+    dialog = gui.message_dialogs()[0]
+    _opt_out_checkbox(dialog).set_active(True)
+    gui.respond('close')
+
+    assert gui.window.config.get_setting('confirm-disconnect', True) is False
+    assert gui.user_pages() == [target]
+
+
+def test_cancel_with_opt_out_checked_keeps_confirmation_enabled(gui):
+    gui.open_local_tabs(2)
+    _enable_confirm(gui, True)
+
+    gui.activate_action('tabmenu-close', target_page=gui.user_pages()[0])
+    dialog = gui.message_dialogs()[0]
+    _opt_out_checkbox(dialog).set_active(True)
+    gui.respond('cancel')
+
+    assert gui.window.config.get_setting('confirm-disconnect', True) is True
+    assert len(gui.user_pages()) == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a “Don’t ask me again” checkbox to single, split-view, and bulk tab-close confirmations
- disable `confirm-disconnect` only after the user confirms the destructive close
- cover persistence, subsequent no-prompt behavior, bulk close, and cancellation with real-GTK tests

Closes #1038

## Walkthrough
[issue_1038_disconnect_opt_out.mp4](https://cursor.com/agents/bc-801ac93c-a48d-47c4-9fc3-3b8cd9ca6f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_1038_disconnect_opt_out.mp4)

[Disconnect confirmation opt-out](https://cursor.com/agents/bc-801ac93c-a48d-47c4-9fc3-3b8cd9ca6f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_1038_checkbox.webp)

[Preference disabled after opt-out](https://cursor.com/agents/bc-801ac93c-a48d-47c4-9fc3-3b8cd9ca6f55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_1038_preference_off.webp)

## Testing
- `SSHPILOT_GUI_TESTS=1 xvfb-run -a pytest -q -m gui tests/test_gui_tab_close.py` — 8 passed
- `pytest -q` — 1381 passed, 29 skipped, 2 xpassed
- `git diff --check` and Python compilation — passed
- manual GUI walkthrough — checkbox persisted the preference and suppressed the next prompt

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-801ac93c-a48d-47c4-9fc3-3b8cd9ca6f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-801ac93c-a48d-47c4-9fc3-3b8cd9ca6f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

