### PR TITLE
Save connection secrets without blocking the UI

### DIFF
--- a/sshpilot/connection_dialog.py
+++ b/sshpilot/connection_dialog.py
@@ -7,6 +7,7 @@ import os
 import logging
 import re
 import subprocess
+import threading
 import types
 from typing import Optional, Dict, Any
 
@@ -1234,6 +1235,7 @@ class FileListEditor(Adw.PreferencesGroup):
                     pass_entry.set_text(existing)
             except Exception:
                 pass
+        row._pass_initial = pass_entry.get_text()
         # Clear the error state as soon as the user edits the value again.
         pass_entry.connect('changed', lambda e: e.remove_css_class('error'))
         # Commit on Enter and when focus leaves the entry.
@@ -1256,6 +1258,7 @@ class FileListEditor(Adw.PreferencesGroup):
         return row
 
     def _commit_passphrase(self, pass_entry, path, norm, force=False):
+        """Validate an edited passphrase; persistence is deferred to dialog save."""
         text = pass_entry.get_text()
         if text and callable(self._verify):
             try:
@@ -1264,27 +1267,9 @@ class FileListEditor(Adw.PreferencesGroup):
                 ok = False
             if not ok:
                 pass_entry.add_css_class('error')
-                return
+                return False
         pass_entry.remove_css_class('error')
-        if self._connection_manager is None:
-            return
-        if not text:
-            # Clearing a passphrase deletes it (not gated by the vault lock state).
-            if hasattr(self._connection_manager, 'delete_key_passphrase'):
-                try:
-                    self._connection_manager.delete_key_passphrase(norm)
-                except Exception:
-                    logger.debug("Failed to delete passphrase for %s", norm, exc_info=True)
-            return
-        # Storing a passphrase needs the selected session vault unlocked. If it is
-        # locked, don't try now (it would fail silently) — defer to the save flow, which
-        # unlocks first, then calls flush_passphrases(force=True).
-        if not force and self._secret_backend_needs_unlock():
-            return
-        try:
-            self._connection_manager.store_key_passphrase(norm, text)
-        except Exception:
-            logger.debug("Failed to store passphrase for %s", norm, exc_info=True)
+        return True
 
     @staticmethod
     def _secret_backend_needs_unlock() -> bool:
@@ -1316,16 +1301,30 @@ class FileListEditor(Adw.PreferencesGroup):
                 pass
         return False
 
-    def flush_passphrases(self) -> None:
-        """Store every non-empty key passphrase now (called after an unlock so secrets
-        land in the chosen vault). Only stores non-empty entries — never deletes — so an
-        entry left blank because the vault was locked is not mistaken for a clear."""
+    def pending_passphrase_operations(self):
+        """Return changed passphrases as GTK-free worker operations.
+
+        Each tuple is ``("store"|"delete", normalized_path, value)``.  Reading and
+        validating entries stays on the GTK thread; only backend I/O uses these snapshots.
+        """
+        operations = []
         for entry, path, norm in self._passphrase_rows():
             try:
-                if entry.get_text():
-                    self._commit_passphrase(entry, path, norm, force=True)
+                if not self._commit_passphrase(entry, path, norm):
+                    return None
+                text = entry.get_text()
+                row = next(
+                    (candidate for candidate in self._rows
+                     if getattr(candidate, '_pass_entry', None) is entry),
+                    None,
+                )
+                initial = getattr(row, '_pass_initial', '') if row is not None else ''
+                if text == initial:
+                    continue
+                operations.append(('store' if text else 'delete', norm, text))
             except Exception:
-                logger.debug("Failed to flush passphrase for %s", norm, exc_info=True)
+                logger.debug("Failed to collect passphrase for %s", norm, exc_info=True)
+        return operations
 
     def _remove_row(self, path, row):
         self._model.remove(path)
@@ -3199,6 +3198,8 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
 
     def on_save_clicked(self, *_args):
         """Handle save button click or dialog save response"""
+        if getattr(self, '_secret_save_in_progress', False):
+            return
         # Plugin protocols collect their own (declarative) fields; the rest of
         # this method is the SSH path, which serializes to ~/.ssh/config.
         backend = self._selected_protocol_backend()
@@ -3308,6 +3309,14 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         nickname_for_meta = connection_data.get('nickname', '').strip()
         self._persist_connection_meta(nickname_for_meta)
 
