### PR TITLE
Quiet wrong/noisy --verbose startup logs

### DIFF
--- a/sshpilot/icon_utils.py
+++ b/sshpilot/icon_utils.py
@@ -186,9 +186,9 @@ def new_image_from_icon_name(icon_name: str, size: Optional[int] = None) -> Gtk.
             file_obj = Gio.File.new_for_uri(resource_uri)
             file_icon = Gio.FileIcon.new(file_obj)
             image = Gtk.Image.new_from_gicon(file_icon)
-            
-            logger.debug(f"Loaded bundled icon from resource: {icon_name}")
-            
+
+            # Success is the hot path at window build (dozens of loads);
+            # only log misses below so --verbose startup stays readable.
             if size:
                 image.set_pixel_size(size)
             return image
@@ -230,8 +230,6 @@ def set_icon_from_name(image: Gtk.Image, icon_name: str) -> None:
             file_obj = Gio.File.new_for_uri(resource_uri)
             file_icon = Gio.FileIcon.new(file_obj)
             image.set_from_gicon(file_icon)
-            
-            logger.debug(f"Set bundled icon from resource: {icon_name}")
             return
         except (GLib.Error, Exception) as e:
             logger.debug(f"Bundled icon not found for {icon_name}, using icon theme: {e}")

--- a/sshpilot/main.py
+++ b/sshpilot/main.py
@@ -251,13 +251,11 @@ class SshPilotApplication(Adw.Application):
             'toggle_sidebar', ['F9', '<Meta>b'] if mac else ['F9']
         )
 
-        # Detailed shortcut list is verbose noise at INFO. Help → Keyboard
-        # Shortcuts already shows this to users.
-        if logger.isEnabledFor(logging.DEBUG):
-            mod_label = "Cmd" if mac else "Ctrl"
-            logger.debug("Registered keyboard shortcuts:")
-            logger.debug("  %s+N: new-connection", mod_label)
-            logger.debug("  %s+Shift+K: new-key", mod_label)
+        # Per-action registration already logs effective shortcuts above.
+        # Do not emit a partial "Registered keyboard shortcuts" summary —
+        # it previously claimed Ctrl/Cmd+N for new-connection while the
+        # real default is Ctrl/Cmd+Shift+N, and Help → Keyboard Shortcuts
+        # is the user-facing source of truth.
         if mac:
             self.create_action('local-terminal', self.on_local_terminal, ['<Meta><Shift>t'])
             self.create_action('preferences', self.on_preferences, ['<Meta>comma'])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`--verbose` startup was dominated by per-icon “Loaded bundled icon…” DEBUG lines, plus a stale shortcut summary that incorrectly claimed `Ctrl+N` for new-connection (actual Linux default is `Ctrl+Shift+N`).

## Changes

- Remove the partial “Registered keyboard shortcuts” summary in `main.py` (each action already logs its effective binding).
- Stop logging successful bundled icon loads in `icon_utils.py`; keep miss/fallback logs.

## Analysis (for the attached log)

| Category | Lines |
|---|---|
| **Wrong** | `Ctrl+N: new-connection` (should be Ctrl+Shift+N) |
| **Unnecessary noise** | All `Loaded bundled icon from resource: …` (incl. `L`/`R`/`D` port-forward badges — those names are intentional, the spam isn’t) |
| **Redundant, not wrong** | Second `Registered action 'toggle_sidebar'` (re-apply when the window action is created) |
| **Fine** | Crash diagnostics, GSettings, per-action shortcut registration, plugin registry, OverlaySplitView/sidebar setup, connection load, askpass server |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d388a862-0d35-4075-8454-c858d1b92dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d388a862-0d35-4075-8454-c858d1b92dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

