### PR TITLE
Fix macOS Keychain prompting again after Always Allow

### DIFF
--- a/documentation/INSTALL-macos.md
+++ b/documentation/INSTALL-macos.md
@@ -164,6 +164,15 @@ python -c "import keyring; print(f'Backend: {keyring.get_keyring().__class__.__n
 # Should output: Backend: Keyring
 ```
 
+SSHPilot stores secrets in the login keychain under the service name `sshPilot`.
+On first access macOS may ask for your login password — choose **Always Allow**.
+
+If the dialog returns on every launch (common with ad-hoc signed `.app` builds),
+open the connection once more after updating to a build that writes a trusted-app
+ACL; SSHPilot rewrites the keychain item after a successful read so later launches
+stay silent. Alternatively, in **Keychain Access**, find the `sshPilot` items →
+**Access Control** → allow SSHPilot (or “all applications”) and save.
+
 **Permission denied errors**
 ```bash
 chmod +x sshpilot-mac.sh

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -62,10 +62,11 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -596,6 +597,121 @@ class LibSecretBackend(SecretBackend):
         return out
 
 
+# --- macOS Keychain ACL helpers ---------------------------------------------
+# Python keyring's macOS backend (SecItemAdd) creates items without an explicit
+# trusted-application ACL. "Always Allow" then binds to the process code
+# signature. Ad-hoc signed SSHPilot.app bundles (and askpass re-execs of the
+# same binary) often fail to match that ACL on the next launch, so macOS
+# re-prompts every time.
+#
+# Storing via `/usr/bin/security … -T <app>` records a path-based ACL entry for
+# our executable(s). That survives relaunches of the same install. After a
+# successful interactive lookup we also rewrite existing items once so users
+# who already clicked Always Allow stop seeing the dialog.
+
+_macos_acl_upgraded: Set[Tuple[str, str]] = set()
+
+
+def macos_keychain_trusted_paths() -> List[str]:
+    """Executable paths that should read sshPilot keychain items without prompting.
+
+    Includes ``sys.executable`` (the .app binary when frozen, or Python otherwise)
+    plus the bundle MacOS binary when we can resolve it — askpass re-invokes the
+    same binary, so trusting it covers both the GUI and the helper.
+    """
+    paths: List[str] = []
+    seen: Set[str] = set()
+
+    def _add(path: Optional[str]) -> None:
+        if not path:
+            return
+        try:
+            resolved = os.path.realpath(path)
+        except Exception:
+            resolved = path
+        if not resolved or resolved in seen or not os.path.isfile(resolved):
+            return
+        seen.add(resolved)
+        paths.append(resolved)
+
+    _add(sys.executable)
+    # Frozen .app: also trust Contents/MacOS/<name> if executable differs (rare).
+    if getattr(sys, "frozen", False):
+        exe = sys.executable
+        # …/SSHPilot.app/Contents/MacOS/SSHPilot
+        macos_dir = os.path.dirname(exe)
+        if os.path.basename(macos_dir) == "MacOS":
+            _add(exe)
+            try:
+                for name in os.listdir(macos_dir):
+                    _add(os.path.join(macos_dir, name))
+            except Exception:
+                pass
+    return paths
+
+
+def _macos_store_generic_password(
+    service: str,
+    account: str,
+    secret: str,
+    label: str = "",
+) -> bool:
+    """Create/update a Keychain generic password with a trusted-app ACL.
+
+    Uses ``security add-generic-password -U -T <path>…`` so subsequent reads by
+    those paths do not show the login-keychain authorization dialog.
+    """
+    security_bin = shutil.which("security") or "/usr/bin/security"
+    if not os.path.isfile(security_bin):
+        return False
+
+    cmd: List[str] = [
+        security_bin,
+        "add-generic-password",
+        "-s", service,
+        "-a", account,
+        "-w", secret,
+        "-U",  # update in place when the item already exists
+    ]
+    if label:
+        cmd.extend(["-l", label])
+    trusted = macos_keychain_trusted_paths()
+    if not trusted:
+        # Fall back to allowing any app rather than leaving a signature-only ACL
+        # that re-prompts on every launch of an ad-hoc signed binary.
+        cmd.append("-A")
+    else:
+        for path in trusted:
+            cmd.extend(["-T", path])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except Exception as exc:
+        logger.debug("macOS security store failed: %s", exc)
+        return False
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()
+        logger.debug("macOS security store failed (%s): %s", result.returncode, err)
+        return False
+    _macos_acl_upgraded.add((service, account))
+    return True
+
+
+def _macos_upgrade_item_acl(service: str, account: str, secret: str, label: str = "") -> None:
+    """Rewrite a just-read item with a trusted-app ACL (once per process)."""
+    key = (service, account)
+    if key in _macos_acl_upgraded:
+        return
+    if _macos_store_generic_password(service, account, secret, label=label):
+        logger.debug("Upgraded macOS keychain ACL for %s / %s", service, account)
+
+
 class KeyringBackend(SecretBackend):
     name = "keyring"
 
