### PR TITLE
Fix red CI tests and ruff lint failures

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -13,7 +13,6 @@ from typing import List
 # SSH key-path canonicalization lives in secret_storage (the single source of truth, shared with
 # credential export). secret_storage is GTK-free and safe to import in the askpass subprocess.
 from .secret_storage import (
-    home_alias_for_path as _home_alias_for_path,
     normalize_key_path_for_storage as _normalize_key_path_for_storage,
     key_path_lookup_candidates as _get_key_path_lookup_candidates,
 )
@@ -95,7 +94,7 @@ def _extract_key_path(prompt: str) -> str:
     return ""
 
 
-def get_secret_schema() -> "Secret.Schema":
+def get_secret_schema():
     """Return the shared Secret.Schema for stored secrets.
 
     Delegates to :func:`sshpilot.secret_storage.get_schema` so a single schema

--- a/sshpilot/connection_manager.py
+++ b/sshpilot/connection_manager.py
@@ -10,11 +10,9 @@ import tempfile
 import asyncio
 import enum
 import logging
-import configparser
 import getpass
 import subprocess
 import shlex
-import signal
 import re
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple, Union, Set
@@ -24,8 +22,6 @@ from .platform_utils import get_config_dir, get_ssh_dir
 from .key_utils import _is_private_key
 from .ssh_connection_builder import build_ssh_connection, ConnectionContext
 
-import socket
-import time
 from gi.repository import GObject, GLib
 from .askpass_utils import (
     clear_passphrase,
@@ -37,7 +33,7 @@ from .askpass_utils import (
 if os.name == 'posix':
     import gi
     gi.require_version('Gtk', '4.0')
-    from gi.repository import Gtk, GLib
+    from gi.repository import GLib
     
     # Set up the asyncio event loop
     if not hasattr(GLib, 'MainLoop'):
@@ -1072,7 +1068,7 @@ class ConnectionManager(GObject.Object):
         try:
             existing = ""
             if os.path.exists(path):
-                with open(path, "r", encoding="utf-8") as f:
+                with open(path, encoding="utf-8") as f:
                     existing = f.read()
             stripped, _removed = self._strip_managed_block(existing)
             if socket:
@@ -1359,7 +1355,7 @@ class ConnectionManager(GObject.Object):
                 current_hosts: List[str] = []
                 current_config: Dict[str, Any] = {}
                 try:
-                    with open(cfg_file, 'r') as f:
+                    with open(cfg_file) as f:
                         lines = f.readlines()
                 except Exception as e:
                     logger.warning(f"Skipping unreadable config {cfg_file}: {e}")
@@ -1435,7 +1431,7 @@ class ConnectionManager(GObject.Object):
         except Exception as e:
             logger.error(f"Failed to load SSH config: {e}", exc_info=True)
 
-    def parse_host_config(self, config: Dict[str, Any], source: str = None) -> Optional[Dict[str, Any]]:
+    def parse_host_config(self, config: Dict[str, Any], source: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Parse host configuration from SSH config"""
         try:
             def _unwrap(val: Any) -> Any:
@@ -2256,7 +2252,7 @@ class ConnectionManager(GObject.Object):
             if not target_path or not os.path.exists(target_path):
                 return None
 
-            with open(target_path, 'r') as f:
+            with open(target_path) as f:
                 lines = f.readlines()
 
             i = 0
@@ -2298,7 +2294,7 @@ class ConnectionManager(GObject.Object):
             target_path = self._ensure_config_parent_dir(target_path)
 
             try:
-                with open(target_path, 'r') as f:
+                with open(target_path) as f:
                     lines = f.readlines()
             except FileNotFoundError:
                 lines = []
@@ -2358,7 +2354,7 @@ class ConnectionManager(GObject.Object):
             logger.error(f"Failed to split host block for '{original_host}': {e}")
             return False
 
-    def update_ssh_config_file(self, connection: Connection, new_data: Dict[str, Any], original_nickname: str = None):
+    def update_ssh_config_file(self, connection: Connection, new_data: Dict[str, Any], original_nickname: Optional[str] = None):
         """Update SSH config file with new connection data"""
         try:
             target_path = new_data.get('source') or getattr(connection, 'source', None) or self.ssh_config_path
@@ -2372,9 +2368,9 @@ class ConnectionManager(GObject.Object):
                 return
 
             try:
-                with open(target_path, 'r') as f:
+                with open(target_path) as f:
                     lines = f.readlines()
-            except IOError as e:
+            except OSError as e:
                 logger.error(f"Failed to read SSH config: {e}")
                 raise
             
@@ -2451,7 +2447,7 @@ class ConnectionManager(GObject.Object):
                     len(new_data.get('forwarding_rules', []) or []),
                     target_path,
                 )
-            except IOError as e:
+            except OSError as e:
                 logger.error(f"Failed to write SSH config: {e}")
                 raise
         except Exception as e:
