### PR TITLE
Fix Bitwarden unlock on Flatpak ("Master password is required")

### DIFF
--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -333,6 +333,60 @@ def resolve_host_binary(binary: str) -> Optional[List[str]]:
     return None
 
 
+# Env vars the Bitwarden CLI (and related host tools) must see when spawned via
+# ``flatpak-spawn --host``. That path does **not** forward the sandbox process
+# environment — without ``--env=KEY=VALUE``, host ``bw unlock --passwordenv
+# BW_PASSWORD`` always fails with "Master password is required."
+FLATPAK_HOST_BW_ENV_KEYS: Tuple[str, ...] = (
+    "BW_PASSWORD",
+    "BW_SESSION",
+    "BW_CLIENTID",
+    "BW_CLIENTSECRET",
+    "BITWARDENCLI_APPDATA_DIR",
+    "NODE_EXTRA_CA_CERTS",
+)
+
+
+def inject_flatpak_host_env(
+    argv: List[str],
+    env: Optional[dict],
+    *,
+    keys: Tuple[str, ...] = FLATPAK_HOST_BW_ENV_KEYS,
+) -> List[str]:
+    """Insert ``--env=KEY=VALUE`` into a ``flatpak-spawn --host …`` argv.
+
+    No-op when ``argv`` is not a host spawn (direct sandbox/native binary). Existing
+    ``--env=`` flags for a key are left alone. Empty values are skipped.
+    """
+    if not argv or not env or not keys:
+        return list(argv)
+    spawn = argv[0]
+    if not (spawn.endswith("flatpak-spawn") and len(argv) >= 3 and argv[1] == "--host"):
+        return list(argv)
+
+    # Options after ``--host`` come before the host command. Insert after any that
+    # are already present so we do not reorder caller-supplied flags.
+    insert_at = 2
+    existing: set[str] = set()
+    while insert_at < len(argv) and argv[insert_at].startswith("--"):
+        opt = argv[insert_at]
+        if opt.startswith("--env="):
+            existing.add(opt[6:].split("=", 1)[0])
+        insert_at += 1
+
+    extras: List[str] = []
+    for key in keys:
+        if key in existing:
+            continue
+        value = env.get(key)
+        if value is None or value == "":
+            continue
+        extras.append(f"--env={key}={value}")
+    if not extras:
+        return list(argv)
+    return list(argv[:insert_at]) + extras + list(argv[insert_at:])
+
+
 def get_config_dir() -> str:
     """Return the per-user configuration directory for sshPilot."""
     return os.path.join(GLib.get_user_config_dir(), APP_NAME)

--- a/sshpilot/platform_utils.py
+++ b/sshpilot/platform_utils.py
@@ -335,8 +335,8 @@ def resolve_host_binary(binary: str) -> Optional[List[str]]:
 
 # Env vars the Bitwarden CLI (and related host tools) must see when spawned via
 # ``flatpak-spawn --host``. That path does **not** forward the sandbox process