@@ -623,6 +739,19 @@ class KeyringBackend(SecretBackend):
         keyring = _get_keyring()
         if keyring is None:
             return False
+        # macOS: prefer path-based Keychain ACL so "Always Allow" is not required
+        # on every launch of an ad-hoc signed app (see helpers above).
+        if is_macos():
+            if _macos_store_generic_password(
+                spec.keyring_service,
+                spec.keyring_account,
+                secret,
+                label=spec.label or "",
+            ):
+                return True
+            logger.debug(
+                "macOS security store unavailable; falling back to keyring API"
+            )
         try:
             keyring.set_password(spec.keyring_service, spec.keyring_account, secret)
             return True
@@ -635,10 +764,23 @@ class KeyringBackend(SecretBackend):
         if keyring is None:
             return None
         try:
-            return keyring.get_password(spec.keyring_service, spec.keyring_account)
+            value = keyring.get_password(spec.keyring_service, spec.keyring_account)
         except Exception as exc:
             logger.debug("keyring lookup failed: %s", exc)
             return None
+        # After the user authorizes once, rewrite the item with a trusted-app
+        # ACL so the next launch does not prompt again.
+        if value and is_macos():
+            try:
+                _macos_upgrade_item_acl(
+                    spec.keyring_service,
+                    spec.keyring_account,
+                    value,
+                    label=spec.label or "",
+                )
+            except Exception:
+                logger.debug("macOS keychain ACL upgrade failed", exc_info=True)
+        return value
 
     def delete(self, spec: SecretSpec) -> bool:
         keyring = _get_keyring()
@@ -646,6 +788,7 @@ class KeyringBackend(SecretBackend):
             return False
         try:
             keyring.delete_password(spec.keyring_service, spec.keyring_account)
+            _macos_acl_upgraded.discard((spec.keyring_service, spec.keyring_account))
             return True
         except Exception as exc:
             logger.debug("keyring delete failed: %s", exc)

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -283,6 +283,111 @@ def test_keyring_backend_describe(monkeypatch):
     assert ss.KeyringBackend().describe() == 'keyring:_Backend'
 
 
