### PR TITLE
Sign the macOS bundle once, last, and verify it strictly

### DIFF
--- a/packaging/pyinstaller/pyinstaller.sh
+++ b/packaging/pyinstaller/pyinstaller.sh
@@ -104,11 +104,25 @@ if [ -d "dist/SSHPilot.app" ]; then
         echo "⚠️  sshpass not found in PATH; bundle will require system sshpass"
     fi
 
-    # Ad-hoc sign the app bundle — prevents "damaged app" Gatekeeper error when downloaded
+    # Ad-hoc sign LAST — after sshpass + the GtkSourceView symlink — so the
+    # signature seals the final bundle. Signing earlier (e.g. in the spec) then
+    # modifying the bundle yields an inconsistent signature and the dreaded
+    # "app is damaged and can't be opened" error on downloaded copies.
+    #
+    # This is ad-hoc (--sign -): no Developer ID, so it can't be notarized and
+    # Gatekeeper still shows "unidentified developer" on first open (right-click
+    # ▸ Open, or `xattr -dr com.apple.quarantine SSHPilot.app`). A *valid*
+    # ad-hoc signature is what keeps users on that recoverable path instead of
+    # the "damaged" dead-end. --deep is fine for ad-hoc; it would need replacing
+    # with inside-out signing + entitlements only if real notarization is added.
     echo "🔐 Ad-hoc code signing app bundle..."
     codesign --sign - --force --deep --timestamp=none "dist/SSHPilot.app"
-    codesign --verify --verbose "dist/SSHPilot.app" 2>&1 || true
-    echo "✅ App bundle signed (ad-hoc)"
+    if codesign --verify --strict --verbose=2 "dist/SSHPilot.app"; then
+        echo "✅ App bundle signed (ad-hoc) and signature verified"
+    else
+        echo "❌ codesign --verify failed — downloaded builds will show 'app is damaged'"
+        exit 1
+    fi
 
     # Create DMG file using create-dmg
     echo "📦 Creating DMG file..."

--- a/packaging/pyinstaller/sshpilot.spec
+++ b/packaging/pyinstaller/sshpilot.spec
@@ -273,17 +273,7 @@ app = BUNDLE(
     },
 )
 
-# Ad-hoc codesign so macOS can match the bundle's identity across launches,
-# preventing repeated keychain authorization prompts.
-if sys.platform == "darwin":
-    import subprocess as _sp
-    _app_path = os.path.join("dist", f"{app_name}.app")
-    if os.path.exists(_app_path):
-        _r = _sp.run(
-            ["codesign", "--force", "--deep", "--sign", "-", _app_path],
-            capture_output=True, text=True,
-        )
-        if _r.returncode == 0:
-            print(f"Ad-hoc code signed: {_app_path}")
-        else:
-            print(f"Warning: codesign failed (non-fatal): {_r.stderr.strip()}")
+# NOTE: no codesign here. The bundle is still modified after this point
+# (pyinstaller.sh adds sshpass and the GtkSourceView ABI symlink), so signing
+# now would be invalidated by those changes and produce the "app is damaged"
+# Gatekeeper error. Ad-hoc signing happens once, last, in pyinstaller.sh.


### PR DESCRIPTION
## Summary

Fixes double ad-hoc signing of the macOS `.app` that could ship an invalidated signature (the "app is damaged and can't be opened" Gatekeeper error).

The bundle was signed **twice**: `sshpilot.spec` signed at the end of the PyInstaller run, then `pyinstaller.sh` added sshpass + the GtkSourceView ABI symlink and re-signed. Two problems:

- PyInstaller [already ad-hoc (re)signs collected binaries **and the `.app` bundle** automatically](https://pyinstaller.org/en/stable/feature-notes.html#macos-binary-code-signing), so the spec's manual sign was redundant.
- Modifying the bundle after signing **invalidates** the signature. The spec's sign happened before the sshpass/symlink steps, so on any direct-spec build it shipped broken → "damaged" on download.

## Changes

- **`sshpilot.spec`** — remove the codesign block. Signing now happens in exactly one place, as the final build step, sealing the finished bundle.
- **`pyinstaller.sh`** — make the verify strict and fatal (`codesign --verify --strict`) so an inconsistent signature fails the build instead of shipping.

## Checked against the PyInstaller macOS docs

- **Signing**: aligns — PyInstaller auto ad-hoc signs; our final re-sign is required only because we modify the bundle post-build.
- **Multi-arch**: already correct, no change — arm64 builds on `macos-14`, x86_64 on `macos-15-intel`; two native single-arch builds on matching runners (not `target_arch`/universal2, which the docs warn can fail when a dep is single-arch). Both workflows also validate the sshpass slice.

## Ceiling (no Developer ID account)

Still ad-hoc, so the app can't be notarized. First launch requires **System Settings ▸ Privacy & Security ▸ Open Anyway** (Sequoia removed the right-click bypass); it's one-time per downloaded copy. A *valid* ad-hoc signature keeps users on that recoverable path — and is mandatory on Apple Silicon for the binary to run at all — instead of the "damaged" dead-end. Notarization (removing the warning entirely) is separate future work needing the paid account.

## Test plan
- [x] `sshpilot.spec` parses; `pyinstaller.sh` passes `bash -n`; only one `codesign` invocation remains.
- [ ] Rebuild the `.app`, confirm `codesign --verify --strict` passes and there's a single seal over the final bundle (incl. sshpass).
- [ ] Download-simulate (`xattr -w com.apple.quarantine ...`) and confirm "Open Anyway" path, not "damaged".