### PR TITLE
Fix GtkSourceView missing from macOS PyInstaller Frameworks root

### DIFF
--- a/.github/workflows/macos-pyinstaller-x86.yml
+++ b/.github/workflows/macos-pyinstaller-x86.yml
@@ -90,6 +90,20 @@ jobs:
           fi
           echo "=== CHECK: sshpass x86_64 architecture verified ==="
 
+      - name: Verify GtkSourceView dylib at Frameworks root
+        run: |
+          # GI typelibs dlopen bare sonames from Contents/Frameworks/ only.
+          FRAMEWORKS="dist/SSHPilot.app/Contents/Frameworks"
+          if [ -e "$FRAMEWORKS/libgtksourceview-5.0.dylib" ] \
+             || ls "$FRAMEWORKS"/libgtksourceview-5*.dylib >/dev/null 2>&1; then
+            echo "=== CHECK: GtkSourceView dylib at Frameworks root ==="
+            ls -la "$FRAMEWORKS"/libgtksourceview-5*.dylib
+          else
+            echo "=== ERROR: libgtksourceview-5 missing from $FRAMEWORKS ==="
+            find dist/SSHPilot.app -name "*gtksourceview*" 2>/dev/null || true
+            exit 1
+          fi
+
 
       - name: Determine artifact names
         id: artifact-info

--- a/.github/workflows/macos-pyinstaller.yml
+++ b/.github/workflows/macos-pyinstaller.yml
@@ -148,11 +148,15 @@ jobs:
             echo "=== DEBUG: SSHPilot.app structure ==="
             find dist/SSHPilot.app -name "*.so" -o -name "*.dylib" -o -name "SSHPilot" | head -20
             echo "=== DEBUG: Checking for gtksourceview5 files ==="
-            if find dist/SSHPilot.app -name "*gtksourceview*" | grep -q .; then
-              echo "=== DEBUG: Found gtksourceview5 files ==="
-              find dist/SSHPilot.app -name "*gtksourceview*" | head -10
+            if [ -e "dist/SSHPilot.app/Contents/Frameworks/libgtksourceview-5.0.dylib" ] \
+               || ls dist/SSHPilot.app/Contents/Frameworks/libgtksourceview-5*.dylib >/dev/null 2>&1; then
+              echo "=== DEBUG: Found gtksourceview5 at Frameworks root (required for GI) ==="
+              ls -la dist/SSHPilot.app/Contents/Frameworks/libgtksourceview-5*.dylib
             else
-              echo "=== DEBUG: WARNING - No gtksourceview5 files found in bundle ==="
+              echo "=== DEBUG: ERROR - libgtksourceview-5 missing from Contents/Frameworks/ ==="
+              echo "=== DEBUG: Nested Frameworks/Frameworks copies are NOT loaded by GI ==="
+              find dist/SSHPilot.app -name "*gtksourceview*" || true
+              exit 1
             fi
             echo "=== DEBUG: Checking for gtksourceview5 share data ==="
             if [ -d "dist/SSHPilot.app/Contents/Resources/share/gtksourceview-5" ]; then

