### PR TITLE
Add local Docker Console target

### DIFF
--- a/PLUGIN_SDK.md
+++ b/PLUGIN_SDK.md
@@ -31,11 +31,13 @@ change without notice.
 | Open a terminal for a connection | `ctx.open_connection(nickname)` |
 | Generate an SSH key | `ctx.generate_key(name, ...)` |
 | Run a one-shot remote command (native SSH/auth path) | `ctx.run_command(nickname, command)` *(1.5)* |
+| Run a one-shot local command (Flatpak-host aware) | `ctx.run_local_command(command)` *(1.11)* |
 | Read resolved SSH config (`ssh -G`) | `ctx.get_effective_ssh_config(nickname)` *(1.5)* |
 | List/delete keys, deploy a key to a host | `ctx.list_keys()` / `ctx.delete_key(path)` / `ctx.copy_key_to_host(nickname, pub)` *(1.5)* |
 | Inspect/drive open terminals | `ctx.list_sessions()` / `ctx.read_terminal(id)` / `ctx.send_terminal(id, text)` *(1.5)* |
 | Persist files / make HTTP calls | `ctx.data_dir`, `ctx.files`, `ctx.http` *(1.5)* |
 | Open a terminal tab running a one-off command (streamed) | `ctx.open_command_terminal(nickname, remote_command, title=)` *(1.6)* |
+| Open a local terminal tab running a command (streamed/interactive) | `ctx.open_local_command_terminal(command, title=)` *(1.11)* |
 | Add an item to the connection right-click menu | `ctx.ui.register_connection_action(action_id, label, icon, callback)` *(1.7)* |
 | Register a page with no menu entry / custom activation | `ctx.ui.register_page(..., add_menu_item=False, on_activate=cb)` *(1.8)* |
 | Keep one SSH connection warm & multiplex calls over it | `ctx.acquire_multiplex(nickname)` / `ctx.release_multiplex(nickname)` *(1.9)* |
@@ -155,6 +157,13 @@ Passed to `activate`. One context per plugin; `ctx.plugin_id` is your manifest i
 - `delete_key(private_path: str) -> bool` — delete a key pair; refuses paths outside the app's key dir. *(after `app_started`)*
 - `copy_key_to_host(nickname: str, public_key_path: str) -> bool` — install a public key on a host via the shared ssh-copy-id/auth path. **Blocking.** *(after `app_started`)*
 - `open_command_terminal(nickname: str, remote_command: str, *, title=None, pty_prompt=None, pty_response=None) -> bool` *(API ≥ 1.6)* — open a new terminal tab running a one-off command on the host over the single native SSH/auth path. Use this for **streamed/interactive** output that `run_command` (one-shot, captured) can't show — e.g. `docker logs -f`, `docker exec -it`, `top`. Optional `pty_prompt`/`pty_response` arm a one-shot auto-fill: the first time `pty_prompt` appears in the terminal output, `pty_response` (plus a newline) is typed into the PTY — useful to answer a remote `sudo` password prompt without putting the secret on a command line. *(after `app_started`)*
