### PR TITLE
Fix import Include placement so Host * User root does not override hosts

### DIFF
--- a/sshpilot/backup_manager.py
+++ b/sshpilot/backup_manager.py
@@ -103,11 +103,213 @@ def _rebase_home_in_text(text: str, source_home: Optional[str], target_home: str
 # Include. Deliberately not inside a common ``*.d`` glob dir, so we can add an explicit Include
 # without risking double-inclusion.
 _IMPORT_FRAGMENT_NAME = "sshpilot-imported.conf"
+# Marker comment written immediately above our managed Include. Must stay at the *top* of the
+# main config (before any Host/Match): OpenSSH treats directives after a Host/Match as part of
+# that block, so an Include appended at EOF nests inside e.g. ``Host *`` / ``User root`` and
+# first-match-wins then overrides per-host ``User`` from the fragment (Oracle → root).
+_IMPORT_INCLUDE_MARKER = "# Added by sshPilot import"
 
 
 def _ssh_config_root(main_path: str) -> str:
     """Directory that owns the SSH config (``~/.ssh`` default, the app config dir isolated)."""
     return os.path.dirname(os.path.abspath(os.path.expanduser(main_path))) or os.path.expanduser('~')
+
+
+def _is_explicit_import_include_line(line: str, fragment_abs: str, config_root: str) -> bool:
+    """True when *line* is an ``Include`` that names our import fragment (not a glob)."""
+    s = line.strip()
+    if not s or s.startswith('#'):
+        return False
+    lowered = s.lower()
+    if not lowered.startswith('include'):
+        return False
+    # ``Include`` + separator (space or =)
+    rest = s[7:]
+    if rest.startswith('='):
+        rest = rest[1:]
+    elif rest[:1] and rest[:1].isspace():
+        rest = rest.lstrip()
+    else:
+        return False
+    try:
+        patterns = shlex.split(rest)
+    except ValueError:
+        return False
+    if len(patterns) != 1:
+        return False
+    pattern = patterns[0]
+    if any(ch in pattern for ch in '*?['):
+        return False
+    from .ssh_config_utils import expand_ssh_tokens
+    expanded = os.path.expanduser(os.path.expandvars(expand_ssh_tokens(pattern)))
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(config_root, expanded)
+    return os.path.abspath(expanded) == os.path.abspath(fragment_abs)
+
+
+def _strip_managed_import_includes(text: str, fragment_abs: str, config_root: str) -> str:
+    """Remove sshPilot-managed ``Include`` lines (and their marker comments) for *fragment_abs*."""
+    if not text:
+        return text
+    lines = text.splitlines(keepends=True)
+    out: List[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        stripped = lines[i].strip()
+        if stripped == _IMPORT_INCLUDE_MARKER:
+            i += 1
+            if i < n and _is_explicit_import_include_line(lines[i], fragment_abs, config_root):
+                i += 1
+            # Drop one blank line that commonly followed our appended block.
+            if i < n and lines[i].strip() == '':
+                i += 1
+            continue
+        if _is_explicit_import_include_line(lines[i], fragment_abs, config_root):
+            i += 1
+            if i < n and lines[i].strip() == '':
+                i += 1
+            continue
+        out.append(lines[i])
+        i += 1
+    return ''.join(out)
+
+
+def _import_include_follows_host_or_match(text: str, fragment_abs: str, config_root: str) -> bool:
+    """True if our managed Include appears after a Host/Match (i.e. nested inside a block)."""
+    seen_block = False
+    for raw in text.splitlines():
+        kw = _ssh_keyword(raw)
+        if kw in ('host', 'match'):
+            seen_block = True
+        if not seen_block:
+            continue
+        if raw.strip() == _IMPORT_INCLUDE_MARKER:
+            return True
+        if _is_explicit_import_include_line(raw, fragment_abs, config_root):
+            return True
+    return False
+
+
+def _import_include_arg(frag_abs: str, config_root: str) -> str:
+    """Return the Include path OpenSSH will resolve with ``-F`` for this config.
+
+    OpenSSH resolves *relative* user-config Includes under ``~/.ssh``, not under the
+    directory of the ``-F`` file. Relative names are therefore only safe when the
+    main config itself lives in ``~/.ssh``; isolated mode (and tests) need an
+    absolute path so ``ssh -F <isolated>`` still finds the fragment.
+    """
+    ssh_dir = os.path.abspath(os.path.expanduser(os.path.join("~", ".ssh")))
+    if os.path.abspath(config_root) == ssh_dir:
+        return os.path.relpath(frag_abs, config_root)
+    return os.path.abspath(frag_abs)
+
+
+def ensure_import_include_at_top(main_path: str, fragment_path: Optional[str] = None) -> bool:
+    """Ensure the merge-import ``Include`` is a top-level directive at the start of *main_path*.
+
+    OpenSSH nests any directive that appears after a ``Host``/``Match`` inside that block.
+    Appending ``Include sshpilot-imported.conf`` at EOF therefore lands inside a trailing
+    ``Host *`` (common for defaults / IdentityAgent), so ``User root`` from ``Host *``
+    wins over per-host ``User`` values in the fragment.
+
+    Returns True when the main config file was rewritten.
+    """
+    main_path = os.path.abspath(os.path.expanduser(main_path))
+    root = _ssh_config_root(main_path)
+    frag_abs = os.path.abspath(
+        fragment_path or os.path.join(root, _IMPORT_FRAGMENT_NAME))
+    if not os.path.isfile(frag_abs):
+        return False
+
+    existing = ''
+    if os.path.exists(main_path):
+        try:
+            with open(main_path, encoding='utf-8') as f:
+                existing = f.read()
+        except OSError:
+            return False
+
+    stripped = _strip_managed_import_includes(existing, frag_abs, root)
+
+    # Is the fragment still pulled in without our explicit Include (e.g. ``Include *.conf``)?
+    still_covered = False
+    try:
+        import tempfile
+        from .ssh_config_utils import resolve_ssh_config_files
+        fd, tmp = tempfile.mkstemp(prefix='sshpilot-inc-', suffix='.conf', dir=root)
+        try:
+            os.close(fd)
+            with open(tmp, 'w', encoding='utf-8') as f:
+                f.write(stripped)
+            # Point includes relative to the real config root: rewrite is same dir as main.
+            # resolve uses the temp file's directory for relative Includes — same root.
+            resolved = {os.path.abspath(p) for p in resolve_ssh_config_files(tmp)}
+            still_covered = frag_abs in resolved
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except Exception:
+        still_covered = False
+
+    if still_covered:
+        new_text = stripped
+    else:
+        include_arg = _import_include_arg(frag_abs, root)
+        block = f"{_IMPORT_INCLUDE_MARKER}\nInclude {include_arg}\n\n"
+        body = stripped[1:] if stripped.startswith('\n') else stripped
+        new_text = block + body
+
+    if new_text == existing:
+        return False
+
+    # Atomic replace (same pattern as BackupManager._atomic_write_text).
+    tmp_path = main_path + '.tmp'
+    try:
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            f.write(new_text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, main_path)
+        try:
+            os.chmod(main_path, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    logger.info("Placed sshPilot import Include at top of %s", main_path)
+    return True
+
+
+def repair_misplaced_import_include(main_path: str) -> bool:
+    """Rewrite *main_path* when a prior merge left ``Include sshpilot-imported.conf`` nested
+    under a Host/Match block. No-op when the fragment is absent or already top-level."""
+    main_path = os.path.abspath(os.path.expanduser(main_path))
+    root = _ssh_config_root(main_path)
+    frag_abs = os.path.join(root, _IMPORT_FRAGMENT_NAME)
+    if not os.path.isfile(frag_abs) or not os.path.isfile(main_path):
+        return False
+    try:
+        with open(main_path, encoding='utf-8') as f:
+            text = f.read()
+    except OSError:
+        return False
+    if not _import_include_follows_host_or_match(text, frag_abs, root):
+        # Still ensure a top-level Include exists when the fragment is orphaned.
+        from .ssh_config_utils import resolve_ssh_config_files
+        try:
+            resolved = {os.path.abspath(p) for p in resolve_ssh_config_files(main_path)}
+        except Exception:
+            resolved = set()
+        if frag_abs in resolved:
+            return False
+    return ensure_import_include_at_top(main_path, frag_abs)
 
 
 def _is_under(path: str, root: str) -> bool:
@@ -1178,30 +1380,13 @@ class BackupManager:
         logger.info("Merged SSH hosts into fragment %s", fragment)
 
     def _ensure_include(self, main_path: str, fragment_path: str) -> None:
-        """Add one ``Include`` for ``fragment_path`` to the main config — unless it is already
-        resolved (via an explicit Include or a glob that already covers it), which avoids
-        double-inclusion (and the duplicate stanzas that would produce)."""
-        from .ssh_config_utils import resolve_ssh_config_files
-        frag_abs = os.path.abspath(fragment_path)
-        try:
-            resolved = {os.path.abspath(p) for p in resolve_ssh_config_files(main_path)}
-        except Exception:
-            resolved = set()
-        if frag_abs in resolved:
-            return
-        rel = os.path.relpath(frag_abs, _ssh_config_root(main_path))
-        existing = ''
-        if os.path.exists(main_path):
-            try:
-                with open(main_path, encoding='utf-8') as f:
-                    existing = f.read()
-            except OSError:
-                existing = ''
-        prefix = existing
-        if prefix and not prefix.endswith('\n'):
-            prefix += '\n'
-        self._atomic_write_text(
-            main_path, prefix + f"\n# Added by sshPilot import\nInclude {rel}\n", 0o600)
+        """Ensure a top-level ``Include`` for ``fragment_path`` at the start of the main config.
+
+        Must be placed *before* any Host/Match block. Appending at EOF nests the Include
+        inside the preceding Host (often ``Host *`` with ``User root``), and OpenSSH's
+        first-match-wins then overrides per-host User values from the fragment.
+        """
+        ensure_import_include_at_top(main_path, fragment_path)
 
     def _merge_known_hosts(self, target_path: str, imported_hosts: str):
         """Merge known_hosts by appending unique entries"""

--- a/sshpilot/backup_manager.py
+++ b/sshpilot/backup_manager.py
@@ -105,8 +105,10 @@ def _rebase_home_in_text(text: str, source_home: Optional[str], target_home: str
 _IMPORT_FRAGMENT_NAME = "sshpilot-imported.conf"
 # Marker comment written immediately above our managed Include. Must stay at the *top* of the
 # main config (before any Host/Match): OpenSSH treats directives after a Host/Match as part of
-# that block, so an Include appended at EOF nests inside e.g. ``Host *`` / ``User root`` and
-# first-match-wins then overrides per-host ``User`` from the fragment (Oracle → root).
+# that block, so an Include appended at EOF is nested inside the preceding Host. Then either
+# (a) that Host does not match the target and the fragment is skipped entirely, or (b) a
+# matching ``Host *`` has already set options such as ``User``, which first-match-wins keeps
+# over the fragment's per-host values.
 _IMPORT_INCLUDE_MARKER = "# Added by sshPilot import"
 
 
@@ -209,9 +211,10 @@ def ensure_import_include_at_top(main_path: str, fragment_path: Optional[str] = 
     """Ensure the merge-import ``Include`` is a top-level directive at the start of *main_path*.
 
     OpenSSH nests any directive that appears after a ``Host``/``Match`` inside that block.
-    Appending ``Include sshpilot-imported.conf`` at EOF therefore lands inside a trailing
-    ``Host *`` (common for defaults / IdentityAgent), so ``User root`` from ``Host *``
-    wins over per-host ``User`` values in the fragment.
+    Appending ``Include sshpilot-imported.conf`` at EOF therefore lands inside whatever Host
+    came last (user defaults, a managed IdentityAgent ``Host *``, or an ordinary host). A
+    non-matching outer Host skips the fragment; a matching ``Host *`` can lock in earlier
+    options (e.g. ``User``) via first-match-wins before the fragment's per-host values apply.
 
     Returns True when the main config file was rewritten.
     """

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -1265,6 +1265,16 @@ class ConnectionManager(GObject.Object):
                 return
             else:
                 self._ensure_secure_permissions(self.ssh_config_path, 0o600)
+            # Heal a merge-import Include that was previously appended at EOF (nested
+            # inside Host */User root → OpenSSH first-match-wins overrides fragment Users).
+            try:
+                from .backup_manager import repair_misplaced_import_include
+                if repair_misplaced_import_include(self.ssh_config_path):
+                    logger.info(
+                        "Relocated sshPilot import Include to top of SSH config "
+                        "(was nested under a Host/Match block)")
+            except Exception as exc:
+                logger.debug("Import Include placement repair skipped: %s", exc)
             config_files = resolve_ssh_config_files(self.ssh_config_path)
 
             # Directives that accumulate per ssh_config(5) ("Multiple ...

--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -857,14 +857,99 @@ def test_merge_fragment_dedups_drops_globals_keeps_unindented(monkeypatch, tmp_p
     assert "existing-main" not in frag
     assert mgr.last_merge_dropped_globals >= 2                       # Host* + Match
     assert any("brand-new" in " ".join(p) for p in mgr.last_merge_collisions)
-    # main gained exactly one Include for the fragment
-    assert main.read_text().count(f"Include {bm._IMPORT_FRAGMENT_NAME}") == 1
+    # main gained exactly one Include for the fragment — at the TOP (before any Host/Match).
+    main_text = main.read_text()
+    assert main_text.count(bm._IMPORT_FRAGMENT_NAME) >= 1
+    assert main_text.lstrip().startswith(bm._IMPORT_INCLUDE_MARKER)
+    include_lines = [l for l in main_text.splitlines()
+                     if l.strip().lower().startswith("include") and bm._IMPORT_FRAGMENT_NAME in l]
+    assert len(include_lines) == 1
+    first_host = main_text.lower().find("\nhost ")
+    first_include = main_text.find(include_lines[0])
+    assert first_include != -1 and (first_host == -1 or first_include < first_host)
 
     # Idempotent: re-importing the same hosts adds nothing (fragment is Include-resolved now).
     before = fragment.read_text()
     mgr._merge_ssh_config_fragment(str(main), [imported])
     assert fragment.read_text() == before
-    assert main.read_text().count(f"Include {bm._IMPORT_FRAGMENT_NAME}") == 1
+    assert len([l for l in main.read_text().splitlines()
+                if l.strip().lower().startswith("include") and bm._IMPORT_FRAGMENT_NAME in l]) == 1
+
+
+def test_ensure_include_prepends_before_host_star(monkeypatch, tmp_path):
+    """Include must be top-level; appended under Host * lets User root win (Oracle bug)."""
+    monkeypatch.setattr(bm, "get_config_dir", lambda: str(tmp_path / "cfg"))
+    root = tmp_path / "dotssh"
+    root.mkdir()
+    main = root / "config"
+    main.write_text(
+        "Host USA\n    HostName 1.2.3.4\n    User root\n\n"
+        "Host *\n    User root\n    ServerAliveInterval 60\n",
+        encoding="utf-8",
+    )
+    mgr = bm.BackupManager(FakeConfig(), FakeConnMgr([], ssh_config_path=str(main)))
+    mgr._merge_ssh_config_fragment(
+        str(main),
+        ["Host Oracle\n    HostName 150.230.27.23\n    User ubuntu\n    Port 2222\n"
+         "    ProxyJump USA\n"],
+    )
+    text = main.read_text()
+    assert text.startswith(bm._IMPORT_INCLUDE_MARKER + "\n")
+    include_line = text.splitlines()[1]
+    assert include_line.lower().startswith("include") and bm._IMPORT_FRAGMENT_NAME in include_line
+    # Must appear before Host *
+    assert text.find(include_line) < text.lower().find("host *")
+    # Outside ~/.ssh, Include must be absolute so OpenSSH -F resolves it.
+    assert include_line.split(None, 1)[1].startswith(str(root))
+
+    # OpenSSH effective config: User ubuntu, not root from Host *
+    import shutil
+    import subprocess
+    if shutil.which("ssh"):
+        out = subprocess.check_output(
+            ["ssh", "-F", str(main), "-G", "Oracle"], text=True, stderr=subprocess.DEVNULL)
+        opts = {line.split(" ", 1)[0]: line.split(" ", 1)[1]
+                for line in out.splitlines() if " " in line}
+        assert opts.get("user") == "ubuntu"
+        assert opts.get("hostname") == "150.230.27.23"
+        assert opts.get("port") == "2222"
+
+
+def test_repair_relocates_appended_import_include(tmp_path):
+    """Existing installs that appended Include under Host * are healed on repair."""
+    root = tmp_path / "dotssh"
+    root.mkdir()
+    main = root / "config"
+    frag = root / bm._IMPORT_FRAGMENT_NAME
+    frag.write_text(
+        "Host Oracle\n    HostName 150.230.27.23\n    User ubuntu\n    Port 2222\n",
+        encoding="utf-8",
+    )
+    # Simulate the old bug: relative Include appended after Host *
+    main.write_text(
+        "Host *\n    User root\n\n"
+        f"{bm._IMPORT_INCLUDE_MARKER}\nInclude {bm._IMPORT_FRAGMENT_NAME}\n",
+        encoding="utf-8",
+    )
+    assert bm._import_include_follows_host_or_match(
+        main.read_text(), str(frag), str(root))
+    assert bm.repair_misplaced_import_include(str(main)) is True
+    text = main.read_text()
+    assert text.startswith(bm._IMPORT_INCLUDE_MARKER)
+    include_lines = [l for l in text.splitlines()
+                     if l.strip().lower().startswith("include") and bm._IMPORT_FRAGMENT_NAME in l]
+    assert len(include_lines) == 1
+    assert not bm._import_include_follows_host_or_match(text, str(frag), str(root))
+    # Second repair is a no-op
+    assert bm.repair_misplaced_import_include(str(main)) is False
+
+    import shutil
+    import subprocess
+    if shutil.which("ssh"):
+        out = subprocess.check_output(
+            ["ssh", "-F", str(main), "-G", "Oracle"], text=True, stderr=subprocess.DEVNULL)
+        user_lines = [l for l in out.splitlines() if l.startswith("user ")]
+        assert user_lines == ["user ubuntu"]
 
 
 def test_merge_no_double_include_when_glob_already_covers(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a Bitwarden backup **merge**, sshPilot appended:

```
# Added by sshPilot import
Include sshpilot-imported.conf
```

at the **end** of `~/.ssh/config`. OpenSSH treats any directive after a `Host`/`Match` as part of that block, so the Include is nested inside whatever Host came last.

Effects:
- If that outer Host does **not** match the target (common when there is no `Host *`), the fragment is skipped for that connection — imported `HostName`/`User`/`Port`/`ProxyJump` never apply.
- If a matching `Host *` (user defaults or sshPilot’s managed IdentityAgent block) already set options such as `User`, first-match-wins keeps those over the fragment.

Separately, hosts like **Oracle** use `ProxyJump USA` and USA is `User root`, so the first auth hop/error can show `root` even when Oracle itself is `User ubuntu`.

## Fix

- Prepend the managed import `Include` **before** any `Host`/`Match`
- Use an absolute Include path when the config is not in `~/.ssh` (isolated mode / `ssh -F`)
- On SSH config load, relocate a previously appended import Include so existing installs heal without re-importing

## Test plan

- [x] Unit tests for prepend-before-`Host *`, repair of appended Include, and `ssh -G Oracle` → `user ubuntu`
- [x] Full `tests/test_backup_manager.py` (34 passed)
- [ ] Manual: merge-import with Include previously at EOF; confirm `ssh -G Oracle` shows fragment User/HostName/Port/ProxyJump
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628ba6f1-140d-4365-88eb-bde61408f46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628ba6f1-140d-4365-88eb-bde61408f46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