--- a/packaging/pyinstaller/gtk_bundle.py
+++ b/packaging/pyinstaller/gtk_bundle.py
@@ -1,0 +1,76 @@
+"""Helpers for bundling GTK/GI dylibs into the macOS PyInstaller .app.
+
+GI typelibs dlopen bare sonames (e.g. ``libgtksourceview-5.0.dylib``) from
+``Contents/Frameworks/``. Placing libraries under a nested
+``Contents/Frameworks/Frameworks/`` directory leaves them invisible to that
+lookup and breaks features such as the SSH config editor.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+
+# Dest "." → Contents/Frameworks/<lib>.dylib (correct for GI dlopen).
+# Dest "Frameworks" → Contents/Frameworks/Frameworks/<lib>.dylib (broken).
+GI_DYLIB_BUNDLE_DEST = "."
+
+
+def collect_homebrew_dylibs(
+    hb_lib: str,
+    patterns: Sequence[str],
+    dest: str = GI_DYLIB_BUNDLE_DEST,
+) -> List[Tuple[str, str]]:
+    """Return ``(src, dest)`` pairs for Homebrew dylibs matching *patterns*."""
+    import glob
+
+    binaries: List[Tuple[str, str]] = []
+    for pat in patterns:
+        for src in glob.glob(os.path.join(hb_lib, pat)):
+            binaries.append((src, dest))
+    return binaries
+
+
+def find_gtksourceview_dylibs(frameworks_dir: Path) -> List[Path]:
+    """List ``libgtksourceview-5*.dylib`` entries directly under Frameworks."""
+    if not frameworks_dir.is_dir():
+        return []
+    return sorted(frameworks_dir.glob("libgtksourceview-5*.dylib"))
+
+
+def ensure_gtksourceview_abi_name(frameworks_dir: Path) -> Optional[Path]:
+    """Ensure ``libgtksourceview-5.0.dylib`` exists (typelib ABI name).
+
+    If only a versioned real file is present (e.g. ``libgtksourceview-5.0.0.dylib``),
+    create a relative symlink with the ABI name. Returns the ABI path, or None
+    if no gtksourceview dylib is present at Frameworks root.
+    """
+    abi = frameworks_dir / "libgtksourceview-5.0.dylib"
+    if abi.exists() or abi.is_symlink():
+        return abi
+
+    versioned = [
+        p for p in find_gtksourceview_dylibs(frameworks_dir)
+        if p.name != abi.name
+    ]
+    if not versioned:
+        return None
+
+    target = versioned[0]
+    abi.symlink_to(target.name)
+    return abi
+
+
+def gtksourceview_bundle_ok(frameworks_dir: Path) -> bool:
+    """True when Frameworks root has the ABI-named GtkSourceView dylib."""
+    ensure_gtksourceview_abi_name(frameworks_dir)
+    abi = frameworks_dir / "libgtksourceview-5.0.dylib"
+    return abi.exists() or abi.is_symlink()
+
+
+def nested_frameworks_paths(frameworks_dir: Path) -> List[Path]:
+    """Return gtksourceview dylibs wrongly nested under Frameworks/Frameworks."""
+    nested = frameworks_dir / "Frameworks"
+    return find_gtksourceview_dylibs(nested)

--- a/packaging/pyinstaller/gtk_bundle.py
+++ b/packaging/pyinstaller/gtk_bundle.py
@@ -4,6 +4,15 @@ GI typelibs dlopen bare sonames (e.g. ``libgtksourceview-5.0.dylib``) from
 ``Contents/Frameworks/``. Placing libraries under a nested
 ``Contents/Frameworks/Frameworks/`` directory leaves them invisible to that
 lookup and breaks features such as the SSH config editor.
+
+The stock PyInstaller hook ``hook-gi.repository.GtkSource``
+(https://github.com/pyinstaller/pyinstaller/pull/3893) already collects the
+shared library with dest ``"."`` (Frameworks root) and, on macOS, rewrites the
+typelib to ``@loader_path/…``. It defaults to GtkSource 3.0 — use
+``hooksconfig['gi']['module-versions']['GtkSource'] = '5'`` plus a
+``gi.repository.GtkSource`` hiddenimport so the hook actually runs for v5.
+These helpers remain as an explicit Homebrew fallback and for build-time
+verification.
 """
 
 from __future__ import annotations

--- a/packaging/pyinstaller/hook-gtk_runtime.py
+++ b/packaging/pyinstaller/hook-gtk_runtime.py
@@ -21,9 +21,14 @@ if sys.platform == "darwin":
     frameworks = (contents / "Frameworks").resolve()
 
     gi_paths = [
-        str(contents / "girepository-1.0"),  # Direct in _internal for onedir
+        # Prefer PyInstaller's GI-hook output (gi_typelibs): on macOS the stock
+        # hooks rewrite shared-library paths to @loader_path/… (see
+        # gir_library_path_fix / pyinstaller#3893). Raw Homebrew typelibs
+        # copied into girepository-1.0 still name bare sonames.
+        str(resources / "gi_typelibs"),
+        str(contents / "gi_typelibs"),
+        str(contents / "girepository-1.0"),
         str(resources / "girepository-1.0"),
-        str(resources / "gi_typelibs"),  # PyInstaller's GI dump
     ]
     os.environ["GI_TYPELIB_PATH"] = ":".join([p for p in gi_paths if Path(p).exists()])
     