+def test_macos_keychain_store_uses_security_trusted_acl(monkeypatch, tmp_path):
+    """macOS KeyringBackend.store must use `security -T` so Always Allow sticks."""
+    ss._macos_acl_upgraded.clear()
+    monkeypatch.setattr(ss, 'is_macos', lambda: True)
+
+    fake_exe = tmp_path / 'SSHPilot'
+    fake_exe.write_text('#!/bin/sh\n')
+    fake_exe.chmod(0o755)
+    security_bin = tmp_path / 'security'
+    security_bin.write_text('#!/bin/sh\n')
+    security_bin.chmod(0o755)
+    monkeypatch.setattr(ss.sys, 'executable', str(fake_exe))
+    monkeypatch.setattr(ss.sys, 'frozen', True, raising=False)
+
+    calls = []
+
+    class _Result:
+        returncode = 0
+        stdout = ''
+        stderr = ''
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return _Result()
+
+    monkeypatch.setattr(ss.subprocess, 'run', fake_run)
+    monkeypatch.setattr(ss.shutil, 'which', lambda name: str(security_bin))
+
+    class FakeKeyring:
+        @staticmethod
+        def get_keyring():
+            return object()
+
+        @staticmethod
+        def set_password(*_a, **_k):
+            raise AssertionError('keyring.set_password must not be used on macOS success path')
+
+    monkeypatch.setattr(ss, 'keyring', FakeKeyring)
+
+    backend = ss.KeyringBackend()
+    spec = password_spec('host.example', 'alice')
+    assert backend.store(spec, 's3cret') is True
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == str(security_bin)
+    assert cmd[1] == 'add-generic-password'
+    assert '-U' in cmd
+    assert '-T' in cmd
+    assert str(fake_exe.resolve()) in cmd
+    assert cmd[cmd.index('-s') + 1] == 'sshPilot'
+    assert cmd[cmd.index('-a') + 1] == 'alice@host.example'
+    assert cmd[cmd.index('-w') + 1] == 's3cret'
+    assert (spec.keyring_service, spec.keyring_account) in ss._macos_acl_upgraded
+
+
+def test_macos_keychain_lookup_upgrades_acl_once(monkeypatch, tmp_path):
+    """After a successful read, rewrite the item with -T so the next launch is silent."""
+    ss._macos_acl_upgraded.clear()
+    monkeypatch.setattr(ss, 'is_macos', lambda: True)
+
+    fake_exe = tmp_path / 'python3'
+    fake_exe.write_text('x')
+    fake_exe.chmod(0o755)
+    security_bin = tmp_path / 'security'
+    security_bin.write_text('#!/bin/sh\n')
+    security_bin.chmod(0o755)
+    monkeypatch.setattr(ss.sys, 'executable', str(fake_exe))
+    monkeypatch.setattr(ss.sys, 'frozen', False, raising=False)
+
+    store_calls = []
+
+    class _Result:
+        returncode = 0
+        stdout = ''
+        stderr = ''
+
+    def fake_run(argv, **kwargs):
+        store_calls.append(list(argv))
+        return _Result()
+
+    monkeypatch.setattr(ss.subprocess, 'run', fake_run)
+    monkeypatch.setattr(ss.shutil, 'which', lambda name: str(security_bin))
+
+    class FakeKeyring:
+        @staticmethod
+        def get_keyring():
+            return object()
+
+        @staticmethod
+        def get_password(service, account):
+            return 'stored-secret'
+
+    monkeypatch.setattr(ss, 'keyring', FakeKeyring)
+
+    backend = ss.KeyringBackend()
+    spec = passphrase_spec('~/.ssh/id_ed25519')
+    assert backend.lookup(spec) == 'stored-secret'
+    assert len(store_calls) == 1
+    assert '-T' in store_calls[0]
+
+    # Second lookup must not rewrite again (same process).
+    assert backend.lookup(spec) == 'stored-secret'
+    assert len(store_calls) == 1
+
+
 def test_pass_path_sanitized_but_keyring_account_raw():
     spec = password_spec('ho/st', 'us/er')
     assert spec.pass_path == 'sshpilot/password/us_er@ho_st'   # no stray '/'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On macOS, choosing **Always Allow** on the Keychain dialog (“SSHPilot wants to use your confidential information stored in sshPilot”) still re-prompts on the next launch.

This is common with **ad-hoc signed** `.app` builds: Always Allow is tied to the process code signature, which often fails to match on relaunch. Python `keyring`’s macOS backend also creates items without an explicit trusted-app ACL.

## Fix

- Store secrets on macOS via `/usr/bin/security add-generic-password -U -T <app-path>…` so the Keychain item has a **path-based** ACL for SSHPilot (covers the GUI and the askpass re-exec of the same binary).
- After a successful read of an existing item, rewrite it once with that ACL so users who already authorized once stop seeing the dialog on later launches.
- Fall back to the normal `keyring` API if `security` is unavailable.
- Document the one-time re-authorize / Keychain Access workaround in `INSTALL-macos.md`.

## How to verify (macOS)

1. Build/run a build that includes this change.
2. Connect once (or otherwise trigger a keychain read) and authorize if prompted.
3. Quit and relaunch — the Keychain password dialog should not return for the same install path.

## Tests

- `tests/test_secret_storage.py` — new unit tests for the macOS `-T` store path and one-time ACL upgrade (mocked `security` CLI).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62ecff05-8ad2-4e84-8809-aa5d4afacbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62ecff05-8ad2-4e84-8809-aa5d4afacbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