+        if self.is_editing and self.connection:
+            connection_data['__previous_secret_identity'] = {
+                'nickname': getattr(self.connection, 'nickname', ''),
+                'hostname': getattr(self.connection, 'hostname', ''),
+                'host': getattr(self.connection, 'host', ''),
+                'username': getattr(self.connection, 'username', ''),
+            }
+
         # Update the connection object locally when editing (do not persist here; window handles persistence)
         if self.is_editing and self.connection:
             try:
@@ -3322,31 +3331,162 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             # Explicitly update forwarding rules to ensure they're fresh
             self.connection.forwarding_rules = forwarding_rules
             
-        # Emit signal with connection data. If a secret is being saved (a host password
-        # or a key passphrase) but the chosen session backend (Bitwarden/Vaultwarden) is
-        # locked or not signed in, unlock first so the secret lands in the chosen vault
-        # instead of failing silently. The prompt owns its own messaging.
+        # Unlock first when needed, then persist all changed secrets in one worker. Secret
+        # backends may invoke external tools (notably ``bw``), so none of this I/O may run
+        # in the GTK signal handler.
         if self._needs_secret_unlock_before_save(connection_data):
             try:
                 from .secret_unlock_dialog import prompt_unlock
 
                 def _after_unlock(ok):
                     if ok:
-                        editor = getattr(self, 'key_editor', None)
-                        if editor is not None:
-                            try:
-                                editor.flush_passphrases()
-                            except Exception:
-                                logger.debug("flush passphrases after unlock failed",
-                                             exc_info=True)
-                    self._emit_connection_saved(connection_data)
+                        self._store_secrets_then_save(connection_data)
+                    else:
+                        self._set_secret_save_busy(False)
 
+                self._set_secret_save_busy(True)
                 prompt_unlock(self, on_done=_after_unlock)
                 return
             except Exception:
-                logger.debug("Secret unlock-on-save gate failed; saving anyway",
-                             exc_info=True)
-        self._emit_connection_saved(connection_data)
+                logger.debug("Secret unlock-on-save gate failed", exc_info=True)
+                self._set_secret_save_busy(False)
+                self.show_error(_("The secure storage backend could not be unlocked."))
+                return
+        self._store_secrets_then_save(connection_data)
+
+    def _set_secret_save_busy(self, busy):
+        self._secret_save_in_progress = bool(busy)
+        for button in getattr(self, '_save_buttons', []) or []:
+            try:
+                button.set_sensitive(not busy)
+            except Exception:
+                pass
+
+    def _store_secrets_then_save(self, connection_data):
+        """Persist changed secrets off-thread, then emit the normal save signal."""
+        operations = []
+        previous_identity = connection_data.pop('__previous_secret_identity', None)
+        manager = getattr(self, 'connection_manager', None)
+        if manager is None:
+            manager = getattr(getattr(self, 'parent_window', None),
+                              'connection_manager', None)
+
+        password = connection_data.get('password') or ''
+        if password or connection_data.get('password_changed'):
+            operations.append(('password', 'store' if password else 'delete', '', password))
+
+        editor = getattr(self, 'key_editor', None)
+        if editor is not None:
+            try:
+                passphrase_operations = editor.pending_passphrase_operations()
+                if passphrase_operations is None:
+                    self._set_secret_save_busy(False)
+                    self.show_error(_("Please correct the invalid key passphrase."))
+                    return
+                operations.extend(
+                    ('passphrase', action, path, value)
+                    for action, path, value in passphrase_operations)
+            except Exception:
+                logger.debug("Failed to collect key passphrase changes", exc_info=True)
+
+        # update_connection normally persists the password synchronously. Mark this save
+        # as pre-handled even when nothing changed so it does not repeat backend I/O.
+        connection_data['__secret_storage_done'] = True
+        if not operations:
+            self._set_secret_save_busy(False)
+            self._emit_connection_saved(connection_data)
+            return
+        if manager is None:
+            self.show_error(_("Secure storage is unavailable."))
+            return
+
+        from .secret_storage import get_secret_manager
+        from .secret_unlock_dialog import _friendly_backend_name, _spinner_dialog
+
+        secret_manager = get_secret_manager()
+        backend = secret_manager.selected_backend()
+        backend_name = _friendly_backend_name(backend)
+        _set_status, close_spinner, spinner = _spinner_dialog(
+            self,
+            _("Saving to {backend}").format(backend=backend_name),
+            _("Saving passwords and passphrases to secure storage…"),
+        )
+        self._set_secret_save_busy(True)
+
+        def _worker():
+            ok = True
+            try:
+                for secret_type, action, key, value in operations:
+                    if secret_type == 'password':
+                        username = connection_data.get('username') or ''
+                        if action == 'store':
+                            ok = bool(manager.store_connection_password(
+                                connection_data, value, username=username,
+                                previous_connection=previous_identity))
+                        else:
+                            removed = bool(manager.delete_connection_passwords(
+                                connection_data, username=username))
+                            if previous_identity:
+                                previous_user = previous_identity.get('username') or username
+                                removed = bool(manager.delete_connection_passwords(
+                                    previous_identity,
+                                    username=previous_user)) or removed
+                            ok = removed
+                    elif action == 'store':
+                        ok = bool(manager.store_key_passphrase(key, value))
+                    else:
+                        ok = bool(manager.delete_key_passphrase(key))
+                    if not ok:
+                        break
+            except Exception:
+                logger.exception("Failed to save connection secrets")
+                ok = False
+            GLib.idle_add(self._finish_secret_save, connection_data, ok,
+                          close_spinner, spinner, True)
+
+        completion_called = [False]
+
+        def _after_config_saved(ok):
+            completion_called[0] = True
+            if ok:
+                threading.Thread(target=_worker, daemon=True).start()
+            else:
+                self._finish_secret_save(
+                    connection_data, False, close_spinner, spinner, False)
+
+        # Preserve the established save order: persist connection/config data first, then
+        # its credentials. The private marker keeps update_connection from performing the
+        # same secret I/O synchronously inside this signal emission.
+        connection_data['__save_completion'] = _after_config_saved
+        self.emit('connection-saved', connection_data)
+        if not completion_called[0]:
+            _after_config_saved(False)
+
+    def _finish_secret_save(self, connection_data, ok, close_spinner, spinner,
+                            settings_saved):
+        """Finish an asynchronous secret save on the GTK main thread."""
+        def _after_closed(*_args):
+            self._set_secret_save_busy(False)
+            if ok:
+                self.close()
+            elif not settings_saved:
+                self.show_error(_("The connection settings could not be saved."))
+            else:
+                self.show_error(_(
+                    "The connection settings were saved, but secure storage rejected "
+                    "a password or passphrase. Please try saving again."
+                ))
+
+        connected = False
+        try:
+            spinner.connect('closed', _after_closed)
+            connected = True
+        except Exception:
+            pass
+        close_spinner()
+        if not connected:
+            _after_closed()
+        return False
 
     def _emit_connection_saved(self, connection_data):
         """Emit the saved signal and close the dialog."""

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1872,10 +1872,12 @@ class ConnectionManager(GObject.Object):
         return stored
 
     def store_connection_password(self, connection, password: str,
-                                  username: Optional[str] = None) -> bool:
+                                  username: Optional[str] = None,
+                                  previous_connection=None) -> bool:
         """Store a connection's SSH password under the canonical host key.
 
-        Clears legacy copies stored under older host aliases (nickname, etc.).
+        Clears legacy copies stored under older host aliases (nickname, etc.) and,
+        when an edited connection changed host or username, its previous identity.
         """
         from .credential_model import canonical_password_host, password_host_candidates
 
@@ -1885,9 +1887,24 @@ class ConnectionManager(GObject.Object):
             return False
         stored = self.store_password(canonical, user, password)
         if stored:
-            for host in password_host_candidates(connection):
-                if host and host != canonical:
-                    self.delete_password(host, user)
+            cleanup = {
+                (host, user)
+                for host in password_host_candidates(connection)
+                if host and host != canonical
+            }
+            if previous_connection:
+                previous_user = (
+                    previous_connection.get('username')
+                    if isinstance(previous_connection, dict)
+                    else getattr(previous_connection, 'username', '')
+                ) or user
+                cleanup.update(
+                    (host, previous_user)
+                    for host in password_host_candidates(previous_connection)
+                    if host and (host != canonical or previous_user != user)
+                )
+            for host, cleanup_user in cleanup:
+                self.delete_password(host, cleanup_user)
         return stored
 
     def get_password(self, host: str, username: str) -> Optional[str]:
@@ -2613,6 +2630,9 @@ class ConnectionManager(GObject.Object):
     def update_connection(self, connection: Connection, new_data: Dict[str, Any]) -> bool:
         """Update an existing connection"""
         try:
+            secret_storage_done = bool(new_data.pop('__secret_storage_done', False))
+            if isinstance(getattr(connection, 'data', None), dict):
+                connection.data.pop('__secret_storage_done', None)
             protocol = (new_data.get('protocol')
                         or getattr(connection, 'protocol', 'ssh') or 'ssh')
             if protocol != 'ssh':
@@ -2669,7 +2689,7 @@ class ConnectionManager(GObject.Object):
                 self.update_ssh_config_file(connection, new_data, original_nickname)
 
             # Handle password storage/removal
-            if 'password' in new_data:
+            if 'password' in new_data and not secret_storage_done:
                 pwd = new_data.get('password') or ''
                 curr_user = new_data.get('username') or getattr(connection, 'username', prev_user)
                 if pwd:

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -1256,6 +1256,12 @@ class BitwardenBackend(SecretBackend):
         return base64.b64encode(json.dumps(item).encode("utf-8"))
 
     def store(self, spec: SecretSpec, secret: str) -> bool:
+        # Serialize cache lookup + create/edit as one transaction. UI saves run in
+        # workers, and two concurrent misses must not create duplicate vault items.
+        with self._lock:
+            return self._store_locked(spec, secret)
+
+    def _store_locked(self, spec: SecretSpec, secret: str) -> bool:
         token = self._current_token()
         if not token or not self._bin:
             return False
@@ -1318,6 +1324,10 @@ class BitwardenBackend(SecretBackend):
         return out
 
     def delete(self, spec: SecretSpec) -> bool:
+        with self._lock:
+            return self._delete_locked(spec)
+
+    def _delete_locked(self, spec: SecretSpec) -> bool:
         token = self._current_token()
         if not token or not self._bin:
             return False
@@ -1535,6 +1545,12 @@ class KdbxBackend(SecretBackend):
         return (entry.password if entry else None) or None
 
     def store(self, spec: SecretSpec, secret: str) -> bool:
+        # PyKeePass mutates one in-memory database object and rewrites the whole file.
+        # Serialize the complete transaction now that UI callers may save off-thread.
+        with self._lock:
+            return self._store_locked(spec, secret)
+
+    def _store_locked(self, spec: SecretSpec, secret: str) -> bool:
         kp = self._db()
         if kp is None:
             return False
@@ -1568,6 +1584,10 @@ class KdbxBackend(SecretBackend):
             return False
 
     def delete(self, spec: SecretSpec) -> bool:
+        with self._lock:
+            return self._delete_locked(spec)
+
+    def _delete_locked(self, spec: SecretSpec) -> bool:
         kp = self._db()
         if kp is None:
             return False

--- a/sshpilot/window.py
+++ b/sshpilot/window.py
@@ -7725,6 +7725,12 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
 
     def on_connection_saved(self, dialog, connection_data):
         """Handle connection saved from dialog"""
+        save_completion = connection_data.pop('__save_completion', None)
+
+        def _complete_save(ok):
+            if callable(save_completion):
+                save_completion(bool(ok))
+
         try:
             if connection_data.get('protocol', 'ssh') != 'ssh':
                 self._on_plugin_connection_saved(dialog, connection_data)
@@ -7797,6 +7803,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                 # Update connection in manager first
                 if not self.connection_manager.update_connection(old_connection, connection_data):
                     logger.error("Failed to update connection in SSH config")
+                    _complete_save(False)
                     return
 
                 # Preserve group assignment if nickname changed
@@ -7932,6 +7939,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     # Store the terminal in the connection for later use
                     old_connection._terminal_instance = terminal
                     self._prompt_reconnect(old_connection)
+                _complete_save(True)
                 
             else:
                 # Create new connection
@@ -7994,11 +8002,14 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     # Manually add the connection to the UI since we're not using the signal
                     # Row list was rebuilt from config; no manual add required
                     logger.info(f"Created new connection: {connection_data['nickname']}")
+                    _complete_save(True)
                 else:
                     logger.error("Failed to save connection to SSH config")
+                    _complete_save(False)
                 
         except Exception as e:
             logger.error(f"Failed to save connection: {e}")
