### PR TITLE
Improve MFA askpass prompt classification

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -119,7 +119,9 @@ _HOSTKEY_MARKERS = (
 # Word-boundary match: bare substrings would misfire on hostnames/usernames
 # ("user@alpine's password:" contains 'pin', "scotp1" contains 'otp').
 _TYPED_INTERACTIVE_RE = re.compile(
-    r'\b(?:pin|otp|verification code|one-time|authentication code)\b'
+    r'\b(?:pin|otp|totp|mfa|2fa|two[-\s]?factor|'
+    r'verification[ -]?(?:code|token)|one[-\s]?time|'
+    r'authentication[ -]?(?:code|token)|passcode|security[ -]?code|token)\b'
 )
 
 

--- a/tests/test_askpass_password.py
+++ b/tests/test_askpass_password.py
@@ -27,6 +27,17 @@ def test_classify_prompt_markers_need_word_boundaries():
     assert classify_prompt("Enter one-time password:") == "interactive"
 
 
+def test_classify_prompt_common_mfa_challenges():
+    assert classify_prompt("Duo two-factor login for alice:") == "interactive"
+    assert (
+        classify_prompt("Enter a passcode or select one of the following options:")
+        == "interactive"
+    )
+    assert classify_prompt("Security code:") == "interactive"
+    assert classify_prompt("TOTP token for alice:") == "interactive"
+    assert classify_prompt("MFA verification-token:") == "interactive"
+
+
 def test_classify_prompt_fido_presence_and_pin():
     assert (
         classify_prompt("Confirm user presence for key ED25519-SK SHA256:abcd")


### PR DESCRIPTION
### Motivation
- Improve detection of common MFA/2FA/TOTP wording so the askpass helper treats those challenges as interactive prompts (showing the challenge dialog) instead of misclassifying them as passwords or falling back to the TTY.

### Description
- Expand the `_TYPED_INTERACTIVE_RE` in `sshpilot/askpass_utils.py` to recognize additional MFA wording such as `totp`, `mfa`, `2fa`, `two-factor`, `verification-code`/`verification token`, `passcode`, `security code`, and `token` while preserving the original word-boundary guards to avoid hostname/user false positives.
- Add regression coverage in `tests/test_askpass_password.py` via `test_classify_prompt_common_mfa_challenges()` with representative challenge strings (Duo two-factor, passcode selection text, security code, TOTP token, verification-token).

### Testing
- Ran `pytest tests/test_askpass_password.py -q` and the suite passed (`24 passed`).
- Ran `pytest tests/test_terminal_pty_autofill.py -q` and the suite passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ca6f53d188328a64348ee67481167)