+
+### Local commands *(API ≥ 1.11)*
+- `run_local_command(command: str, *, timeout=30, input=None) -> CommandResult` — run a local shell command and capture its output. **Blocking** — call from a worker thread. In Flatpak the command runs on the host via `flatpak-spawn --host`.
+- `open_local_command_terminal(command: str, *, title=None, pty_prompt=None, pty_response=None) -> bool` — open a local terminal and run a streamed/interactive command. It uses the same host-aware local terminal as the rest of sshPilot. *(after `app_started`)*
+
+Use these only for genuinely local work. Remote commands must use `run_command` /
+`open_command_terminal` so they retain sshPilot's unified SSH and authentication path.
 
 ### Connection multiplexing — faster polling *(API ≥ 1.9)*
 If your plugin polls a host (repeated `run_command` calls — a dashboard, a stats
@@ -387,7 +396,7 @@ must be made on the UI thread.
 
 ## 9. Versioning
 
-- `API_VERSION = (major, minor)`, currently `(1, 9)`. Your manifest declares the
+- `API_VERSION = (major, minor)`, currently `(1, 11)`. Your manifest declares the
   **major** you target; the loader skips plugins whose major doesn't match.
 - Minor bumps are additive (new methods/events); your plugin keeps working. Note
   the loader checks only the **major**, so a plugin using a newer minor's API on
@@ -403,7 +412,8 @@ must be made on the UI thread.
   output); `1.7` `ui.register_connection_action` (connection right-click menu);
   `1.8` `ui.register_page(add_menu_item=…, on_activate=…)`; `1.9`
   `acquire_multiplex`/`release_multiplex` (ControlMaster connection reuse for
-  polling plugins — `run_command` reuses the warm master transparently).
+  polling plugins — `run_command` reuses the warm master transparently); `1.10`
+  `identities`; `1.11` `run_local_command`/`open_local_command_terminal`.
 
 ---
 