+            _complete_save(False)
             # Show error dialog
             error_dialog = Gtk.MessageDialog(
                 transient_for=self,

--- a/tests/test_connection_dialog_passphrase.py
+++ b/tests/test_connection_dialog_passphrase.py
@@ -201,8 +201,7 @@ def test_edit_connection_retains_passphrase_without_keyring():
 
 
 def test_filelisteditor_defers_passphrase_when_vault_locked(monkeypatch):
-    # With a locked session vault, committing a passphrase must NOT store (and fail
-    # silently); it stays pending and is flushed after the save-flow unlock.
+    # Entry signals only validate. Backend I/O is deferred to the save worker.
     import sshpilot.secret_storage as ss
     from sshpilot.connection_dialog import FileListEditor
 
@@ -212,7 +211,8 @@ def test_filelisteditor_defers_passphrase_when_vault_locked(monkeypatch):
     cm = DummyConnectionManager()
     ed._connection_manager = cm
     entry = DummyEntry('secret')
-    ed._rows = [types.SimpleNamespace(_pass_entry=entry, _pass_path='/k', _pass_norm='/k')]
+    ed._rows = [types.SimpleNamespace(
+        _pass_entry=entry, _pass_path='/k', _pass_norm='/k', _pass_initial='')]
 
     sm = ss.get_secret_manager()
     monkeypatch.setattr(sm, 'selected_needs_unlock', lambda: True)
@@ -221,11 +221,11 @@ def test_filelisteditor_defers_passphrase_when_vault_locked(monkeypatch):
     assert cm.stored == {}
     assert ed.has_pending_passphrases() is True
 
-    ed.flush_passphrases()                             # after unlock
-    assert cm.stored == {'/k': 'secret'}
+    assert ed.pending_passphrase_operations() == [('store', '/k', 'secret')]
+    assert cm.stored == {}
 
 
-def test_filelisteditor_stores_passphrase_when_unlocked(monkeypatch):
+def test_filelisteditor_defers_passphrase_when_unlocked(monkeypatch):
     import sshpilot.secret_storage as ss
     from sshpilot.connection_dialog import FileListEditor
 
@@ -234,13 +234,108 @@ def test_filelisteditor_stores_passphrase_when_unlocked(monkeypatch):
     ed._verify = None
     cm = DummyConnectionManager()
     ed._connection_manager = cm
-    ed._rows = []
+    entry = DummyEntry('secret')
+    ed._rows = [types.SimpleNamespace(
+        _pass_entry=entry, _pass_path='/k', _pass_norm='/k', _pass_initial='')]
 
     sm = ss.get_secret_manager()
     monkeypatch.setattr(sm, 'selected_needs_unlock', lambda: False)
 
-    ed._commit_passphrase(DummyEntry('secret'), '/k', '/k')   # unlocked -> stored now
-    assert cm.stored == {'/k': 'secret'}
+    ed._commit_passphrase(entry, '/k', '/k')
+    assert cm.stored == {}
+    assert ed.pending_passphrase_operations() == [('store', '/k', 'secret')]
+
+
+def test_connection_secret_save_runs_backend_io_in_worker(monkeypatch):
+    import sshpilot.connection_dialog as dialog_module
+    import sshpilot.secret_storage as ss
+    import sshpilot.secret_unlock_dialog as unlock_dialog
+
+    calls = []
+
+    class Manager(DummyConnectionManager):
+        def store_connection_password(self, connection, password, username=None,
+                                      previous_connection=None):
+            calls.append(('password', connection['hostname'], username, password))
+            return True
+
+        def store_key_passphrase(self, key_path, value):
+            calls.append((key_path, value))
+            return True
+
+    class Spinner:
+        def connect(self, signal, callback):
+            assert signal == 'closed'
+            self.callback = callback
+
+    spinner = Spinner()
+    monkeypatch.setattr(
+        unlock_dialog,
+        '_spinner_dialog',
+        lambda *_args: (lambda _text: None, lambda: spinner.callback(), spinner),
+    )
+    monkeypatch.setattr(
+        ss.get_secret_manager(),
+        'selected_backend',
+        lambda: types.SimpleNamespace(name='bitwarden'),
+    )
+    monkeypatch.setattr(
+        dialog_module.GLib,
+        'idle_add',
+        lambda callback, *args: callback(*args),
+    )
+
+    pending_threads = []
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            pending_threads.append(self)
+
+    monkeypatch.setattr(dialog_module.threading, 'Thread', DeferredThread)
+
+    dialog = ConnectionDialog.__new__(ConnectionDialog)
+    dialog.connection_manager = Manager()
+    dialog.key_editor = types.SimpleNamespace(
+        pending_passphrase_operations=lambda: [('store', '/key', 'key-secret')])
+    dialog._save_buttons = []
+    emitted = []
+    closed = []
+
+    def emit(signal, data):
+        emitted.append((signal, dict(data)))
+        data.pop('__save_completion')(True)
+
+    dialog.emit = emit
+    dialog.close = lambda: closed.append(True)
+    dialog.show_error = lambda message: calls.append(('error', message))
+
+    data = {
+        'hostname': 'example.com',
+        'nickname': 'example',
+        'username': 'demo',
+        'password': 'host-secret',
+        'password_changed': True,
+    }
+    dialog._store_secrets_then_save(data)
+
+    assert len(pending_threads) == 1
+    assert pending_threads[0].daemon is True
+    assert calls == []
+    assert emitted[0][0] == 'connection-saved'
+    assert emitted[0][1]['__secret_storage_done'] is True
+    assert closed == []
+
+    pending_threads[0].target()
+
+    assert calls == [
+        ('password', 'example.com', 'demo', 'host-secret'),
+        ('/key', 'key-secret'),
+    ]
+    assert closed == [True]
 
 
 def test_save_gate_detects_pending_passphrase_when_locked(monkeypatch):

--- a/tests/test_connection_edit_host_tokens.py
+++ b/tests/test_connection_edit_host_tokens.py
@@ -72,3 +72,26 @@ def test_edit_preserves_supplied_host_tokens():
     })
     # Supplied tokens are respected (not overwritten by the nickname-only refresh).
     assert conn.data['__host_tokens'] == ['web1', 'web1-alias']