@@ -2468,9 +2464,9 @@ class ConnectionManager(GObject.Object):
             if not os.path.exists(target_path):
                 return False
             try:
-                with open(target_path, 'r') as f:
+                with open(target_path) as f:
                     lines = f.readlines()
-            except IOError as e:
+            except OSError as e:
                 logger.error(f"Failed to read SSH config for delete: {e}")
                 return False
 
@@ -2535,7 +2531,7 @@ class ConnectionManager(GObject.Object):
                 try:
                     self._safe_write_config(target_path, ''.join(updated_lines))
                     logger.info(f"SSH config updated: {'removed' if host_nickname else 'modified'} entry for '{host_nickname}'")
-                except IOError as e:
+                except OSError as e:
                     logger.error(f"Failed to write SSH config after delete: {e}")
                     return False
             return modified

--- a/sshpilot/preferences.py
+++ b/sshpilot/preferences.py
@@ -9,16 +9,13 @@ import hashlib
 import zipfile
 import tempfile
 import threading
-import importlib
-import importlib.util
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from gettext import gettext as _
 
-from .platform_utils import get_config_dir, is_flatpak, is_macos
+from .platform_utils import get_config_dir, is_macos
 from .file_manager_integration import (
     has_internal_file_manager,
-    has_native_gvfs_support,
 )
 from .shortcut_editor import ShortcutsPreferencesPage
 from .monospace_font_dialog import MonospaceFontDialog

--- a/sshpilot/providers/file_key.py
+++ b/sshpilot/providers/file_key.py
@@ -90,7 +90,7 @@ class FileKeyProvider(IdentityProvider):
             if os.path.isfile(pub_path):
                 from ..authorized_keys_parser import compute_fingerprint
 
-                with open(pub_path, "r", encoding="utf-8") as handle:
+                with open(pub_path, encoding="utf-8") as handle:
                     parts = handle.read().split()
                 if len(parts) >= 2:
                     return compute_fingerprint(parts[0], parts[1]) or None

--- a/sshpilot/scp_window.py
+++ b/sshpilot/scp_window.py
@@ -240,7 +240,6 @@ class ScpWindowController:
         saved_passphrase: Optional[str] = None
         combined_auth = False
         connection_manager = getattr(self.window, 'connection_manager', None)
-        lookup_host = hostname_value or host_value
         if connection_manager:
             try:
                 saved_password = connection_manager.get_connection_password(connection)

--- a/sshpilot/terminal_backends.py
+++ b/sshpilot/terminal_backends.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Protocol, Sequence
-import shlex
 
 import gi
 
@@ -14,7 +12,6 @@ gi.require_version("Gtk", "4.0")
 
 from gi.repository import GObject, Gtk
 
-from .platform_utils import is_flatpak, get_data_dir
 
 logger = logging.getLogger(__name__)
 

--- a/sshpilot/window_dialogs.py
+++ b/sshpilot/window_dialogs.py
@@ -15,6 +15,7 @@ import logging
 import os
 import threading
 from datetime import datetime
+from typing import Optional
 
 from gi.repository import Adw, Gio, GLib, Gtk
 from gettext import gettext as _
@@ -1247,7 +1248,7 @@ class WindowConfigDialogsMixin:
             logger.error(f"Failed to read backup: {e}")
             self._simple_dialog(_("Import Failed"), str(e))
 
-    def _prompt_spbk_passphrase(self, import_path: str, error: str = None, on_cleanup=None):
+    def _prompt_spbk_passphrase(self, import_path: str, error: Optional[str] = None, on_cleanup=None):
         """Prompt for the backup passphrase; retry on a wrong passphrase.
 
         ``on_cleanup`` fires on success, on a fatal error, and on cancel — but NOT between

--- a/sshpilot/window_session.py
+++ b/sshpilot/window_session.py
@@ -5,11 +5,10 @@ WindowBroadcastMixin) to shrink the window.py god-object. MainWindow inherits
 this; methods keep their signatures and `self.` state access, so this is a pure
 code move with no behavior change.
 
-`TerminalWidget` is imported here the same way window.py imports it
-(``from .terminal import TerminalWidget``); both bind to the one
-``sshpilot.terminal`` module in the same import cycle, so the isinstance()
-checks below use the identical class object the rest of the app (and the
-session tests via ``window_module.TerminalWidget``) check against.
+`TerminalWidget` is imported at module level so the isinstance() checks
+below use the class object the session tests bind via
+``window_session.TerminalWidget`` (window.py only imports it under
+``TYPE_CHECKING``).
 """
 
 import logging

--- a/sshpilot/xterm_shell.py
+++ b/sshpilot/xterm_shell.py
@@ -38,7 +38,7 @@ def asset_dir() -> str:
 
 
 def _read(rel: str) -> str:
-    with open(os.path.join(asset_dir(), rel), "r", encoding="utf-8") as f:
+    with open(os.path.join(asset_dir(), rel), encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_bitwarden_setup.py
+++ b/tests/test_bitwarden_setup.py
@@ -1,7 +1,6 @@
 """Tests for sshpilot/bitwarden_setup.py (GTK-free helpers)."""
 
 import io
-import subprocess
 import zipfile
 
 import pytest

--- a/tests/test_credential_adapters.py
+++ b/tests/test_credential_adapters.py
@@ -11,7 +11,6 @@ from sshpilot.credential_model import (
     TYPE_SUDO,
     TYPE_KEY,
     credential_to_spec,
-    credential_from_attributes,
 )
 from sshpilot.credential_adapters import SecretBackendAdapter, KdbxAdapter
 

--- a/tests/test_gui_docker_local.py
+++ b/tests/test_gui_docker_local.py
@@ -33,7 +33,7 @@ def _local_ctx():
             get=lambda key, default=None: default,
             set=lambda key, value: None,
         ),
-        list_connections=lambda: [],
+        list_connections=list,
         open_command_terminal=lambda *args, **kwargs:
             pytest.fail("Local target must not open a remote SSH terminal"),
         open_local_command_terminal=lambda command, **kwargs:

--- a/tests/test_import_export_edge_cases.py
+++ b/tests/test_import_export_edge_cases.py
@@ -5,9 +5,7 @@ deliberate design choices found during the hunt (auto-backup is config-only beca
 restore is non-destructive; legacy JSON never restores secrets; the vault gate lives in the UI).
 """
 import json
-import os
 
-import pytest
 
 import sshpilot.backup_manager as bm
 import sshpilot.credential_manager as cmod

--- a/tests/test_manage_files_ui.py
+++ b/tests/test_manage_files_ui.py
@@ -64,8 +64,10 @@ def create_window():
     class DummyWindow:
         # Any action handler the registration connects to resolves to a no-op,
         # so the test doesn't have to enumerate every on_*_action (they grow).
+        # open_file_manager_from_menu is the main-menu file-manager entry point
+        # (not an on_* handler name).
         def __getattr__(self, name):
-            if name.startswith("on_"):
+            if name.startswith("on_") or name == "open_file_manager_from_menu":
                 return lambda *a, **k: None
             raise AttributeError(name)
 

--- a/tests/test_preferences_secret_backend.py
+++ b/tests/test_preferences_secret_backend.py
@@ -2,7 +2,6 @@
 
 from unittest import mock
 
-import pytest
 
 from sshpilot import preferences
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -129,13 +129,15 @@ def _make_page(child, custom_title=None):
 def test_capture_session_schema(monkeypatch):
     _ensure_cairo_stub()
     from sshpilot import window as window_module
-    # capture_session uses window's *module-level* TerminalWidget in an
-    # isinstance() check. In full-suite order a sibling may have imported window
-    # (binding TerminalWidget) before sshpilot.terminal was re-imported as a fresh
-    # module, so a separate ``from sshpilot.terminal import TerminalWidget`` would
-    # yield a different class and the regular/local tabs would be silently
-    # dropped. Use the exact class the app checks against.
-    TerminalWidget = window_module.TerminalWidget
+    from sshpilot import window_session as window_session_module
+    # capture_session lives on WindowSessionMixin and uses that module's
+    # TerminalWidget in an isinstance() check. In full-suite order a sibling
+    # may have imported window_session (binding TerminalWidget) before
+    # sshpilot.terminal was re-imported as a fresh module, so a separate
+    # ``from sshpilot.terminal import TerminalWidget`` would yield a different
+    # class and the regular/local tabs would be silently dropped. Use the
+    # exact class the mixin checks against.
+    TerminalWidget = window_session_module.TerminalWidget
     from sshpilot.split_view import SplitViewTab
 
     win = window_module.MainWindow.__new__(window_module.MainWindow)

--- a/tests/test_xterm_prewarm.py
+++ b/tests/test_xterm_prewarm.py
@@ -1,5 +1,4 @@
 """Unit tests for PyXterm shell pool dispatch (no WebKit required)."""
-from types import SimpleNamespace
 
 from sshpilot.xterm_prewarm import XtermShellPool, _ShellEntry
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Restores green CI on `Tests`, `Lint`, and `Test environment` after recent window/session refactors left two unit tests and ruff checks failing on `dev`/`main`.

## Failures fixed
- **pytest** (`test_manage_files_ui`): action registration now connects `open_file_manager_from_menu`; the dummy window stub only auto-resolved `on_*` handlers.
- **pytest** (`test_sessions`): `capture_session` moved to `WindowSessionMixin`, so the test must use `window_session.TerminalWidget` for `isinstance` checks.
- **ruff**: unused imports, implicit `Optional` annotations, unused `lookup_host`, and an undefined `Secret` type annotation.

## Verification
- `ruff check sshpilot/ tests/` — clean
- `pytest -m "not integration"` — 1445 passed (matching the CI Tests job)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71254e89-aec7-4f3a-83f2-cfc434b272e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71254e89-aec7-4f3a-83f2-cfc434b272e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

