### PR TITLE
Fix MFA "password" prompts being autofilled as login passwords

### DIFF
--- a/sshpilot/askpass_utils.py
+++ b/sshpilot/askpass_utils.py
@@ -118,8 +118,16 @@ _HOSTKEY_MARKERS = (
 )
 # Word-boundary match: bare substrings would misfire on hostnames/usernames
 # ("user@alpine's password:" contains 'pin', "scotp1" contains 'otp').
+#
+# OTP/MFA markers shared with the "…password" exemption below so prompts like
+# "one time password" / "TOTP password" are never treated as login passwords
+# (which would autofill the stored SSH password into an MFA challenge).
+_OTP_MFA_MARKER_RE = re.compile(
+    r'\b(?:pin|otp|totp|mfa|2fa|two[-\s]?factor|one[-\s]?time)\b'
+)
 _TYPED_INTERACTIVE_RE = re.compile(
-    r'\b(?:pin|otp|verification code|one-time|authentication code)\b'
+    r'\b(?:pin|otp|totp|mfa|2fa|two[-\s]?factor|'
+    r'verification code|one[-\s]?time|authentication code)\b'
 )
 
 
@@ -144,8 +152,9 @@ def classify_prompt(text: str) -> "str | None":
         if 'passphrase' in last:
             return 'passphrase'
         # "…'s password:" for a host that legitimately contains an OTP/PIN
-        # word is still a login password — but "one-time password" is not.
-        if 'password' in last and not re.search(r'\b(?:pin|otp|one-time)\b', last):
+        # word is still a login password — but "one-time password",
+        # "one time password", "TOTP password", etc. are MFA challenges.
+        if 'password' in last and not _OTP_MFA_MARKER_RE.search(last):
             return 'password'
         return 'interactive'
     if last.endswith(':'):

--- a/tests/test_askpass_password.py
+++ b/tests/test_askpass_password.py
@@ -27,6 +27,22 @@ def test_classify_prompt_markers_need_word_boundaries():
     assert classify_prompt("Enter one-time password:") == "interactive"
 
 
+def test_classify_prompt_mfa_password_not_login_password():
+    # MFA challenges that contain the word "password" must not classify as
+    # login passwords (askpass would autofill the stored SSH secret).
+    assert classify_prompt("Enter one-time password:") == "interactive"
+    assert classify_prompt("Enter one time password:") == "interactive"
+    assert classify_prompt("TOTP password:") == "interactive"
+    assert classify_prompt("MFA password:") == "interactive"
+    assert classify_prompt("2FA password:") == "interactive"
+    assert classify_prompt("two-factor password:") == "interactive"
+    assert classify_prompt("two factor password:") == "interactive"
+    # Ordinary login passwords are unchanged.
+    assert classify_prompt("Password:") == "password"
+    assert classify_prompt("Password for alice@host:") == "password"
+    assert classify_prompt("user@alpine's password:") == "password"
+
+
 def test_classify_prompt_fido_presence_and_pin():
     assert (
         classify_prompt("Confirm user presence for key ED25519-SK SHA256:abcd")
@@ -286,6 +302,30 @@ def test_askpass_prompts_user_for_otp(monkeypatch):
         lambda prompt, _log: (True, "123456"),
     )
     assert handle_askpass_cli("Verification code:") == "123456"
+
+
+def test_askpass_does_not_autofill_mfa_password_prompt(monkeypatch):
+    # "one time password" / "TOTP password" contain "password" but are MFA —
+    # must not return the vaulted SSH login password.
+    monkeypatch.delenv("SSHPILOT_SESSION_PASSWORD_FILE", raising=False)
+    monkeypatch.delenv("SSHPILOT_SESSION_PASSWORD_ID", raising=False)
+    monkeypatch.setenv("SSHPILOT_PASSWORD_USER", "alice")
+    monkeypatch.setenv("SSHPILOT_PASSWORD_HOSTS", "example.com")
+    monkeypatch.setattr(
+        "sshpilot.askpass_utils.lookup_ssh_password",
+        lambda host, user: "vaulted-ssh-password",
+    )
+    monkeypatch.setattr(
+        "sshpilot.askpass_utils._route_challenge_to_main_app",
+        lambda prompt, _log: (True, "654321"),
+    )
+    for prompt in (
+        "Enter one time password:",
+        "Enter one-time password:",
+        "TOTP password:",
+        "MFA password:",
+    ):
+        assert handle_askpass_cli(prompt) == "654321", prompt
 
 
 def test_askpass_otp_cancel(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
Askpass could misclassify MFA challenges that contain the word `password` (e.g. `Enter one time password:`, `TOTP password:`) as login passwords and autofill the stored SSH secret into the OTP prompt.

### Description
- Introduce a shared `_OTP_MFA_MARKER_RE` covering `pin` / `otp` / `totp` / `mfa` / `2fa` / `two-factor` / `one time` (hyphen or space).
- Use those markers in `_TYPED_INTERACTIVE_RE` and in the `"…password"` exemption so these prompts classify as `interactive`.
- Ordinary login passwords (`Password:`, `user@alpine's password:`) are unchanged.
- Add classifier and askpass regression tests that assert vault passwords are never returned for MFA+"password" prompts.

### Testing
- `pytest tests/test_askpass_password.py tests/test_terminal_pty_autofill.py -q` → 34 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09aafa22-b28b-4fb6-86b4-6ef474adbe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09aafa22-b28b-4fb6-86b4-6ef474adbe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