+
+
+def test_update_skips_password_io_prehandled_by_dialog_worker():
+    conn = Connection({
+        'nickname': 'web1',
+        'hostname': '10.0.0.1',
+        'username': 'u',
+    })
+    cm = _make_cm()
+    cm.connections = [conn]
+    calls = []
+    cm.store_connection_password = lambda *a, **k: calls.append((a, k))
+
+    assert cm.update_connection(conn, {
+        'nickname': 'web1',
+        'hostname': '10.0.0.1',
+        'username': 'u',
+        'password': 'secret',
+        '__secret_storage_done': True,
+    })
+
+    assert calls == []
+    assert '__secret_storage_done' not in conn.data

--- a/tests/test_connection_passwords.py
+++ b/tests/test_connection_passwords.py
@@ -72,6 +72,27 @@ def test_store_connection_password_uses_canonical_and_clears_aliases(conn_mgr):
     assert 'bob@bnick' not in backend.data
 
 
+def test_store_connection_password_clears_previous_identity(conn_mgr):
+    cm, _mgr, backend = conn_mgr
+    old = {
+        'nickname': 'old-name',
+        'hostname': 'old.example',
+        'username': 'alice',
+    }
+    new = {
+        'nickname': 'new-name',
+        'hostname': 'new.example',
+        'username': 'bob',
+    }
+    backend.data['alice@old.example'] = 'old-pw'
+
+    assert cm.store_connection_password(
+        new, 'new-pw', username='bob', previous_connection=old) is True
+
+    assert backend.data['bob@new.example'] == 'new-pw'
+    assert 'alice@old.example' not in backend.data
+
+
 def test_get_connection_password_migrates_legacy_alias(conn_mgr):
     cm, _mgr, backend = conn_mgr
     conn = FakeConn('bnick', hostname='b.example', username='bob')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move connection password and key passphrase persistence off the GTK main thread
- show a modal backend-specific saving spinner and prevent duplicate saves
- wait for SSH config persistence before starting credential writes and surface failures
- preserve credential migration across host or username edits
- serialize Bitwarden and KeePassXC write transactions

## Testing
- focused connection-dialog, credential, and secret-storage tests
- Python compile checks

Fixes #1039
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9feb9b9-2ccf-4259-aa8c-098e60edf5a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9feb9b9-2ccf-4259-aa8c-098e60edf5a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