--- a/packaging/pyinstaller/pyinstaller.sh
+++ b/packaging/pyinstaller/pyinstaller.sh
@@ -61,6 +61,31 @@ python -m PyInstaller --clean --noconfirm packaging/pyinstaller/sshpilot.spec
 if [ -d "dist/SSHPilot.app" ]; then
     echo "✅ Build successful! Bundle created at: dist/SSHPilot.app"
 
+    # GI typelibs dlopen bare sonames from Contents/Frameworks/ (not a nested
+    # Frameworks/Frameworks/). Fail the build if GtkSourceView is missing —
+    # otherwise the SSH config editor crashes with "must be an interface".
+    FRAMEWORKS_DIR="dist/SSHPilot.app/Contents/Frameworks"
+    echo "🔍 Verifying GtkSourceView dylib in Frameworks root..."
+    if ! ls "$FRAMEWORKS_DIR"/libgtksourceview-5*.dylib >/dev/null 2>&1; then
+        echo "❌ libgtksourceview-5*.dylib not found in $FRAMEWORKS_DIR"
+        echo "   Nested copies under Frameworks/Frameworks/ are not loaded by GI."
+        find dist/SSHPilot.app -name '*gtksourceview*' 2>/dev/null || true
+        exit 1
+    fi
+    # Typelib references libgtksourceview-5.0.dylib; ensure that ABI name exists
+    # even if PyInstaller only copied the versioned real file.
+    if [ ! -e "$FRAMEWORKS_DIR/libgtksourceview-5.0.dylib" ]; then
+        VERSIONED="$(ls "$FRAMEWORKS_DIR"/libgtksourceview-5.*.dylib 2>/dev/null | head -1 || true)"
+        if [ -n "$VERSIONED" ]; then
+            ln -sf "$(basename "$VERSIONED")" "$FRAMEWORKS_DIR/libgtksourceview-5.0.dylib"
+            echo "✅ Created ABI symlink libgtksourceview-5.0.dylib -> $(basename "$VERSIONED")"
+        else
+            echo "❌ Could not create libgtksourceview-5.0.dylib ABI name"
+            exit 1
+        fi
+    fi
+    echo "✅ GtkSourceView dylib present: $(ls "$FRAMEWORKS_DIR"/libgtksourceview-5*.dylib)"
+
     # Bundle sshpass into the correct location expected by hook-gtk_runtime.py
     # (Contents/Resources/bin/ — NOT Contents/MacOS/ which PyInstaller's binaries[] uses)
     echo "🔑 Bundling sshpass..."

--- a/packaging/pyinstaller/sshpilot.spec
+++ b/packaging/pyinstaller/sshpilot.spec
@@ -9,6 +9,10 @@ site_packages_dir = Path(sysconfig.get_path("platlib"))
 # This spec lives in packaging/pyinstaller/; anchor paths to the repo root.
 ROOT = os.path.abspath(os.path.join(SPECPATH, os.pardir, os.pardir))
 
+# Local helpers for GI dylib placement (must live next to this spec).
+sys.path.insert(0, SPECPATH)
+from gtk_bundle import collect_homebrew_dylibs  # noqa: E402
+
 app_name = "SSHPilot"
 entry_py = os.path.join(ROOT, "run.py")
 icon_file = os.path.join(ROOT, "packaging", "macos", "sshpilot.icns")
@@ -55,14 +59,9 @@ gtk_libs_patterns = [
     "libicu*.dylib",
 ]
 
