### PR TITLE
Fix Docker Console password authentication prompt

### DIFF
--- a/sshpilot/plugins/builtin/docker_manager/page.py
+++ b/sshpilot/plugins/builtin/docker_manager/page.py
@@ -89,6 +89,10 @@ class DockerConsolePage(
         # access probe (keyring autofill) or the GUI prompt; fed to ``sudo -S``
         # on captured commands and auto-typed into the PTY for interactive ones.
         self._sudo_passwords: dict[str, str] = {}
+        # Hosts whose SSH login-password prompt was cancelled.  Captured Docker
+        # commands have no TTY, so polling must stay stopped until the user
+        # explicitly retries instead of failing invisibly in the background.
+        self._ssh_auth_blocked: set[str] = set()
         # Container list filter text (search box).
         self._container_query = ""
         # Guards the runtime dropdown against feedback loops when synced in code.
@@ -380,7 +384,7 @@ class DockerConsolePage(
 
         refresh = Gtk.Button(icon_name="view-refresh-symbolic")
         refresh.set_tooltip_text("Refresh")
-        refresh.connect("clicked", lambda _b: self._refresh_visible())
+        refresh.connect("clicked", lambda _b: self._manual_refresh())
         bar.append(refresh)
         return bar
 
@@ -521,6 +525,71 @@ class DockerConsolePage(
             conns = []
         return [c for c in conns if getattr(c, "protocol", "ssh") in ("ssh", "", None)]
 
+    def _ensure_ssh_password(self, nickname: str) -> bool:
+        """Collect a missing SSH login password before captured Docker calls.
+
+        ``ctx.run_command`` is deliberately non-interactive, so password-mode
+        connections cannot fall back to the terminal prompt used by a normal
+        SSH tab.  Prompt here on the GTK thread and put the session password on
+        the connection; the shared native auth resolver then feeds it through
+        the normal sshpass FIFO path.
+        """
+        connection = self._connection_for(nickname)
+        if connection is None:
+            return True
+        try:
+            password_mode = int(getattr(connection, "auth_method", 0) or 0) == 1
+        except (TypeError, ValueError):
+            password_mode = False
+        if not password_mode or getattr(connection, "password", None):
+            self._ssh_auth_blocked.discard(nickname)
+            return True
+
+        manager = getattr(self.ctx, "connection_manager", None)
+        if manager is not None:
+            try:
+                if manager.get_connection_password(connection):
+                    self._ssh_auth_blocked.discard(nickname)
+                    return True
+            except Exception:
+                logger.debug("Docker Console password lookup failed", exc_info=True)
+
+        from ....window import show_ssh_password_dialog
+
+        password = show_ssh_password_dialog(
+            from_widget=self,
+            connection=connection,
+            connection_manager=manager,
+            heading="SSH password required",
+            body=(f"“{nickname}” uses password authentication.\n\n"
+                  "Enter the SSH login password to open Docker Console:"),
+        )
+        if not password:
+            self._ssh_auth_blocked.add(nickname)
+            return False
+        connection.password = password
+        self._ssh_auth_blocked.discard(nickname)
+        return True
+
+    def _show_ssh_auth_required(self) -> None:
+        for placeholder in (
+            self._containers_placeholder,
+            self._images_placeholder,
+            self._compose_placeholder,
+        ):
+            self._set_placeholder_idle(
+                placeholder, "SSH password required — click Refresh to retry")
+        self._pulse_stop(self._stats_pulse)
+        self._stats_pulse.set_visible(False)
+        self._toast("SSH password required to open Docker Console.")
+
+    def _manual_refresh(self) -> None:
+        nick = self._current_nickname()
+        if nick and nick in self._ssh_auth_blocked:
+            self._on_host_changed()
+            return
+        self._refresh_visible()
+
     def _on_host_changed(self, *_a) -> None:
         nick = self._current_nickname()
         if not nick:
@@ -531,6 +600,9 @@ class DockerConsolePage(
         self._syncing_runtime = True
         self._runtime_drop.set_selected(self._runtime_mode_index(nick))
         self._syncing_runtime = False
+        if not self._ensure_ssh_password(nick):
+            self._show_ssh_auth_required()
+            return
         # Move the warm SSH master to the newly selected host.
         self._acquire_multiplex(nick)
 
@@ -765,6 +837,8 @@ class DockerConsolePage(
     def _tick(self) -> bool:
         if self._paused:
             return True  # keep the timer; just skip this round
+        if self._current_nickname() in self._ssh_auth_blocked:
+            return True
         # Only auto-refresh the live views; images is manual. Logs auto-refresh
         # only when its toggle is on.
         name = self._stack.get_visible_child_name()

--- a/sshpilot/plugins/builtin/docker_manager/page.py
+++ b/sshpilot/plugins/builtin/docker_manager/page.py
@@ -267,13 +267,20 @@ class DockerConsolePage(
         return self._sudo_passwords.get(nickname) if nickname else None
 
     def _connection_for(self, nickname: str) -> Optional[Any]:
-        for c in self._connections:
-            if getattr(c, "nickname", None) == nickname:
-                return c
+        # Plugin list entries are ConnectionInfo snapshots and intentionally do
+        # not expose SSH-only fields such as ``auth_method`` or ``password``.
+        # Prefer the authoritative Connection object for authentication checks.
         try:
-            return self.ctx.connection_manager.find_connection_by_nickname(nickname)
+            connection = self.ctx.connection_manager.find_connection_by_nickname(
+                nickname)
+            if connection is not None:
+                return connection
         except Exception:
-            return None
+            pass
+        for connection in self._connections:
+            if getattr(connection, "nickname", None) == nickname:
+                return connection
+        return None
 
     def _host_user_for(self, nickname: str) -> tuple[Optional[str], str]:
         """(host, username) used as the keyring identity for the sudo password —

--- a/tests/test_gui_docker_password.py
+++ b/tests/test_gui_docker_password.py
@@ -28,6 +28,12 @@ def _password_auth_ctx(*, stored_password=None):
         password = None
 
     connection = Connection()
+    connection_info = types.SimpleNamespace(
+        nickname="web",
+        protocol="ssh",
+        host="example.test",
+        username="alice",
+    )
     manager = types.SimpleNamespace(
         find_connection_by_nickname=lambda _nick: connection,
         get_connection_password=lambda _connection: stored_password,
@@ -40,7 +46,9 @@ def _password_auth_ctx(*, stored_password=None):
             get=lambda key, default=None: default,
             set=lambda key, value: None,
         ),
-        list_connections=lambda: [connection],
+        # Plugin APIs return a ConnectionInfo snapshot without auth_method;
+        # password preflight must resolve the authoritative saved Connection.
+        list_connections=lambda: [connection_info],
         open_command_terminal=lambda *args, **kwargs: True,
         ui=types.SimpleNamespace(notify=lambda *args, **kwargs: None),
     )

--- a/tests/test_gui_docker_password.py
+++ b/tests/test_gui_docker_password.py
@@ -1,0 +1,104 @@
+"""GUI regressions for Docker Console SSH password preflight."""
+
+import types
+
+import pytest
+
+from tests._gui_harness import requires_gui
+
+
+requires_gui()
+
+pytestmark = pytest.mark.gui
+
+
+class _Result:
+    exit_code = 0
+    stdout = ""
+    stderr = ""
+
+
+def _password_auth_ctx(*, stored_password=None):
+    class Connection:
+        nickname = "web"
+        protocol = "ssh"
+        auth_method = 1
+        hostname = "example.test"
+        username = "alice"
+        password = None
+
+    connection = Connection()
+    manager = types.SimpleNamespace(
+        find_connection_by_nickname=lambda _nick: connection,
+        get_connection_password=lambda _connection: stored_password,
+    )
+    ctx = types.SimpleNamespace(
+        connection_manager=manager,
+        run_command=lambda *args, **kwargs: _Result(),
+        run_on_ui_thread=lambda fn, *args: fn(*args),
+        settings=types.SimpleNamespace(
+            get=lambda key, default=None: default,
+            set=lambda key, value: None,
+        ),
+        list_connections=lambda: [connection],
+        open_command_terminal=lambda *args, **kwargs: True,
+        ui=types.SimpleNamespace(notify=lambda *args, **kwargs: None),
+    )
+    return ctx, connection
+
+
+def test_password_auth_prompts_before_docker_probe(gui, monkeypatch):
+    from sshpilot import window
+    from sshpilot.plugins.builtin.docker_manager.page import DockerConsolePage
+
+    ctx, connection = _password_auth_ctx()
+    page = DockerConsolePage(ctx, initial_host="web")
+    prompts = []
+    monkeypatch.setattr(
+        window,
+        "show_ssh_password_dialog",
+        lambda **kwargs: prompts.append(kwargs) or "login-secret",
+    )
+
+    assert page._ensure_ssh_password("web") is True
+    assert connection.password == "login-secret"
+    assert prompts[0]["connection"] is connection
+    assert prompts[0]["connection_manager"] is ctx.connection_manager
+
+
+def test_saved_password_skips_docker_prompt(gui, monkeypatch):
+    from sshpilot import window
+    from sshpilot.plugins.builtin.docker_manager.page import DockerConsolePage
+
+    ctx, connection = _password_auth_ctx(stored_password="saved-secret")
+    page = DockerConsolePage(ctx, initial_host="web")
+    monkeypatch.setattr(
+        window,
+        "show_ssh_password_dialog",
+        lambda **kwargs: pytest.fail("saved password should skip the prompt"),
+    )
+
+    assert page._ensure_ssh_password("web") is True
+    assert connection.password is None
+
+
+def test_cancelled_password_stops_probe_and_polling(gui, monkeypatch):
+    from sshpilot import window
+    from sshpilot.plugins.builtin.docker_manager.page import DockerConsolePage
+
+    ctx, _connection = _password_auth_ctx()
+    page = DockerConsolePage(ctx, initial_host="web")
+    monkeypatch.setattr(
+        window, "show_ssh_password_dialog", lambda **kwargs: None)
+    probes = []
+    monkeypatch.setattr(
+        page, "_run_async", lambda *args: probes.append(args))
+
+    page._on_host_changed()
+
+    assert probes == []
+    assert "web" in page._ssh_auth_blocked
+    assert page._tick() is True
+    assert probes == []
+    assert "SSH password required" in (
+        page._containers_placeholder._label.get_text())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- resolve the authoritative saved Connection instead of the plugin-facing ConnectionInfo snapshot when checking Docker Console authentication
- prompt for a missing SSH login password before Docker Console starts captured SSH commands
- cache the session password on the connection so the shared native auth resolver uses its sshpass FIFO path
- stop background polling after cancellation and let Refresh retry authentication
- add real-GTK regression coverage for entered, saved, and cancelled password flows across the ConnectionInfo boundary

## Walkthrough
[docker_console_ssh_password_prompt.mp4](https://cursor.com/agents/bc-6187be25-ed04-4fea-bc50-b170db97d894/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_console_ssh_password_prompt.mp4)

[Docker Console after SSH password authentication](https://cursor.com/agents/bc-6187be25-ed04-4fea-bc50-b170db97d894/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_console_after_password.webp)

The demo host authenticates successfully; the final command error is expected because Docker is not installed there.

## Testing
- `python3 -m pytest` — 1396 passed, 29 skipped, 2 xpassed
- `python3 -m pytest tests/test_docker_manager_plugin.py -q` — 74 passed, 15 skipped
- `DISPLAY=:1 SSHPILOT_GUI_TESTS=1 python3 -m pytest -m gui tests/test_gui_docker_password.py -q` — 3 passed
- `python3 -m py_compile sshpilot/plugins/builtin/docker_manager/page.py tests/test_gui_docker_password.py`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6187be25-ed04-4fea-bc50-b170db97d894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6187be25-ed04-4fea-bc50-b170db97d894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