-# environment — without ``--env=KEY=VALUE``, host ``bw unlock --passwordenv
-# BW_PASSWORD`` always fails with "Master password is required."
+# environment — without forwarding, host ``bw unlock --passwordenv BW_PASSWORD``
+# always fails with "Master password is required."
 FLATPAK_HOST_BW_ENV_KEYS: Tuple[str, ...] = (
     "BW_PASSWORD",
     "BW_SESSION",
@@ -352,17 +352,25 @@ def inject_flatpak_host_env(
     env: Optional[dict],
     *,
     keys: Tuple[str, ...] = FLATPAK_HOST_BW_ENV_KEYS,
-) -> List[str]:
-    """Insert ``--env=KEY=VALUE`` into a ``flatpak-spawn --host …`` argv.
+) -> Tuple[List[str], Tuple[int, ...]]:
+    """Forward selected env vars into a ``flatpak-spawn --host …`` argv.
 
-    No-op when ``argv`` is not a host spawn (direct sandbox/native binary). Existing
-    ``--env=`` flags for a key are left alone. Empty values are skipped.
+    Returns ``(argv, pass_fds)``. When forwarding is needed, a ``--env-fd=N``
+    flag is inserted and ``pass_fds`` holds the memfd ``N`` carrying the
+    NUL-terminated ``KEY=VALUE`` assignments (``env -0`` format). ``--env-fd``
+    is used instead of ``--env=KEY=VALUE`` so secrets (master password, session
+    token) never appear in the world-readable ``/proc/<pid>/cmdline``.
+
+    The caller must spawn with ``pass_fds`` and close those fds afterwards.
+    No-op — ``(argv, ())`` — when ``argv`` is not a host spawn, no key has a
+    value, or a key already has an explicit ``--env=`` flag. Empty values are
+    skipped.
     """
     if not argv or not env or not keys:
-        return list(argv)
+        return list(argv), ()
     spawn = argv[0]
     if not (spawn.endswith("flatpak-spawn") and len(argv) >= 3 and argv[1] == "--host"):
-        return list(argv)
+        return list(argv), ()
 
     # Options after ``--host`` come before the host command. Insert after any that
     # are already present so we do not reorder caller-supplied flags.
@@ -374,17 +382,26 @@ def inject_flatpak_host_env(
             existing.add(opt[6:].split("=", 1)[0])
         insert_at += 1
 
-    extras: List[str] = []
+    payload = b""
     for key in keys:
         if key in existing:
             continue
         value = env.get(key)
         if value is None or value == "":
             continue
-        extras.append(f"--env={key}={value}")
-    if not extras:
-        return list(argv)
-    return list(argv[:insert_at]) + extras + list(argv[insert_at:])
+        payload += f"{key}={value}".encode() + b"\0"
+    if not payload:
+        return list(argv), ()
+
+    # Linux-only, but so is flatpak-spawn. flatpak-spawn reads the fd via
+    # /proc/self/fd/N, so a memfd needs no rewind.
+    fd = os.memfd_create("sshpilot-host-env")
+    os.write(fd, payload)
+    os.lseek(fd, 0, os.SEEK_SET)
+    return (
+        list(argv[:insert_at]) + [f"--env-fd={fd}"] + list(argv[insert_at:]),
+        (fd,),
+    )
 
 
 def get_config_dir() -> str:

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -865,6 +865,23 @@ class BitwardenBackend(SecretBackend):
         return bw_cli_discoverable()
 
     # -- bw subprocess helper --------------------------------------------
+    def _bw_command(self, args: List[str], env: dict) -> List[str]:
+        """Build the full ``bw`` argv, forwarding env into Flatpak host spawns.
+
+        ``flatpak-spawn --host`` does not inherit the sandbox environment, so
+        secrets like ``BW_PASSWORD`` / ``BW_SESSION`` must be passed as
+        ``--env=KEY=VALUE`` or host ``bw`` never sees them.
+        """
+        argv = self._bw_argv(*args)
+        try:
+            from .platform_utils import inject_flatpak_host_env
+        except Exception:  # pragma: no cover - loose-module fallback
+            try:
+                from platform_utils import inject_flatpak_host_env  # type: ignore
+            except Exception:
+                return argv
+        return inject_flatpak_host_env(argv, env)
+
     def _run(self, args: List[str], *, token: Optional[str] = None,
              input_bytes: Optional[bytes] = None, extra_env: Optional[dict] = None):
         """Run ``bw <args>`` non-interactively, returning the CompletedProcess.
@@ -886,7 +903,7 @@ class BitwardenBackend(SecretBackend):
             env["BW_SESSION"] = token
         started = time.monotonic()
         result = subprocess.run(
-            self._bw_argv(*args),
+            self._bw_command(args, env),
             input=input_bytes, capture_output=True, env=env, check=False,
             timeout=self._TIMEOUT,
         )
@@ -1147,16 +1164,14 @@ class BitwardenBackend(SecretBackend):
                 # ever burned a ~1-2s spawn. Vaultwarden's server is configured by the user
                 # via the CLI (`bw config server <url>` then `bw login`); the app's URL
                 # setting just gates availability and labels the backend.
-                env = os.environ.copy()
-                env["BW_PASSWORD"] = secret or ""
                 self._report(progress, "unlocking")
-                started = time.monotonic()
-                result = subprocess.run(
-                    self._bw_argv("unlock", "--passwordenv", "BW_PASSWORD", "--raw"),
-                    capture_output=True, env=env, check=False, timeout=self._TIMEOUT,
+                # Use _run so Flatpak host spawns get ``--env=BW_PASSWORD=…`` —
+                # ``flatpak-spawn --host`` does not forward sandbox env, and host
+                # ``bw`` then fails with "Master password is required."
+                result = self._run(
+                    ["unlock", "--passwordenv", "BW_PASSWORD", "--raw"],
+                    extra_env={"BW_PASSWORD": secret or ""},
                 )
-                logger.debug("bw unlock: %.2fs (rc=%s)",
-                             time.monotonic() - started, result.returncode)
                 if result.returncode != 0:
                     logger.error("bw unlock failed: %s",
                                  result.stderr.decode("utf-8", "replace").strip())

--- a/sshpilot/secret_storage.py
+++ b/sshpilot/secret_storage.py
@@ -865,12 +865,16 @@ class BitwardenBackend(SecretBackend):
         return bw_cli_discoverable()
 
     # -- bw subprocess helper --------------------------------------------
-    def _bw_command(self, args: List[str], env: dict) -> List[str]:
+    def _bw_command(self, args: List[str], env: dict) -> Tuple[List[str], Tuple[int, ...]]:
         """Build the full ``bw`` argv, forwarding env into Flatpak host spawns.
 
         ``flatpak-spawn --host`` does not inherit the sandbox environment, so
-        secrets like ``BW_PASSWORD`` / ``BW_SESSION`` must be passed as
-        ``--env=KEY=VALUE`` or host ``bw`` never sees them.
+        secrets like ``BW_PASSWORD`` / ``BW_SESSION`` are forwarded via a
+        ``--env-fd`` memfd — never ``--env=KEY=VALUE``, which would put the
+        master password in the world-readable ``/proc/<pid>/cmdline``.
+
+        Returns ``(argv, pass_fds)``; the caller must spawn with ``pass_fds``
+        and close those fds afterwards.
         """
         argv = self._bw_argv(*args)
         try:
@@ -879,7 +883,7 @@ class BitwardenBackend(SecretBackend):
             try:
                 from platform_utils import inject_flatpak_host_env  # type: ignore
             except Exception:
-                return argv
+                return argv, ()
         return inject_flatpak_host_env(argv, env)
 
     def _run(self, args: List[str], *, token: Optional[str] = None,
@@ -901,12 +905,19 @@ class BitwardenBackend(SecretBackend):
             env.update(extra_env)
         if token:
             env["BW_SESSION"] = token
+        argv, pass_fds = self._bw_command(args, env)
+        # Only pass ``pass_fds`` when needed so non-Flatpak spawns are untouched.
+        spawn_kwargs = {"pass_fds": pass_fds} if pass_fds else {}
         started = time.monotonic()
-        result = subprocess.run(
-            self._bw_command(args, env),
-            input=input_bytes, capture_output=True, env=env, check=False,
-            timeout=self._TIMEOUT,
-        )
+        try:
+            result = subprocess.run(
+                argv,
+                input=input_bytes, capture_output=True, env=env, check=False,
+                timeout=self._TIMEOUT, **spawn_kwargs,
+            )
+        finally:
+            for fd in pass_fds:
+                os.close(fd)
         logger.debug("bw %s: %.2fs (rc=%s)",
                      " ".join(args[:2]), time.monotonic() - started, result.returncode)
         return result

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -53,22 +53,38 @@ def test_resolve_host_binary_flatpak_host_fallback(monkeypatch):
     assert platform_utils.resolve_host_binary("bw") == ["/usr/bin/flatpak-spawn", "--host", "bw"]
 
 
-def test_inject_flatpak_host_env_inserts_after_host():
+def _read_env_fd(argv):
+    """Decode the ``env -0`` payload behind an ``--env-fd=N`` flag, if any."""
+    flag = next((a for a in argv if a.startswith("--env-fd=")), None)
+    if flag is None:
+        return None
+    data = os.pread(int(flag[len("--env-fd="):]), 65536, 0)
+    return dict(item.split("=", 1) for item in data.decode().split("\0") if item)
+
+
+def test_inject_flatpak_host_env_inserts_env_fd_after_host():
     argv = ["/usr/bin/flatpak-spawn", "--host", "bw", "--nointeraction", "unlock"]
-    out = platform_utils.inject_flatpak_host_env(
+    out, fds = platform_utils.inject_flatpak_host_env(
         argv, {"BW_PASSWORD": "secret", "BW_SESSION": "tok", "IGNORED": "x"},
     )
-    assert out[0:2] == ["/usr/bin/flatpak-spawn", "--host"]
-    assert "--env=BW_PASSWORD=secret" in out
-    assert "--env=BW_SESSION=tok" in out
-    assert all(not a.startswith("--env=IGNORED=") for a in out)
-    assert out.index("--host") < out.index("--env=BW_PASSWORD=secret") < out.index("bw")
+    try:
+        assert out[0:2] == ["/usr/bin/flatpak-spawn", "--host"]
+        assert len(fds) == 1
+        flag = f"--env-fd={fds[0]}"
+        assert out.index("--host") < out.index(flag) < out.index("bw")
+        assert _read_env_fd(out) == {"BW_PASSWORD": "secret", "BW_SESSION": "tok"}
+        # The whole point of --env-fd: no secret may appear in the argv itself.
+        assert all("secret" not in a and "tok" not in a for a in out)
+    finally:
+        for fd in fds:
+            os.close(fd)
 
 
 def test_inject_flatpak_host_env_noop_for_direct_binary():
     argv = ["/usr/bin/bw", "--nointeraction", "unlock"]
-    out = platform_utils.inject_flatpak_host_env(argv, {"BW_PASSWORD": "secret"})
+    out, fds = platform_utils.inject_flatpak_host_env(argv, {"BW_PASSWORD": "secret"})
     assert out == argv
+    assert fds == ()
 
 
 def test_inject_flatpak_host_env_skips_empty_and_existing():
@@ -77,13 +93,15 @@ def test_inject_flatpak_host_env_skips_empty_and_existing():
         "--env=BW_PASSWORD=already",
         "bw", "unlock",
     ]
-    out = platform_utils.inject_flatpak_host_env(
+    out, fds = platform_utils.inject_flatpak_host_env(
         argv, {"BW_PASSWORD": "new", "BW_SESSION": "", "BITWARDENCLI_APPDATA_DIR": "/data"},
     )
-    assert out.count("--env=BW_PASSWORD=already") == 1
-    assert "--env=BW_PASSWORD=new" not in out
-    assert "--env=BW_SESSION=" not in out
-    assert "--env=BITWARDENCLI_APPDATA_DIR=/data" in out
+    try:
+        assert out.count("--env=BW_PASSWORD=already") == 1
+        assert _read_env_fd(out) == {"BITWARDENCLI_APPDATA_DIR": "/data"}
+    finally:
+        for fd in fds:
+            os.close(fd)
 
 
 def test_get_config_dir(monkeypatch, tmp_path):

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -53,6 +53,39 @@ def test_resolve_host_binary_flatpak_host_fallback(monkeypatch):
     assert platform_utils.resolve_host_binary("bw") == ["/usr/bin/flatpak-spawn", "--host", "bw"]
 
 
+def test_inject_flatpak_host_env_inserts_after_host():
+    argv = ["/usr/bin/flatpak-spawn", "--host", "bw", "--nointeraction", "unlock"]
+    out = platform_utils.inject_flatpak_host_env(
+        argv, {"BW_PASSWORD": "secret", "BW_SESSION": "tok", "IGNORED": "x"},
+    )
+    assert out[0:2] == ["/usr/bin/flatpak-spawn", "--host"]
+    assert "--env=BW_PASSWORD=secret" in out
+    assert "--env=BW_SESSION=tok" in out
+    assert all(not a.startswith("--env=IGNORED=") for a in out)
+    assert out.index("--host") < out.index("--env=BW_PASSWORD=secret") < out.index("bw")
+
+
+def test_inject_flatpak_host_env_noop_for_direct_binary():
+    argv = ["/usr/bin/bw", "--nointeraction", "unlock"]
+    out = platform_utils.inject_flatpak_host_env(argv, {"BW_PASSWORD": "secret"})
+    assert out == argv
+
+
+def test_inject_flatpak_host_env_skips_empty_and_existing():
+    argv = [
+        "/usr/bin/flatpak-spawn", "--host",
+        "--env=BW_PASSWORD=already",
+        "bw", "unlock",
+    ]
+    out = platform_utils.inject_flatpak_host_env(
+        argv, {"BW_PASSWORD": "new", "BW_SESSION": "", "BITWARDENCLI_APPDATA_DIR": "/data"},
+    )
+    assert out.count("--env=BW_PASSWORD=already") == 1
+    assert "--env=BW_PASSWORD=new" not in out
+    assert "--env=BW_SESSION=" not in out
+    assert "--env=BITWARDENCLI_APPDATA_DIR=/data" in out
+
+
 def test_get_config_dir(monkeypatch, tmp_path):
     monkeypatch.setattr(
         platform_utils.GLib,

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -796,7 +796,95 @@ def test_bitwarden_flatpak_uses_host_spawn(monkeypatch):
     backend = ss.BitwardenBackend()
     assert backend.is_available() is True
     assert backend.needs_login() is False
-    assert calls == [['/usr/bin/flatpak-spawn', '--host', 'bw', '--nointeraction', 'login', '--check']]
+    assert len(calls) == 1
+    argv = calls[0]
+    assert argv[0:2] == ['/usr/bin/flatpak-spawn', '--host']
+    assert argv[-4:] == ['bw', '--nointeraction', 'login', '--check']
+    # Host spawn must place any ``--env=`` flags between ``--host`` and ``bw``.
+    for flag in argv[2:-4]:
+        assert flag.startswith('--env=')
+
+
+def test_bitwarden_flatpak_forwards_password_via_env_flag(monkeypatch):
+    """Regression: Flatpak host ``bw`` never sees sandbox ``BW_PASSWORD`` unless
+    ``flatpak-spawn --host --env=BW_PASSWORD=…`` is used — otherwise unlock fails
+    with ``Master password is required.`` even when the typed password is correct.
+    """
+    from sshpilot import platform_utils
+
+    captured = []
+
+    def fake_resolve():
+        return ['/usr/bin/flatpak-spawn', '--host', 'bw']
+
+    def fake_run(argv, **kwargs):
+        argv = list(argv)
+        captured.append(argv)
+        # Host process only receives vars passed via ``--env=`` (not subprocess env=).
+        host_env = {}
+        args = argv[2:] if argv[:2] == ['/usr/bin/flatpak-spawn', '--host'] else []
+        while args and args[0].startswith('--env='):
+            key, _, value = args.pop(0)[6:].partition('=')
+            host_env[key] = value
+        if not args or args[0] != 'bw':
+            return _Result(1, b'', b'unexpected argv')
+        cmd = [a for a in args[1:] if a != '--nointeraction']
+        if cmd[:1] == ['unlock']:
+            if '--passwordenv' in cmd:
+                name = cmd[cmd.index('--passwordenv') + 1]
+                if not host_env.get(name):
+                    return _Result(1, b'', b'Master password is required.')
+            return _Result(0, b'SESSION\n')
+        if cmd[:2] == ['list', 'items']:
+            return _Result(0, b'[]')
+        if cmd[:1] == ['sync']:
+            return _Result(0, b'')
+        return _Result(1, b'', b'unexpected: %s' % cmd)
+
+    monkeypatch.setattr(platform_utils, 'resolve_bw_cli_unverified', fake_resolve)
+    monkeypatch.setattr(ss.subprocess, 'run', fake_run)
+    backend = ss.BitwardenBackend()
+    assert backend.unlock('correct-master') is True
+
+    unlock_argv = next(a for a in captured if 'unlock' in a)
+    assert '--env=BW_PASSWORD=correct-master' in unlock_argv
+    host_i = unlock_argv.index('--host')
+    bw_i = unlock_argv.index('bw')
+    env_i = unlock_argv.index('--env=BW_PASSWORD=correct-master')
+    assert host_i < env_i < bw_i
+
+
+def test_bitwarden_flatpak_login_forwards_password_via_env_flag(monkeypatch):
+    from sshpilot import platform_utils
+
+    captured = []
+
+    def fake_resolve():
+        return ['/usr/bin/flatpak-spawn', '--host', 'bw']
+
+    def fake_run(argv, **kwargs):
+        argv = list(argv)
+        captured.append(argv)
+        host_env = {}
+        args = argv[2:] if argv[:2] == ['/usr/bin/flatpak-spawn', '--host'] else []
+        while args and args[0].startswith('--env='):
+            key, _, value = args.pop(0)[6:].partition('=')
+            host_env[key] = value
+        cmd = [a for a in args[1:] if a != '--nointeraction'] if args and args[0] == 'bw' else []
+        if cmd[:1] == ['login'] and '--passwordenv' in cmd:
+            name = cmd[cmd.index('--passwordenv') + 1]
+            if not host_env.get(name):
+                return _Result(1, b'', b'Master password is required.')
+            return _Result(0, json.dumps({"success": True, "data": "LOGIN_SESSION"}).encode())
+        return _Result(1, b'', b'unexpected')
+
+    monkeypatch.setattr(platform_utils, 'resolve_bw_cli_unverified', fake_resolve)
+    monkeypatch.setattr(ss.subprocess, 'run', fake_run)
+    backend = ss.BitwardenBackend()
+    ok, detail, needs_2fa = backend.login_with_password('user@host', 'mp')
+    assert ok is True and detail == '' and needs_2fa is False
+    login_argv = next(a for a in captured if 'login' in a)
+    assert '--env=BW_PASSWORD=mp' in login_argv
 
 
 def test_non_session_backend_needs_no_unlock(manager):
@@ -831,16 +919,29 @@ class FakeBw:
     @staticmethod
     def _bw_command(argv):
         args = list(argv)
+        host_env = {}
         if len(args) >= 3 and os.path.basename(args[0]) == "flatpak-spawn" and args[1] == "--host":
-            args = args[3:]
+            args = args[2:]
+            # Skip flatpak-spawn host options (``--env=KEY=VALUE``, …) before the binary.
+            while args and args[0].startswith("--"):
+                opt = args.pop(0)
+                if opt.startswith("--env="):
+                    key, _, value = opt[6:].partition("=")
+                    host_env[key] = value
+            if args:
+                args = args[1:]  # drop host ``bw`` path/name
         elif args:
             args = args[1:]
-        return [a for a in args if a != '--nointeraction']
+        return [a for a in args if a != '--nointeraction'], host_env
 
     def run(self, argv, input=None, capture_output=None, env=None, check=None, timeout=None):
-        cmd = self._bw_command(argv)
+        cmd, host_env = self._bw_command(argv)
+        merged = dict(env or {})
+        merged.update(host_env)
         self.calls.append(cmd)
-        self.envs.append(dict(env or {}))
+        self.envs.append(merged)
+        # Prefer host-forwarded secrets when present (Flatpak --env= path).
+        env = merged
         if cmd[:1] == ['status']:
             return _Result(0, json.dumps({"status": self.status}).encode())
         if cmd[:2] == ['login', '--check']:
@@ -848,6 +949,13 @@ class FakeBw:
                 return _Result(1, b'', b'You are not logged in.')
             return _Result(0, b'You are logged in!\n')
         if cmd[:1] == ['unlock']:
+            # Mirror real ``bw unlock --passwordenv``: empty/missing password →
+            # "Master password is required." (the Flatpak env-forwarding bug).
+            if '--passwordenv' in cmd:
+                idx = cmd.index('--passwordenv')
+                env_name = cmd[idx + 1] if idx + 1 < len(cmd) else 'BW_PASSWORD'
+                if not (env or {}).get(env_name):
+                    return _Result(1, b'', b'Master password is required.')
             if self.status == "unauthenticated" or not self.unlock_ok:
                 return _Result(1, b'', b'unlock failed')
             self.status = "unlocked"
@@ -875,6 +983,10 @@ class FakeBw:
                     b'{"success":false,"message":"Login failed."}',
                 )
             if email:
+                if '--passwordenv' in cmd:
+                    env_name = cmd[cmd.index('--passwordenv') + 1]
+                    if not (env or {}).get(env_name):
+                        return _Result(1, b'', b'Master password is required.')
                 if '--raw' in cmd:
                     self.status = "unlocked"
                     if '--response' in cmd:

--- a/tests/test_secret_storage.py
+++ b/tests/test_secret_storage.py
@@ -779,6 +779,28 @@ def test_bitwarden_is_available_reresolves_bw(monkeypatch):
     assert backend.is_available() is True
 
 
+def _consume_spawn_options(args):
+    """Pop leading flatpak-spawn options off ``args``; decode env forwarding.
+
+    Mirrors the host side: only vars forwarded via ``--env-fd`` (``env -0``
+    payload) or ``--env=`` reach the host process — the sandbox subprocess
+    ``env=`` never does. Returns ``(host_env, remaining_args)``.
+    """
+    host_env = {}
+    args = list(args)
+    while args and args[0].startswith('--'):
+        opt = args.pop(0)
+        if opt.startswith('--env-fd='):
+            data = os.pread(int(opt[len('--env-fd='):]), 65536, 0)
+            host_env.update(
+                item.split('=', 1) for item in data.decode().split('\0') if item
+            )
+        elif opt.startswith('--env='):
+            key, _, value = opt[6:].partition('=')
+            host_env[key] = value
+    return host_env, args
+
+
 def test_bitwarden_flatpak_uses_host_spawn(monkeypatch):
     from sshpilot import platform_utils
 
@@ -800,15 +822,16 @@ def test_bitwarden_flatpak_uses_host_spawn(monkeypatch):
     argv = calls[0]
     assert argv[0:2] == ['/usr/bin/flatpak-spawn', '--host']
     assert argv[-4:] == ['bw', '--nointeraction', 'login', '--check']
-    # Host spawn must place any ``--env=`` flags between ``--host`` and ``bw``.
+    # Host spawn forwards env only via ``--env-fd`` between ``--host`` and ``bw``.
     for flag in argv[2:-4]:
-        assert flag.startswith('--env=')
+        assert flag.startswith('--env-fd=')
 
 
-def test_bitwarden_flatpak_forwards_password_via_env_flag(monkeypatch):
+def test_bitwarden_flatpak_forwards_password_via_env_fd(monkeypatch):
     """Regression: Flatpak host ``bw`` never sees sandbox ``BW_PASSWORD`` unless
-    ``flatpak-spawn --host --env=BW_PASSWORD=…`` is used — otherwise unlock fails
-    with ``Master password is required.`` even when the typed password is correct.
+    it is forwarded through ``flatpak-spawn --host --env-fd=…`` — otherwise unlock
+    fails with ``Master password is required.`` even when the typed password is
+    correct. And the secret must travel via the fd, never in argv itself.
     """
     from sshpilot import platform_utils
 
@@ -819,13 +842,9 @@ def test_bitwarden_flatpak_forwards_password_via_env_flag(monkeypatch):
 
     def fake_run(argv, **kwargs):
         argv = list(argv)
-        captured.append(argv)
-        # Host process only receives vars passed via ``--env=`` (not subprocess env=).
-        host_env = {}
         args = argv[2:] if argv[:2] == ['/usr/bin/flatpak-spawn', '--host'] else []
-        while args and args[0].startswith('--env='):
-            key, _, value = args.pop(0)[6:].partition('=')
-            host_env[key] = value
+        host_env, args = _consume_spawn_options(args)
+        captured.append((argv, host_env))
         if not args or args[0] != 'bw':
             return _Result(1, b'', b'unexpected argv')
         cmd = [a for a in args[1:] if a != '--nointeraction']
@@ -846,15 +865,17 @@ def test_bitwarden_flatpak_forwards_password_via_env_flag(monkeypatch):
     backend = ss.BitwardenBackend()
     assert backend.unlock('correct-master') is True
 
-    unlock_argv = next(a for a in captured if 'unlock' in a)
-    assert '--env=BW_PASSWORD=correct-master' in unlock_argv
+    unlock_argv, unlock_env = next(t for t in captured if 'unlock' in t[0])
+    assert unlock_env.get('BW_PASSWORD') == 'correct-master'
+    # The secret must never appear on the command line (/proc/<pid>/cmdline).
+    assert all('correct-master' not in a for a in unlock_argv)
     host_i = unlock_argv.index('--host')
     bw_i = unlock_argv.index('bw')
-    env_i = unlock_argv.index('--env=BW_PASSWORD=correct-master')
-    assert host_i < env_i < bw_i
+    fd_i = next(i for i, a in enumerate(unlock_argv) if a.startswith('--env-fd='))
+    assert host_i < fd_i < bw_i
 
 
-def test_bitwarden_flatpak_login_forwards_password_via_env_flag(monkeypatch):
+def test_bitwarden_flatpak_login_forwards_password_via_env_fd(monkeypatch):
     from sshpilot import platform_utils
 
     captured = []
@@ -864,12 +885,9 @@ def test_bitwarden_flatpak_login_forwards_password_via_env_flag(monkeypatch):
 
     def fake_run(argv, **kwargs):
         argv = list(argv)
-        captured.append(argv)
-        host_env = {}
         args = argv[2:] if argv[:2] == ['/usr/bin/flatpak-spawn', '--host'] else []
-        while args and args[0].startswith('--env='):
-            key, _, value = args.pop(0)[6:].partition('=')
-            host_env[key] = value
+        host_env, args = _consume_spawn_options(args)
+        captured.append((argv, host_env))
         cmd = [a for a in args[1:] if a != '--nointeraction'] if args and args[0] == 'bw' else []
         if cmd[:1] == ['login'] and '--passwordenv' in cmd:
             name = cmd[cmd.index('--passwordenv') + 1]
@@ -883,8 +901,9 @@ def test_bitwarden_flatpak_login_forwards_password_via_env_flag(monkeypatch):
     backend = ss.BitwardenBackend()
     ok, detail, needs_2fa = backend.login_with_password('user@host', 'mp')
     assert ok is True and detail == '' and needs_2fa is False
-    login_argv = next(a for a in captured if 'login' in a)
-    assert '--env=BW_PASSWORD=mp' in login_argv
+    login_argv, login_env = next(t for t in captured if 'login' in t[0])
+    assert login_env.get('BW_PASSWORD') == 'mp'
+    assert all('mp' != a and 'BW_PASSWORD=mp' not in a for a in login_argv)
 
 
 def test_non_session_backend_needs_no_unlock(manager):
@@ -921,26 +940,22 @@ class FakeBw:
         args = list(argv)
         host_env = {}
         if len(args) >= 3 and os.path.basename(args[0]) == "flatpak-spawn" and args[1] == "--host":
-            args = args[2:]
-            # Skip flatpak-spawn host options (``--env=KEY=VALUE``, …) before the binary.
-            while args and args[0].startswith("--"):
-                opt = args.pop(0)
-                if opt.startswith("--env="):
-                    key, _, value = opt[6:].partition("=")
-                    host_env[key] = value
+            # Decode flatpak-spawn host options (``--env-fd``, ``--env=``, …).
+            host_env, args = _consume_spawn_options(args[2:])
             if args:
                 args = args[1:]  # drop host ``bw`` path/name
         elif args:
             args = args[1:]
         return [a for a in args if a != '--nointeraction'], host_env
 
-    def run(self, argv, input=None, capture_output=None, env=None, check=None, timeout=None):
+    def run(self, argv, input=None, capture_output=None, env=None, check=None,
+            timeout=None, pass_fds=()):
         cmd, host_env = self._bw_command(argv)
         merged = dict(env or {})
         merged.update(host_env)
         self.calls.append(cmd)
         self.envs.append(merged)
-        # Prefer host-forwarded secrets when present (Flatpak --env= path).
+        # Prefer host-forwarded secrets when present (Flatpak --env-fd path).
         env = merged
         if cmd[:1] == ['status']:
             return _Result(0, json.dumps({"status": self.status}).encode())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Diagnosed and fixed a Flatpak-only Bitwarden/Vaultwarden unlock failure where a correct master password still produced **`Master password is required.`**

### Root cause

Under Flatpak, sshPilot runs host `bw` via `flatpak-spawn --host bw …`. That path **does not forward the sandbox process environment** to the host command.

Unlock/login set `BW_PASSWORD` in the subprocess `env=` and ran `bw unlock --passwordenv BW_PASSWORD`. On Debian/native that works. On Flatpak, host `bw` never saw `BW_PASSWORD`, so the CLI reported exactly:

```text
Master password is required.
```

This matches the report (Flatpak broken, Debian package fine; self-hosted Vaultwarden).

### Fix

- Add `inject_flatpak_host_env()` to forward Bitwarden-related vars (`BW_PASSWORD`, `BW_SESSION`, `BW_CLIENTID`, `BW_CLIENTSECRET`, `BITWARDENCLI_APPDATA_DIR`, `NODE_EXTRA_CA_CERTS`) via `flatpak-spawn --host --env-fd=N …` — a memfd with NUL-terminated `KEY=VALUE` assignments (`env -0` format), passed with `pass_fds` and closed after the spawn. `--env-fd` (not `--env=`) keeps the master password and session token out of the world-readable `/proc/<pid>/cmdline`.
- Route all `BitwardenBackend` spawns (including unlock) through that helper.

### Reproduction

Simulated `flatpak-spawn --host` (strips sandbox env unless `--env=`):

| Path | Result |
|------|--------|
| Before (`env=` only) | `Master password is required.` |
| After (`--env-fd` payload with `BW_PASSWORD`) | unlock succeeds |

### Tests

- Unit tests for `inject_flatpak_host_env`
- Regression tests that Flatpak unlock/login argv forwards `BW_PASSWORD` via an `--env-fd` payload between `--host` and `bw`, and that the secret never appears in argv

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8b6b91d-9d5c-4d53-86e4-5818b01e25cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8b6b91d-9d5c-4d53-86e4-5818b01e25cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