--- a/sshpilot/host_picker.py
+++ b/sshpilot/host_picker.py
@@ -75,7 +75,8 @@ def show_host_picker(window, anchor, on_selected, *, toast=None,
 
         info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         info.set_hexpand(True)
-        lbl = Gtk.Label(label=conn.nickname)
+        display_name = getattr(conn, 'display_name', None) or conn.nickname
+        lbl = Gtk.Label(label=display_name)
         lbl.set_halign(Gtk.Align.START)
         lbl.add_css_class('heading')
         info.append(lbl)
@@ -109,7 +110,8 @@ def show_host_picker(window, anchor, on_selected, *, toast=None,
         if conn is None:
             return False
         host = getattr(conn, 'hostname', '') or getattr(conn, 'host', '')
-        return q in conn.nickname.lower() or q in host.lower()
+        display_name = getattr(conn, 'display_name', None) or conn.nickname
+        return q in display_name.lower() or q in conn.nickname.lower() or q in host.lower()
 
     list_box.set_filter_func(_filter)
     search_entry.connect('search-changed', lambda _e: list_box.invalidate_filter())

--- a/sshpilot/plugins/api.py
+++ b/sshpilot/plugins/api.py
@@ -51,7 +51,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # 1.10: ctx.identities — read-only view of SSH identities from the configured
 #      identity providers (ctx.identities.list() / .is_agent_available()),
 #      paralleling ctx.secrets. See sshpilot.identity / IDENTITY_PROVIDERS.md.
-API_VERSION: Tuple[int, int] = (1, 10)
+# 1.11: ctx.run_local_command / ctx.open_local_command_terminal — captured and
+#      streamed/interactive commands on the local machine (Flatpak-host aware).
+API_VERSION: Tuple[int, int] = (1, 11)
 
 # Stable event names and event payload types live in host.py; re-exported here
 # so plugins import everything from sshpilot.plugins.api. (host.py imports
@@ -551,6 +553,24 @@ class PluginContext:
             nickname, remote_command, title=title,
             pty_prompt=pty_prompt, pty_response=pty_response)
 
+    def open_local_command_terminal(self, command: str, *,
+                                    title: Optional[str] = None,
+                                    pty_prompt: Optional[str] = None,
+                                    pty_response: Optional[str] = None) -> bool:
+        """Open a local terminal tab and run ``command`` in its shell (API >= 1.11).
+
+        Use this for streamed or interactive local output. In Flatpak the
+        existing local-terminal host bridge is reused, so the command runs on
+        the host rather than inside the sandbox. ``pty_prompt`` /
+        ``pty_response`` have the same one-shot auto-fill semantics as
+        :meth:`open_command_terminal`.
+        """
+        if self._host is None:
+            return False
+        return self._host.open_local_command_terminal(
+            command, title=title,
+            pty_prompt=pty_prompt, pty_response=pty_response)
+
     # --- groups -------------------------------------------------------
     def create_group(self, name: str, color: Optional[str] = None) -> Optional[str]:
         """Find-or-create a sidebar group by display name; return its id
@@ -663,6 +683,39 @@ class PluginContext:
         finally:
             if cleanup is not None:
                 cleanup()
+
+    def run_local_command(self, command: str, *, timeout: float = 30,
+                          input: Optional[str] = None) -> "CommandResult":
+        """Run a local shell command and capture its output (API >= 1.11).
+
+        **Blocking** — call from a worker thread. In Flatpak the command is run
+        on the host via ``flatpak-spawn --host``. This is a local execution API;
+        remote commands must continue to use :meth:`run_command`.
+        """
+        import os
+        import shutil
+        import subprocess
+        from ..platform_utils import is_flatpak
+
+        if not command or not str(command).strip():
+            return CommandResult(-1, "", "Command is empty")
+        shell = shutil.which("sh") or "/bin/sh"
+        argv = [shell, "-lc", str(command)]
+        if is_flatpak():
+            spawn = shutil.which("flatpak-spawn")
+            if spawn is None:
+                return CommandResult(
+                    -1, "", "flatpak-spawn is unavailable; cannot run host command")
+            argv = [spawn, "--host", "sh", "-lc", str(command)]
+        try:
+            result = subprocess.run(
+                argv, env=os.environ.copy(), capture_output=True, text=True,
+                timeout=timeout, check=False, input=input)
+            return CommandResult(result.returncode, result.stdout, result.stderr)
+        except subprocess.TimeoutExpired:
+            return CommandResult(-1, "", "Command timed out")
+        except Exception as exc:  # noqa: BLE001 — surface as a failed result
+            return CommandResult(-1, "", str(exc))
 
     def acquire_multiplex(self, nickname: str) -> None:
         """Keep a shared SSH master (ControlMaster) warm for ``nickname`` while a

--- a/sshpilot/plugins/builtin/docker_manager/__init__.py
+++ b/sshpilot/plugins/builtin/docker_manager/__init__.py
@@ -1,11 +1,10 @@
 """Docker Console plugin.
 
-A management dashboard for the Docker/Podman daemon running on a host you reach
-over SSH. It does NOT talk to a daemon socket or use the docker SDK — every
-operation runs the ``docker``/``podman`` CLI on the host through the app's single
-native SSH path (``ctx.run_command``) and parses ``--format '{{json .}}'`` output
-with stdlib json. Streamed/interactive output (live logs, exec shell) opens a
-terminal tab via ``ctx.open_command_terminal`` (API >= 1.6).
+A management dashboard for the local Docker/Podman daemon or one reached over
+SSH. It does NOT talk to a daemon socket or use the docker SDK — every operation
+runs the ``docker``/``podman`` CLI through the plugin command APIs and parses
+``--format '{{json .}}'`` output with stdlib json. Remote targets retain the
+app's single native SSH/auth path.
 
 Sibling of the ``docker`` *protocol* plugin (which is a per-container connection
 type); this one is the management surface: lifecycle, logs, exec, stats, and
@@ -21,6 +20,8 @@ from ...api import PluginContext, SshPilotPlugin
 logger = logging.getLogger(__name__)
 
 _ICON = "brand-docker-symbolic"
+_LOCAL_TARGET = "__local__"
+_LOCAL_TITLE = "Local"
 
 
 class Plugin(SshPilotPlugin):
@@ -49,8 +50,9 @@ class Plugin(SshPilotPlugin):
         page_id = f"host-{nickname}"
         if page_id not in self._host_pages:
             try:
+                display_name = _LOCAL_TITLE if nickname == _LOCAL_TARGET else nickname
                 self.ctx.ui.register_page(
-                    page_id, f"Docker — {nickname}", _ICON,
+                    page_id, f"Docker — {display_name}", _ICON,
                     lambda nk=nickname: self._build_host_page(nk),
                     add_menu_item=False,
                 )
@@ -66,17 +68,17 @@ class Plugin(SshPilotPlugin):
         return DockerConsolePage(self.ctx, initial_host=nickname)
 
     def _open_last_host(self) -> None:
-        # No host context from the Tools menu → use the last-used host, else the
-        # first SSH connection.
+        # No host context from the Tools menu → use the last-used target, with
+        # Local always available even when there are no saved SSH connections.
         nick = self.ctx.settings.get("last_host", None)
-        if not nick:
+        if nick and nick != _LOCAL_TARGET:
             try:
-                conns = [c for c in self.ctx.list_connections()
-                         if getattr(c, "protocol", "ssh") in ("ssh", "", None)]
+                known = {
+                    connection.nickname for connection in self.ctx.list_connections()
+                    if getattr(connection, "protocol", "ssh") in ("ssh", "", None)
+                }
             except Exception:
-                conns = []
-            nick = conns[0].nickname if conns else None
-        if nick:
-            self._open_host_page(nick)
-        else:
-            self.ctx.ui.notify("No SSH connections to manage Docker on")
+                known = set()
+            if nick not in known:
+                nick = None
+        self._open_host_page(nick or _LOCAL_TARGET)

--- a/sshpilot/plugins/builtin/docker_manager/page.py
+++ b/sshpilot/plugins/builtin/docker_manager/page.py
@@ -2,15 +2,16 @@
 
 A single page with a host picker and seven sections — Containers, Logs, Stats,
 Images, Volumes, Networks, Compose — driven by :class:`DockerClient` over
-``ctx.run_command``. Every Docker call runs on a worker thread and marshals back
-with ``ctx.run_on_ui_thread``; streamed/interactive output (live logs, exec shell)
-opens a terminal tab via ``ctx.open_command_terminal``.
+the local or remote command API. Every Docker call runs on a worker thread and
+marshals back with ``ctx.run_on_ui_thread``; streamed/interactive output (live
+logs, exec shell) opens a corresponding local or remote terminal tab.
 """
 
 from __future__ import annotations
 
 import logging
 import math
+import os
 import threading
 from typing import Any, Callable, List, Optional
 
@@ -36,6 +37,16 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_REFRESH_SECONDS = 10
 _MIN_REFRESH_SECONDS = 2
+_LOCAL_TARGET = "__local__"
+
+
+class _LocalDockerTarget:
+    nickname = _LOCAL_TARGET
+    display_name = "Local"
+    host = "localhost"
+    hostname = "localhost"
+    username = os.environ.get("USER", "")
+    protocol = "local"
 
 
 class DockerConsolePage(
@@ -267,6 +278,12 @@ class DockerConsolePage(
         return self._sudo_passwords.get(nickname) if nickname else None
 
     def _connection_for(self, nickname: str) -> Optional[Any]:
+        if nickname == _LOCAL_TARGET:
+            return next(
+                (target for target in self._connections
+                 if getattr(target, "nickname", None) == _LOCAL_TARGET),
+                _LocalDockerTarget(),
+            )
         # Plugin list entries are ConnectionInfo snapshots and intentionally do
         # not expose SSH-only fields such as ``auth_method`` or ``password``.
         # Prefer the authoritative Connection object for authentication checks.
@@ -296,9 +313,22 @@ class DockerConsolePage(
         nick = self._current_nickname()
         if not nick:
             return None
-        return DockerClient(self.ctx.run_command, nick, self._runtime_for(nick),
+        return DockerClient(self._run_command_for(nick), nick, self._runtime_for(nick),
                             use_sudo=self._use_sudo_for(nick),
                             sudo_password=self._sudo_password_for(nick))
+
+    @staticmethod
+    def _is_local(nickname: Optional[str]) -> bool:
+        return nickname == _LOCAL_TARGET
+
+    def _run_command_for(self, nickname: str) -> Callable[..., Any]:
+        if not self._is_local(nickname):
+            return self.ctx.run_command
+
+        def run_local(_nickname: str, command: str, **kwargs):
+            return self.ctx.run_local_command(command, **kwargs)
+
+        return run_local
 
     def _open_command_terminal(self, nick: str, cmd: str,
                                title: Optional[str] = None) -> bool:
@@ -306,6 +336,12 @@ class DockerConsolePage(
         PTY auto-fill when this host's sudo needs a password (so the prompt the
         ``sudo -p`` sentinel produces is answered without the user typing it)."""
         pw = self._sudo_password_for(nick) if self._use_sudo_for(nick) else None
+        if self._is_local(nick):
+            return self.ctx.open_local_command_terminal(
+                cmd, title=title,
+                pty_prompt=DockerClient.SUDO_PROMPT if pw else None,
+                pty_response=pw,
+            )
         if pw:
             return self.ctx.open_command_terminal(
                 nick, cmd, title=title,
@@ -328,7 +364,7 @@ class DockerConsolePage(
     def _build_host_bar(self) -> Gtk.Widget:
         bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
 
-        self._connections = self._list_ssh_connections()
+        self._connections = self._list_hosts()
         target = self._initial_host or self.ctx.settings.get("last_host", None)
         if target and any(c.nickname == target for c in self._connections):
             self._selected_nick = target
@@ -427,7 +463,13 @@ class DockerConsolePage(
     def _update_host_button_label(self) -> None:
         nick = self._selected_nick
         if nick:
-            self._host_label.set_label(nick)
+            target = next(
+                (item for item in self._connections
+                 if getattr(item, "nickname", None) == nick),
+                None,
+            )
+            self._host_label.set_label(
+                getattr(target, "display_name", None) or nick)
             self._host_btn.set_sensitive(True)
         else:
             self._host_label.set_label("(no connections)")
@@ -436,7 +478,7 @@ class DockerConsolePage(
     def _show_host_picker(self, _btn: Gtk.Button) -> None:
         from ....host_picker import show_host_picker  # noqa: PLC0415
 
-        self._connections = self._list_ssh_connections()
+        self._connections = self._list_hosts()
         if not self._connections:
             self._toast("No SSH connections")
             return
@@ -488,6 +530,9 @@ class DockerConsolePage(
 
     def _acquire_multiplex(self, nick: Optional[str]) -> None:
         """Keep a master warm for ``nick`` (idempotent per held nick)."""
+        if self._is_local(nick):
+            self._release_multiplex()
+            return
         if not nick or not self._multiplex_enabled():
             return
         if self._mux_nick == nick:
@@ -525,12 +570,16 @@ class DockerConsolePage(
             on_refresh_interval_changed=self._on_refresh_interval_changed,
         ).present()
 
-    def _list_ssh_connections(self) -> List[Any]:
+    def _list_hosts(self) -> List[Any]:
         try:
             conns = self.ctx.list_connections()
         except Exception:
             conns = []
-        return [c for c in conns if getattr(c, "protocol", "ssh") in ("ssh", "", None)]
+        remote = [
+            connection for connection in conns
+            if getattr(connection, "protocol", "ssh") in ("ssh", "", None)
+        ]
+        return [_LocalDockerTarget(), *remote]
 
     def _ensure_ssh_password(self, nickname: str) -> bool:
         """Collect a missing SSH login password before captured Docker calls.
@@ -541,6 +590,9 @@ class DockerConsolePage(
         the connection; the shared native auth resolver then feeds it through
         the normal sshpass FIFO path.
         """
+        if self._is_local(nickname):
+            self._ssh_auth_blocked.discard(nickname)
+            return True
         connection = self._connection_for(nickname)
         if connection is None:
             return True
@@ -634,7 +686,7 @@ class DockerConsolePage(
         self._stats_pulse.set_visible(True)
         self._pulse_start(self._stats_pulse)
 
-        rc = self.ctx.run_command
+        rc = self._run_command_for(nick)
 
         mode = self._runtime_mode(nick)
 
@@ -783,7 +835,7 @@ class DockerConsolePage(
             self._refresh_visible()
             return
 
-        rc = self.ctx.run_command
+        rc = self._run_command_for(nick)
 
         def verify():
             ok, kind = self._check_sudo(rc, nick, runtime, password)

--- a/sshpilot/plugins/host.py
+++ b/sshpilot/plugins/host.py
@@ -503,6 +503,26 @@ class PluginHost:
             logger.exception("open_command_terminal(%r) failed", nickname)
             return False
 
+    def open_local_command_terminal(self, command: str, *,
+                                    title: Optional[str] = None,
+                                    pty_prompt: Optional[str] = None,
+                                    pty_response: Optional[str] = None) -> bool:
+        if self._window is None:
+            logger.warning("open_local_command_terminal before window is ready")
+            return False
+        if not command or not str(command).strip():
+            return False
+        try:
+            return bool(self._window.terminal_manager.show_local_terminal(
+                title=title or "Local Command",
+                command=str(command),
+                pty_prompt=pty_prompt,
+                pty_response=pty_response,
+            ))
+        except Exception:
+            logger.exception("open_local_command_terminal failed")
+            return False
+
     # --- connection groups -------------------------------------------
     def ensure_group(self, name: str, color: Optional[str] = None) -> Optional[str]:
         """Find-or-create a connection group by display name; return its id.

--- a/sshpilot/terminal_manager.py
+++ b/sshpilot/terminal_manager.py
@@ -667,7 +667,10 @@ class TerminalManager:
         except Exception as e:
             logger.error(f"Failed to add terminal tab: {e}")
 
-    def show_local_terminal(self, *, title="Local Terminal"):
+    def show_local_terminal(self, *, title="Local Terminal",
+                            command: Optional[str] = None,
+                            pty_prompt: Optional[str] = None,
+                            pty_response: Optional[str] = None) -> bool:
         logger.info("Show local terminal tab")
         try:
             class LocalConnection:
@@ -680,6 +683,20 @@ class TerminalManager:
                     self.is_connected = True
             local_connection = LocalConnection()
             terminal_widget = TerminalWidget(local_connection, self.window.config, self.window.connection_manager)
+            if pty_prompt and pty_response is not None:
+                terminal_widget._pty_autofill = (pty_prompt, pty_response)
+            if command and str(command).strip():
+                command_text = str(command).strip()
+
+                def _run_command(*_args):
+                    data = (command_text + "\n").encode("utf-8")
+                    backend = getattr(terminal_widget, "backend", None)
+                    if backend is not None and hasattr(backend, "feed_child"):
+                        backend.feed_child(data)
+                    elif getattr(terminal_widget, "vte", None) is not None:
+                        terminal_widget.vte.feed_child(data)
+
+                terminal_widget.connect("connection-established", _run_command)
             terminal_widget.setup_local_shell()
             self._add_terminal_tab(terminal_widget, title)
 
@@ -716,6 +733,7 @@ class TerminalManager:
                 # Fallback for older versions
                 GLib.timeout_add(100, _focus_local_terminal)
             logger.info("Local terminal tab created successfully")
+            return True
         except Exception as e:
             logger.error(f"Failed to show local terminal: {e}")
             try:
@@ -729,6 +747,7 @@ class TerminalManager:
                 dialog.present()
             except Exception:
                 pass
+            return False
 
     # Terminal discovery (regular tabs + split-view panes)
     def _is_broadcastable_ssh_terminal(self, terminal) -> bool:

--- a/tests/test_docker_manager_plugin.py
+++ b/tests/test_docker_manager_plugin.py
@@ -124,7 +124,8 @@ def test_connection_action_opens_per_host_tab_and_reuses_it():
 
 
 def test_tools_menu_opens_last_used_host():
-    ctx = _fake_ctx(last_host="beta")
+    connection = types.SimpleNamespace(nickname="beta", protocol="ssh")
+    ctx = _fake_ctx(last_host="beta", connections=(connection,))
     plugin = Plugin()
     plugin.activate(ctx)
     on_activate = next(p[4]["on_activate"] for p in ctx.ui.pages if p[0] == "manager")
@@ -132,13 +133,15 @@ def test_tools_menu_opens_last_used_host():
     assert "host-beta" in ctx.ui.opened
 
 
-def test_tools_menu_no_connections_notifies():
+def test_tools_menu_no_connections_opens_local_console():
     ctx = _fake_ctx(last_host=None, connections=())
     plugin = Plugin()
     plugin.activate(ctx)
     on_activate = next(p[4]["on_activate"] for p in ctx.ui.pages if p[0] == "manager")
     on_activate()
-    assert not ctx.ui.opened and ctx.ui.toasts
+    assert ctx.ui.opened == ["host-__local__"]
+    local = next(p for p in ctx.ui.pages if p[0] == "host-__local__")
+    assert local[1] == "Docker — Local"
 
 
 def test_activate_without_register_connection_action_is_safe():

--- a/tests/test_gui_docker_local.py
+++ b/tests/test_gui_docker_local.py
@@ -1,0 +1,70 @@
+"""GUI regressions for Docker Console's connection-free Local target."""
+
+import types
+
+import pytest
+
+from tests._gui_harness import requires_gui
+
+
+requires_gui()
+
+pytestmark = pytest.mark.gui
+
+
+class _Result:
+    exit_code = 0
+    stdout = ""
+    stderr = ""
+
+
+def _local_ctx():
+    calls = []
+    terminal_calls = []
+    ctx = types.SimpleNamespace(
+        connection_manager=types.SimpleNamespace(
+            find_connection_by_nickname=lambda nickname: None),
+        run_command=lambda *args, **kwargs:
+            pytest.fail("Local target must not use remote SSH command API"),
+        run_local_command=lambda command, **kwargs:
+            calls.append((command, kwargs)) or _Result(),
+        run_on_ui_thread=lambda fn, *args: fn(*args),
+        settings=types.SimpleNamespace(
+            get=lambda key, default=None: default,
+            set=lambda key, value: None,
+        ),
+        list_connections=lambda: [],
+        open_command_terminal=lambda *args, **kwargs:
+            pytest.fail("Local target must not open a remote SSH terminal"),
+        open_local_command_terminal=lambda command, **kwargs:
+            terminal_calls.append((command, kwargs)) or True,
+        ui=types.SimpleNamespace(notify=lambda *args, **kwargs: None),
+    )
+    return ctx, calls, terminal_calls
+
+
+def test_local_target_exists_without_ssh_connections(gui):
+    from sshpilot.plugins.builtin.docker_manager.page import DockerConsolePage
+
+    ctx, calls, _terminal_calls = _local_ctx()
+    page = DockerConsolePage(ctx)
+
+    assert page._current_nickname() == "__local__"
+    assert page._host_label.get_label() == "Local"
+    assert page._ensure_ssh_password("__local__") is True
+    assert page._client().ping().exit_code == 0
+    assert calls == [("docker ps -q", {"timeout": 30})]
+
+
+def test_local_interactive_action_uses_local_terminal(gui):
+    from sshpilot.plugins.builtin.docker_manager.page import DockerConsolePage
+
+    ctx, _calls, terminal_calls = _local_ctx()
+    page = DockerConsolePage(ctx)
+
+    assert page._open_command_terminal(
+        "__local__", "docker logs -f web", title="Web logs")
+    assert terminal_calls == [(
+        "docker logs -f web",
+        {"title": "Web logs", "pty_prompt": None, "pty_response": None},
+    )]

--- a/tests/test_plugin_context_power_apis.py
+++ b/tests/test_plugin_context_power_apis.py
@@ -14,11 +14,9 @@ from sshpilot.plugins.api import API_VERSION, CommandResult, PluginContext
 from sshpilot.plugins.registry import ProtocolRegistry
 
 
-def test_api_version_is_at_least_1_7():
-    # 1.6 added ctx.open_command_terminal; 1.7 added
-    # ctx.ui.register_connection_action. Keep the floor pinned so a regression
-    # that drops an API method is caught.
-    assert API_VERSION >= (1, 7)
+def test_api_version_is_at_least_1_11():
+    # 1.11 added local captured and interactive command APIs.
+    assert API_VERSION >= (1, 11)
 
 
 class _Conn:
@@ -126,6 +124,69 @@ def test_run_command_timeout_is_a_failed_result(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _boom)
     res = _ctx(_Manager([_Conn("web")])).run_command("web", "sleep 99")
     assert res.exit_code == -1 and "timed out" in res.stderr.lower()
+
+
+# --- local commands --------------------------------------------------------
+
+def test_run_local_command_uses_local_shell(monkeypatch):
+    seen = {}
+
+    monkeypatch.setattr("sshpilot.platform_utils.is_flatpak", lambda: False)
+
+    def _fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["input"] = kwargs["input"]
+        return types.SimpleNamespace(returncode=0, stdout="local\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    result = _ctx().run_local_command("printf local", input="stdin")
+
+    assert result.ok and result.stdout == "local\n"
+    assert seen["argv"][-2:] == ["-lc", "printf local"]
+    assert seen["input"] == "stdin"
+
+
+def test_run_local_command_uses_flatpak_host(monkeypatch):
+    seen = {}
+
+    monkeypatch.setattr("sshpilot.platform_utils.is_flatpak", lambda: True)
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/bin/flatpak-spawn" if name == "flatpak-spawn" else None,
+    )
+
+    def _fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert _ctx().run_local_command("docker ps").ok
+    assert seen["argv"] == [
+        "/usr/bin/flatpak-spawn", "--host", "sh", "-lc", "docker ps"]
+
+
+def test_open_local_command_terminal_delegates_to_host():
+    calls = []
+    host = types.SimpleNamespace(
+        events=types.SimpleNamespace(),
+        ui=types.SimpleNamespace(),
+        open_local_command_terminal=lambda command, **kwargs:
+            calls.append((command, kwargs)) or True,
+    )
+    ctx = PluginContext(
+        plugin_id="test-plugin", app_config=None,
+        connection_manager=_Manager([]), protocol_registry=ProtocolRegistry(),
+        host=host,
+    )
+
+    assert ctx.open_local_command_terminal(
+        "docker logs -f web", title="Logs",
+        pty_prompt="Password:", pty_response="secret",
+    )
+    assert calls == [(
+        "docker logs -f web",
+        {"title": "Logs", "pty_prompt": "Password:", "pty_response": "secret"},
+    )]
 
 
 # --- files facade ---------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an always-available Local target so Docker Console works without a localhost SSH profile
- add Flatpak-host-aware local captured and interactive command APIs while leaving remote Docker operations on the unified SSH/auth path
- route Docker polling, actions, logs, and exec terminals through the local APIs for the Local target
- add unit and real-GTK coverage for local target selection and transport routing

## Testing
- `python3 -m pytest tests/test_plugin_context_power_apis.py tests/test_docker_manager_plugin.py -q` — 86 passed, 15 skipped
- `DISPLAY=:1 SSHPILOT_GUI_TESTS=1 python3 -m pytest -m gui tests/test_gui_docker_local.py tests/test_gui_docker_password.py -q` — 5 passed
- Python compilation and `git diff --check` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6187be25-ed04-4fea-bc50-b170db97d894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6187be25-ed04-4fea-bc50-b170db97d894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

