### PR TITLE
Cache Bitwarden sign-in state between connections

### DIFF
--- a/sshpilot/bitwarden_setup.py
+++ b/sshpilot/bitwarden_setup.py
@@ -304,9 +304,14 @@ def probe_bitwarden_status(bw=None, *, force_refresh: bool = False) -> Bitwarden
         elif _safe(lambda: bw.is_unlocked(), default=False):
             status = BitwardenStatus(cli_installed=True, needs_login=False, unlocked=True)
         else:
+            def _needs_login():
+                if force_refresh:
+                    return bw.needs_login(force_refresh=True)
+                return bw.needs_login()
+
             status = BitwardenStatus(
                 cli_installed=True,
-                needs_login=_safe(lambda: bw.needs_login(), default=True),
+                needs_login=_safe(_needs_login, default=True),
                 unlocked=False,
             )
     _bw_status_cache = (status, now)
@@ -1138,7 +1143,10 @@ def _login_wizard(window, bw, on_done: Callable[[bool], None]):
                 ok, detail = bw.login_with_sso(data.get("sso_id") or None)
                 if ok:
                     for _ in range(150):
-                        if not _safe(lambda: bw.needs_login(), default=True):
+                        if not _safe(
+                            lambda: bw.needs_login(force_refresh=True),
+                            default=True,
+                        ):
                             break
                         time.sleep(2)
                     else:

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -702,6 +702,7 @@ class BitwardenBackend(SecretBackend):
         self._token: Optional[str] = None                # session token (this process)
         self._unlocked = False                           # we unlocked it this session
         self._needs_login: Optional[bool] = None         # stable CLI account state
+        self._login_profile: Optional[str] = None        # profile that state belongs to
         self._idle = _SessionIdleTimeout()
         self._items: Optional[Dict[str, dict]] = None    # name→item; None = not loaded
         self._cache_complete = False                     # _items holds the whole vault
@@ -805,12 +806,18 @@ class BitwardenBackend(SecretBackend):
         """
         if not self._bin:
             return False
+        profile = os.environ.get("BITWARDENCLI_APPDATA_DIR", "")
         with self._lock:
-            if self._needs_login is not None and not force_refresh:
+            if (
+                self._needs_login is not None
+                and self._login_profile == profile
+                and not force_refresh
+            ):
                 return self._needs_login
             try:
                 result = self._run(["login", "--check"])
                 self._needs_login = result.returncode != 0
+                self._login_profile = profile
                 return self._needs_login
             except Exception as exc:
                 logger.debug("bw login --check failed: %s", exc)
@@ -820,11 +827,13 @@ class BitwardenBackend(SecretBackend):
         """Forget the cached CLI account state before an explicit status refresh."""
         with self._lock:
             self._needs_login = None
+            self._login_profile = None
 
     def _set_needs_login(self, needs_login: bool) -> None:
         """Record account state after an in-process login/logout operation."""
         with self._lock:
             self._needs_login = needs_login
+            self._login_profile = os.environ.get("BITWARDENCLI_APPDATA_DIR", "")
 
     @staticmethod
     def _bw_cli_message(result) -> str:

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -701,6 +701,7 @@ class BitwardenBackend(SecretBackend):
         self._argv_override: Optional[List[str]] = None
         self._token: Optional[str] = None                # session token (this process)
         self._unlocked = False                           # we unlocked it this session
+        self._needs_login: Optional[bool] = None         # stable CLI account state
         self._idle = _SessionIdleTimeout()
         self._items: Optional[Dict[str, dict]] = None    # name→item; None = not loaded
         self._cache_complete = False                     # _items holds the whole vault
@@ -794,17 +795,36 @@ class BitwardenBackend(SecretBackend):
         return result
 
     # -- login / unlock state --------------------------------------------
-    def needs_login(self) -> bool:
+    def needs_login(self, *, force_refresh: bool = False) -> bool:
         """True when no account is authenticated (``bw login`` required), so ``bw unlock``
-        cannot succeed. Only called in the unlock-decision flow."""
+        cannot succeed.
+
+        Account state is stable until login/logout, so cache it after the first CLI probe.
+        Connection attempts call this path and must not each pay for a slow Node startup.
+        Setup/status UI can use ``force_refresh`` after an out-of-process account change.
+        """
         if not self._bin:
             return False
-        try:
-            result = self._run(["login", "--check"])
-            return result.returncode != 0
-        except Exception as exc:
-            logger.debug("bw login --check failed: %s", exc)
-            return False
+        with self._lock:
+            if self._needs_login is not None and not force_refresh:
+                return self._needs_login
+            try:
+                result = self._run(["login", "--check"])
+                self._needs_login = result.returncode != 0
+                return self._needs_login
+            except Exception as exc:
+                logger.debug("bw login --check failed: %s", exc)
+                return False
+
+    def invalidate_login_state(self) -> None:
+        """Forget the cached CLI account state before an explicit status refresh."""
+        with self._lock:
+            self._needs_login = None
+
+    def _set_needs_login(self, needs_login: bool) -> None:
+        """Record account state after an in-process login/logout operation."""
+        with self._lock:
+            self._needs_login = needs_login
 
     @staticmethod
     def _bw_cli_message(result) -> str:
@@ -909,6 +929,7 @@ class BitwardenBackend(SecretBackend):
             extra_env["BW_CLIENTSECRET"] = challenge
         result = self._run(args, extra_env=extra_env)
         if result.returncode == 0:
+            self._set_needs_login(False)
             token = self._extract_login_session(result)
             if token:
                 with self._lock:
@@ -930,6 +951,7 @@ class BitwardenBackend(SecretBackend):
             extra_env={"BW_CLIENTID": client_id, "BW_CLIENTSECRET": client_secret},
         )
         if result.returncode == 0:
+            self._set_needs_login(False)
             return True, ""
         return False, self._bw_cli_message(result) or "login failed"
 
@@ -943,6 +965,7 @@ class BitwardenBackend(SecretBackend):
             args.append(ident)
         result = self._run(args)
         if result.returncode == 0:
+            self._set_needs_login(False)
             return True, ""
         return False, self._bw_cli_message(result) or "sso login failed"
 
@@ -1033,6 +1056,7 @@ class BitwardenBackend(SecretBackend):
                 token = result.stdout.decode("utf-8", "replace").strip()
                 if not token:
                     return False
+                self._needs_login = False
                 self._store_session_token(token)
                 self._report(progress, "loading")
                 # Warm the whole-vault cache now, while the unlock spinner is still up, so
@@ -1081,6 +1105,7 @@ class BitwardenBackend(SecretBackend):
                 detail = (result.stderr or result.stdout or b"").decode("utf-8", "replace").strip()
                 logger.error("bw logout failed: %s", detail)
                 return False
+            self._set_needs_login(True)
             return True
         except Exception as exc:
             logger.error("bw logout error: %s", exc)

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -1094,6 +1094,18 @@ def test_bitwarden_needs_login_force_refresh_detects_external_login(monkeypatch)
     assert fake.calls == [['login', '--check'], ['login', '--check']]
 
 
+def test_bitwarden_needs_login_cache_is_scoped_to_profile(monkeypatch):
+    fake = FakeBw(status="unauthenticated")
+    b = _make_backend(monkeypatch, fake)
+    monkeypatch.setenv("BITWARDENCLI_APPDATA_DIR", "/profiles/personal")
+    assert b.needs_login() is True
+
+    fake.status = "locked"
+    monkeypatch.setenv("BITWARDENCLI_APPDATA_DIR", "/profiles/work")
+    assert b.needs_login() is False
+    assert fake.calls == [['login', '--check'], ['login', '--check']]
+
+
 def test_bitwarden_login_and_logout_update_cached_account_state(monkeypatch):
     fake = FakeBw(status="unauthenticated")
     b = _make_backend(monkeypatch, fake)

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -1069,6 +1069,46 @@ def test_bitwarden_needs_login(monkeypatch):
     assert mgr.selected_needs_login() is True
 
 
+def test_bitwarden_needs_login_is_cached_between_connections(monkeypatch):
+    # The connect gate asks on every connection attempt. A signed-out result is stable,
+    # so only the first attempt should pay for the slow `bw` Node process startup.
+    fake = FakeBw(status="unauthenticated")
+    b = _make_backend(monkeypatch, fake)
+
+    assert b.needs_login() is True
+    assert b.needs_login() is True
+    assert b.needs_login() is True
+    assert fake.calls == [['login', '--check']]
+
+
+def test_bitwarden_needs_login_force_refresh_detects_external_login(monkeypatch):
+    # Preferences can explicitly refresh after the account changes outside sshPilot.
+    fake = FakeBw(status="unauthenticated")
+    b = _make_backend(monkeypatch, fake)
+    assert b.needs_login() is True
+
+    fake.status = "locked"
+    assert b.needs_login() is True                  # cached connection hot path
+    assert b.needs_login(force_refresh=True) is False
+    assert b.needs_login() is False                 # refreshed state is now cached
+    assert fake.calls == [['login', '--check'], ['login', '--check']]
+
+
+def test_bitwarden_login_and_logout_update_cached_account_state(monkeypatch):
+    fake = FakeBw(status="unauthenticated")
+    b = _make_backend(monkeypatch, fake)
+    assert b.needs_login() is True
+
+    assert b.login_with_api_key("client", "secret") == (True, "")
+    monkeypatch.setattr(ss.subprocess, 'run', _boom_bw)
+    assert b.needs_login() is False                 # no post-login status spawn
+
+    monkeypatch.setattr(ss.subprocess, 'run', fake.run)
+    assert b.logout() is True
+    monkeypatch.setattr(ss.subprocess, 'run', _boom_bw)
+    assert b.needs_login() is True                  # no post-logout status spawn
+
+
 def test_one_session_backend_no_vaultwarden(monkeypatch):
     # Bitwarden + Vaultwarden were merged into one `bw` backend; there is no separate
     # 'vaultwarden' backend, and availability is bin-only (no server URL gate).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cache Bitwarden CLI sign-in state so signed-out connection attempts do not repeatedly wait for `bw login --check`
- scope cached state to the active Bitwarden profile and support explicit refreshes after out-of-process changes
- update account state immediately after login, unlock, and logout
- add regression coverage for repeated connects, profile changes, external refreshes, and account transitions

## Testing
- `pytest -q tests/test_secret_storage.py tests/test_bitwarden_setup.py`
- `pytest -q tests/test_secret_unlock_dialog.py tests/test_window_vault_unlock_gate.py tests/test_askpass_utils.py`
- `pytest -q`
- controlled delayed-probe reproduction (one CLI call; repeated check returns from cache)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-274527ef-f96f-4340-bfe3-e0810d5b075d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-274527ef-f96f-4340-bfe3-e0810d5b075d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