-binaries = []
-for pat in gtk_libs_patterns:
-    for src in glob.glob(os.path.join(hb_lib, pat)):
-        # Special handling for VTE and Adwaita libraries to avoid nested Frameworks structure
-        if "vte" in pat.lower() or "adwaita" in pat.lower():
-            binaries.append((src, "."))  # Place directly in Frameworks root
-        else:
-            binaries.append((src, "Frameworks"))
+# Place GI dylibs at Contents/Frameworks/ (dest "."). Nested Frameworks/Frameworks
+# breaks typelib dlopen of bare sonames such as libgtksourceview-5.0.dylib.
+binaries = collect_homebrew_dylibs(hb_lib, gtk_libs_patterns)
 
 # GI typelibs
 datas = []

--- a/packaging/pyinstaller/sshpilot.spec
+++ b/packaging/pyinstaller/sshpilot.spec
@@ -61,6 +61,8 @@ gtk_libs_patterns = [
 
 # Place GI dylibs at Contents/Frameworks/ (dest "."). Nested Frameworks/Frameworks
 # breaks typelib dlopen of bare sonames such as libgtksourceview-5.0.dylib.
+# The stock hook-gi.repository.GtkSource (pyinstaller#3893) also uses dest ".";
+# this Homebrew glob is belt-and-suspenders for libs GI hooks may miss.
 binaries = collect_homebrew_dylibs(hb_lib, gtk_libs_patterns)
 
 # GI typelibs
@@ -158,6 +160,18 @@ if gi_site_packages.exists():
 
 hiddenimports = collect_submodules("gi")
 hiddenimports += ["gi._gi_cairo", "gi.repository.cairo", "cairo"]
+# Force the stock PyInstaller GI hooks to run (hook-gi.repository.GtkSource
+# from pyinstaller#3893, etc.). GtkSource is imported behind try/except in app
+# code, so analysis may miss it without an explicit hiddenimport. The hook
+# collects the shared library at Frameworks root (dest ".") and on macOS
+# rewrites the typelib to @loader_path/… — but only for the configured version.
+hiddenimports += [
+    "gi.repository.Gtk",
+    "gi.repository.Gdk",
+    "gi.repository.GtkSource",
+    "gi.repository.Adw",
+    "gi.repository.Vte",
+]
 # Built-in plugins are imported dynamically (the loader scans the dir), so
 # PyInstaller can't see them by following imports — collect them explicitly,
 # and bundle their plugin.json manifests (read from disk at runtime).
@@ -190,6 +204,22 @@ for _kp_bin in ("lxml", "Cryptodome", "argon2_cffi_bindings"):
     except Exception:
         pass
 
+# Official GI hooks default to Gtk/GtkSource 3.x; sshPilot needs GTK4 + GtkSource 5
+# (see https://github.com/pyinstaller/pyinstaller/pull/3893 and hooks-config docs).
+gi_hooksconfig = {
+    "gi": {
+        "module-versions": {
+            "Gtk": "4.0",
+            "Gdk": "4.0",
+            "GtkSource": "5",
+        },
+        # Keep the bundle lean — full icon/theme trees are huge; we already ship
+        # Adwaita icons via datas above.
+        "icons": ["Adwaita"],
+        "themes": ["Adwaita"],
+    },
+}
+
 block_cipher = None
 
 a = Analysis(
@@ -199,6 +229,7 @@ a = Analysis(
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[SPECPATH],
+    hooksconfig=gi_hooksconfig,
     runtime_hooks=[os.path.join(SPECPATH, "hook-gtk_runtime.py")],
     noarchive=False,
 )

--- a/sshpilot/file_manager_window.py
+++ b/sshpilot/file_manager_window.py
@@ -32,13 +32,16 @@ from gettext import gettext as _
 
 from gi.repository import Adw, Gio, GLib, GObject, Gdk, Gtk
 
-# Try to import GtkSourceView for syntax highlighting
+# Try to import GtkSourceView for syntax highlighting.
+# Probe a type so a missing shared library (incomplete bundle) disables GtkSource
+# instead of failing later with a cryptic GI error.
 try:
     import gi
     gi.require_version('GtkSource', '5')
     from gi.repository import GtkSource
+    _ = GtkSource.View  # noqa: F841 — force shared-library load
     _HAS_GTKSOURCE = True
-except (ImportError, ValueError, AttributeError):
+except Exception:  # noqa: BLE001 — ImportError/ValueError/GError/TypeError
     _HAS_GTKSOURCE = False
     GtkSource = None
 

--- a/sshpilot/text_editor.py
+++ b/sshpilot/text_editor.py
@@ -19,13 +19,17 @@ from gi.repository import Adw, Gio, GLib, GObject, Gdk, Gtk, Pango
 
 from .platform_utils import is_macos
 
-# Try to import GtkSourceView for syntax highlighting
+# Try to import GtkSourceView for syntax highlighting.
+# Typelib import alone can succeed when the shared library is missing (e.g. an
+# incomplete PyInstaller bundle); probing a type forces the dylib load so we
+# fall back to Gtk.TextView instead of crashing later with "must be an interface".
 try:
     import gi
     gi.require_version('GtkSource', '5')
     from gi.repository import GtkSource
+    _ = GtkSource.View  # noqa: F841 — force shared-library load
     _HAS_GTKSOURCE = True
-except (ImportError, ValueError, AttributeError):
+except Exception:  # noqa: BLE001 — ImportError/ValueError/GError/TypeError
     _HAS_GTKSOURCE = False
     GtkSource = None
 
@@ -287,22 +291,11 @@ class RemoteFileEditorWindow(Adw.Window):
         
         header_bar.pack_start(zoom_box)
 
-        # Color-scheme chooser — icon-only button on the right, just before Save.
-        # Only meaningful with GtkSource.
-        if self._gtksource_enabled and hasattr(GtkSource, "StyleSchemeChooserWidget"):
-            self._scheme_button = Gtk.MenuButton()
-            self._scheme_button.set_child(icon_utils.new_image_from_icon_name("color-symbolic"))
-            self._scheme_button.set_tooltip_text("Editor color scheme")
-            chooser_scroller = Gtk.ScrolledWindow()
-            chooser_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-            chooser_scroller.set_min_content_width(240)
-            chooser_scroller.set_min_content_height(320)
-            self._scheme_chooser = GtkSource.StyleSchemeChooserWidget()
-            chooser_scroller.set_child(self._scheme_chooser)
-            popover = Gtk.Popover()
-            popover.set_child(chooser_scroller)
-            self._scheme_button.set_popover(popover)
-            header_bar.pack_end(self._scheme_button)
+        # Color-scheme chooser is added after GtkSourceView init succeeds
+        # (_add_scheme_chooser). Creating StyleSchemeChooserWidget before the
+        # shared library is verified crashes with "must be an interface" when
+        # the typelib is present but the dylib is missing from the bundle.
+        self._header_bar = header_bar
 
         toolbar_view.add_top_bar(header_bar)
         
@@ -371,7 +364,9 @@ class RemoteFileEditorWindow(Adw.Window):
         # Create editor widget (SourceView if available, otherwise TextView)
         if not self._init_source_view():
             self._init_text_view()
-        
+        elif self._gtksource_enabled:
+            self._add_scheme_chooser(self._header_bar)
+
         # Connect to buffer changes
         self._buffer.connect("modified-changed", self._on_buffer_modified_changed)
         
@@ -445,6 +440,40 @@ class RemoteFileEditorWindow(Adw.Window):
         # Show initial loading toast
         self._show_toast("Loading…" if self._is_local else "Downloading…", timeout=2)
 
+    def _add_scheme_chooser(self, header_bar: Adw.HeaderBar) -> None:
+        """Add the GtkSource style-scheme chooser to the header bar.
+
+        Must run only after GtkSourceView init succeeded — constructing
+        StyleSchemeChooserWidget is what first loads the shared library for
+        some GI builds, and a missing dylib raises TypeError ("must be an
+        interface") rather than a clean import failure.
+        """
+        if not (self._gtksource_enabled and GtkSource is not None
+                and hasattr(GtkSource, "StyleSchemeChooserWidget")):
+            return
+        from sshpilot import icon_utils
+        try:
+            self._scheme_button = Gtk.MenuButton()
+            self._scheme_button.set_child(
+                icon_utils.new_image_from_icon_name("color-symbolic"))
+            self._scheme_button.set_tooltip_text("Editor color scheme")
+            chooser_scroller = Gtk.ScrolledWindow()
+            chooser_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            chooser_scroller.set_min_content_width(240)
+            chooser_scroller.set_min_content_height(320)
+            self._scheme_chooser = GtkSource.StyleSchemeChooserWidget()
+            chooser_scroller.set_child(self._scheme_chooser)
+            popover = Gtk.Popover()
+            popover.set_child(chooser_scroller)
+            self._scheme_button.set_popover(popover)
+            header_bar.pack_end(self._scheme_button)
+            self._scheme_chooser.connect(
+                "notify::style-scheme", self._on_scheme_changed)
+        except Exception as e:  # noqa: BLE001 — chooser is optional chrome
+            logger.warning("GtkSource style-scheme chooser unavailable: %s", e)
+            self._scheme_button = None
+            self._scheme_chooser = None
+
     def _init_source_view(self) -> bool:
         """Initialize GtkSourceView if available.
 
@@ -478,11 +507,9 @@ class RemoteFileEditorWindow(Adw.Window):
                 self._buffer = GtkSource.Buffer()
             self._source_view.set_buffer(self._buffer)
 
-            # Apply the saved/auto color scheme, then start listening for changes
-            # (connect after the initial apply so it doesn't fire spuriously).
+            # Apply the saved/auto color scheme, then start listening for dark
+            # mode changes. Scheme-chooser notify is wired in _add_scheme_chooser.
             self._apply_style_scheme()
-            if self._scheme_chooser is not None:
-                self._scheme_chooser.connect("notify::style-scheme", self._on_scheme_changed)
             self._connect_dark_follow()
 
             self._search_settings = GtkSource.SearchSettings()

--- a/tests/test_gtk_bundle_pyinstaller.py
+++ b/tests/test_gtk_bundle_pyinstaller.py
@@ -24,6 +24,8 @@ from gtk_bundle import (  # noqa: E402
 def test_gi_dylib_dest_is_frameworks_root():
     # Nested "Frameworks" dest was the PyInstaller bug that broke the SSH
     # config editor ("Failed to load ... libgtksourceview-5.0.dylib").
+    # Matches stock hook-gi.repository.GtkSource (pyinstaller#3893), which
+    # also collects shared libs with dest ".".
     assert GI_DYLIB_BUNDLE_DEST == "."
 
 

--- a/tests/test_gtk_bundle_pyinstaller.py
+++ b/tests/test_gtk_bundle_pyinstaller.py
@@ -1,0 +1,75 @@
+"""GtkSourceView must land in Contents/Frameworks/ for GI typelib dlopen."""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "packaging", "pyinstaller")
+    ),
+)
+
+from gtk_bundle import (  # noqa: E402
+    GI_DYLIB_BUNDLE_DEST,
+    collect_homebrew_dylibs,
+    ensure_gtksourceview_abi_name,
+    find_gtksourceview_dylibs,
+    gtksourceview_bundle_ok,
+    nested_frameworks_paths,
+)
+
+
+def test_gi_dylib_dest_is_frameworks_root():
+    # Nested "Frameworks" dest was the PyInstaller bug that broke the SSH
+    # config editor ("Failed to load ... libgtksourceview-5.0.dylib").
+    assert GI_DYLIB_BUNDLE_DEST == "."
+
+
+def test_collect_homebrew_dylibs_uses_root_dest(tmp_path):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "libgtksourceview-5.0.dylib").write_bytes(b"fake")
+    (lib / "libvte-2.91.0.dylib").write_bytes(b"fake")
+
+    pairs = collect_homebrew_dylibs(
+        str(lib),
+        ["libgtksourceview-5.*.dylib", "libvte-2.91.*.dylib"],
+    )
+    assert pairs
+    assert all(dest == "." for _src, dest in pairs)
+    names = {Path(src).name for src, _dest in pairs}
+    assert "libgtksourceview-5.0.dylib" in names
+    assert "libvte-2.91.0.dylib" in names
+
+
+def test_ensure_abi_symlink_when_only_versioned_present(tmp_path):
+    frameworks = tmp_path / "Frameworks"
+    frameworks.mkdir()
+    versioned = frameworks / "libgtksourceview-5.0.0.dylib"
+    versioned.write_bytes(b"fake")
+
+    assert not (frameworks / "libgtksourceview-5.0.dylib").exists()
+    abi = ensure_gtksourceview_abi_name(frameworks)
+    assert abi is not None
+    assert abi.name == "libgtksourceview-5.0.dylib"
+    assert abi.is_symlink()
+    assert abi.resolve() == versioned.resolve()
+    assert gtksourceview_bundle_ok(frameworks)
+
+
+def test_gtksourceview_bundle_ok_requires_frameworks_root(tmp_path):
+    frameworks = tmp_path / "Frameworks"
+    frameworks.mkdir()
+    nested = frameworks / "Frameworks"
+    nested.mkdir()
+    (nested / "libgtksourceview-5.0.dylib").write_bytes(b"fake")
+
+    assert find_gtksourceview_dylibs(frameworks) == []
+    assert nested_frameworks_paths(frameworks)
+    assert not gtksourceview_bundle_ok(frameworks)
+
+    # After placing at root, verification passes.
+    (frameworks / "libgtksourceview-5.0.dylib").write_bytes(b"fake")
+    assert gtksourceview_bundle_ok(frameworks)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The macOS PyInstaller `.app` failed to open the SSH Config Editor with:

```
Failed to load shared library 'libgtksourceview-5.0.dylib' ...
/Applications/SSHPilot.app/Contents/Frameworks/libgtksourceview-5.0.dylib (no such file)
Failed to open SSH config editor: must be an interface
```

**Root causes:**
1. Manual Homebrew dylib collection used dest `"Frameworks"`, nesting libs under `Contents/Frameworks/Frameworks/` while GI looks in `Contents/Frameworks/`.
2. The stock PyInstaller hook [`hook-gi.repository.GtkSource`](https://github.com/pyinstaller/pyinstaller/pull/3893) already collects the shared library at Frameworks root (`"."`) and rewrites macOS typelibs to `@loader_path/…`, but it **defaults to GtkSource 3.0**. Without `hooksconfig` + a `gi.repository.GtkSource` hiddenimport, the hook never collected GtkSource 5 for this app (GtkSource is imported behind `try/except`).

## Changes

- `hooksconfig` for `Gtk`/`Gdk` `4.0` and `GtkSource` `5`, plus GI hiddenimports so the official hook runs
- Prefer `gi_typelibs` (rewritten typelibs) over raw `girepository-1.0` copies on `GI_TYPELIB_PATH`
- Place all Homebrew GI dylibs at Frameworks root as a fallback; build/CI verify `libgtksourceview-5*.dylib` is present there
- Harden the editor: probe GtkSource shared-library load at import; create the style-scheme chooser only after SourceView init succeeds
- Unit tests for Frameworks-root placement helpers

## Test plan

- [x] `pytest tests/test_gtk_bundle_pyinstaller.py`
- [ ] Rebuild macOS `.app` with `./packaging/pyinstaller/pyinstaller.sh` and confirm `Contents/Frameworks/libgtksourceview-5.0.dylib` exists
- [ ] Confirm `Contents/Resources/gi_typelibs` (or equivalent) contains a GtkSource-5 typelib from the official hook
- [ ] Open **SSH Config Editor** in the bundled app (syntax highlighting should work; no GI warning / `"must be an interface"`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cf072d5-b5d8-4b69-8854-5e82114fcac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cf072d5-b5d8-4b69-8854-5e82114fcac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

