### PR TITLE
Fix missing SFTP server error classification

### DIFF
--- a/sshpilot/file_manager/openssh_backend.py
+++ b/sshpilot/file_manager/openssh_backend.py
@@ -522,8 +522,7 @@ class OpenSSHSFTPManager(GObject.GObject):
 
     def _emit_connect_error(self, exc: Exception) -> None:
         message = str(exc)
-        lowered = message.lower()
-        if "permission denied" in lowered or "authentication" in lowered or "password" in lowered:
+        if isinstance(exc, PermissionError):
             self.emit("authentication-required", message)
         else:
             self.emit("connection-error", message)
@@ -683,7 +682,12 @@ class OpenSSHSFTPManager(GObject.GObject):
     def _classify_handshake_failure(self, text: str, exc: Exception) -> Exception:
         text = (text or "").strip()
         lowered = text.lower()
-        if "permission denied" in lowered or "password" in lowered or "publickey" in lowered:
+        auth_failure_markers = (
+            "permission denied",
+            "authentication failed",
+            "too many authentication failures",
+        )
+        if any(marker in lowered for marker in auth_failure_markers):
             return PermissionError(text or "Authentication failed")
         if text:
             from ..scp_utils import classify_sftp_error

--- a/tests/test_openssh_backend.py
+++ b/tests/test_openssh_backend.py
@@ -363,6 +363,80 @@ def _wait_for(predicate, timeout=3.0):
     return False
 
 
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        (
+            "ash: /usr/libexec/sftp-server: not found\n"
+            "Connection closed.\n"
+            "Connection closed"
+        ),
+        (
+            "debug1: Authentications that can continue: publickey,password\n"
+            "debug1: Authentication succeeded (publickey).\n"
+            "ash: /usr/libexec/sftp-server: not found\n"
+            "Connection closed."
+        ),
+    ],
+)
+def test_manager_classifies_missing_sftp_as_connection_error(
+    backend_modules, monkeypatch, stderr
+):
+    _, ob, _ = backend_modules
+    from sshpilot.scp_utils import SFTP_UNAVAILABLE_MESSAGE
+
+    manager = ob.OpenSSHSFTPManager("host", "user")
+    emitted = []
+    monkeypatch.setattr(manager, "emit", lambda *args: emitted.append(args))
+
+    exc = manager._classify_handshake_failure(
+        stderr, EOFError("SFTP stream closed")
+    )
+    manager._emit_connect_error(exc)
+
+    assert type(exc) is OSError
+    assert str(exc) == SFTP_UNAVAILABLE_MESSAGE
+    assert emitted == [("connection-error", SFTP_UNAVAILABLE_MESSAGE)]
+    manager.close()
+
+
+def test_manager_classifies_permission_denied_as_authentication_error(
+    backend_modules, monkeypatch
+):
+    _, ob, _ = backend_modules
+    manager = ob.OpenSSHSFTPManager("host", "user")
+    emitted = []
+    monkeypatch.setattr(manager, "emit", lambda *args: emitted.append(args))
+    stderr = "Permission denied (publickey,password)."
+
+    exc = manager._classify_handshake_failure(
+        stderr, EOFError("SFTP stream closed")
+    )
+    manager._emit_connect_error(exc)
+
+    assert isinstance(exc, PermissionError)
+    assert emitted == [("authentication-required", stderr)]
+    manager.close()
+
+
+def test_manager_routes_connect_errors_by_exception_type(
+    backend_modules, monkeypatch
+):
+    _, ob, _ = backend_modules
+    manager = ob.OpenSSHSFTPManager("host", "user")
+    emitted = []
+    monkeypatch.setattr(manager, "emit", lambda *args: emitted.append(args))
+
+    manager._emit_connect_error(
+        OSError("Authentication succeeded; SFTP subsystem failed")
+    )
+
+    assert emitted == [
+        ("connection-error", "Authentication succeeded; SFTP subsystem failed")
+    ]
+    manager.close()
+
+
 def test_manager_listdir_emits_directory_loaded(backend_modules, monkeypatch):
     _, ob, proto = backend_modules
     manager, server, emitted = _make_manager(ob, proto, monkeypatch)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- classify only explicit SSH authentication failures as authentication errors
- route connection failures by exception type instead of broad message substrings
- add regression coverage for missing SFTP servers with normal and verbose SSH output

Fixes #1040

## Testing
- `pytest -q tests/test_openssh_backend.py tests/test_scp_transfers.py` (43 passed)
- `pytest` (1388 passed, 29 skipped, 2 xpassed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5877294d-1842-421d-81bc-21687ef9b8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5877294d-1842-421d-81bc-21687ef9b8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

