### PR TITLE
Simplify long SSH parsing and option-building helpers

### DIFF
--- a/src/sshpilot/command_converter.py
+++ b/src/sshpilot/command_converter.py
@@ -80,6 +80,17 @@ _DYNAMIC_RE = re.compile(
     r'(' + _PORT + r')$'          # port
 )
 
+_TRUE_VALUES = frozenset(('yes', 'true', '1', 'on'))
+_FALSE_VALUES = frozenset(('no', 'false', '0', 'off'))
+
+
+def _is_ssh_true(value: str) -> bool:
+    return value.lower() in _TRUE_VALUES
+
+
+def _is_ssh_false(value: str) -> bool:
+    return value.lower() in _FALSE_VALUES
+
 
 def _parse_forward_spec(spec: str, fwd_type: str):
     """Parse -L/-R spec [bind_addr:]port:host:hostport into a forwarding_rules dict.
@@ -123,6 +134,120 @@ def _append_extra_config(data: dict, line: str) -> None:
     data["extra_ssh_config"] = (existing + "\n" + line).lstrip("\n")
 
 
+def _bare_user_host_data(username: str, host: str) -> dict:
+    return {
+        "nickname": host,
+        "host": host,
+        "hostname": host,
+        "username": username,
+        "port": 22,
+        "auth_method": 0,
+        "key_select_mode": 0,
+        "unparsed_args": [],
+    }
+
+
+def _empty_connection_data() -> dict:
+    return {
+        "nickname": "",
+        "host": "",
+        "hostname": "",
+        "username": "",
+        "port": 22,
+        "auth_method": 0,
+        "key_select_mode": 0,
+        "keyfile": "",
+        "certificate": "",
+        "x11_forwarding": False,
+        "forwarding_rules": [],
+        "proxy_jump": [],
+        "forward_agent": False,
+        "extra_ssh_config": "",
+        "unparsed_args": [],
+    }
+
+
+def _apply_o_option(data: dict, key: str, value: str) -> None:
+    """Apply a single ``-o Key=value`` (or ``Key value``) option to *data*."""
+    key_lower = key.lower()
+    value = value.strip()
+    if key_lower == 'user':
+        data["username"] = value
+    elif key_lower == 'port':
+        try:
+            data["port"] = int(value)
+        except ValueError:
+            pass
+    elif key_lower == 'identityfile':
+        data["keyfile"] = value
+        data["key_select_mode"] = 2
+    elif key_lower == 'identitiesonly':
+        if _is_ssh_true(value):
+            data["key_select_mode"] = 1
+        elif _is_ssh_false(value) and data.get("keyfile"):
+            data["key_select_mode"] = 2
+    elif key_lower == 'forwardagent':
+        data["forward_agent"] = _is_ssh_true(value)
+    else:
+        _append_extra_config(data, f"{key} {value}")
+
+
+def _set_host_token(data: dict, token: str) -> None:
+    """Fill host/username fields from a destination token (``user@host`` or host)."""
+    if '@' in token:
+        username, host = token.split('@', 1)
+        data["username"] = username
+        data["host"] = host
+        data["hostname"] = host
+        data["nickname"] = host
+    else:
+        data["host"] = token
+        data["hostname"] = token
+        data["nickname"] = token
+
+
+def _consume_unknown_option(data: dict, args: list, i: int) -> int:
+    """Record an unrecognized flag (and its argument, if any) in unparsed_args.
+
+    Returns the next index to process.
+    """
+    arg = args[i]
+    option_key = arg
+    attached_value = ""
+    if option_key.startswith('--'):
+        option_key, _sep, attached_value = option_key.partition('=')
+    elif option_key.startswith('-') and len(option_key) > 2:
+        option_key, attached_value = option_key[:2], option_key[2:]
+
+    expects_argument = option_key in SSH_OPTIONS_EXPECTING_ARGUMENT
+    if attached_value:
+        data["unparsed_args"].append(arg)
+        return i + 1
+
+    if expects_argument and i + 1 < len(args) and not args[i + 1].startswith('-'):
+        data["unparsed_args"].extend([arg, args[i + 1]])
+        return i + 2
+
+    data["unparsed_args"].append(arg)
+    return i + 1
+
+
+def _try_parse_int_option(data: dict, field: str, raw: str) -> bool:
+    """Set *field* from *raw* if it parses as an int. Returns True on success."""
+    try:
+        data[field] = int(raw)
+        return True
+    except ValueError:
+        return False
+
+
+def _tokenize(raw_command: str) -> list:
+    try:
+        return shlex.split(raw_command)
+    except ValueError:
+        return raw_command.split()
+
+
 def parse_ssh_command(command_text: str) -> Optional[dict]:
     """Parse an SSH command string into connection parameters.
 
@@ -135,226 +260,95 @@ def parse_ssh_command(command_text: str) -> Optional[dict]:
 
         # Allow bare user@host without the 'ssh' prefix
         if '@' in raw_command and ' ' not in raw_command and not raw_command.startswith('ssh'):
-            parts = raw_command.split('@', 1)
-            username, host = parts[0], parts[1]
-            if not host:
-                return None
-            return {
-                "nickname": host,
-                "host": host,
-                "hostname": host,
-                "username": username,
-                "port": 22,
-                "auth_method": 0,
-                "key_select_mode": 0,
-                "unparsed_args": [],
-            }
+            username, host = raw_command.split('@', 1)
+            return _bare_user_host_data(username, host) if host else None
 
-        # For any other input the first token must be exactly "ssh"
-        try:
-            tokens = shlex.split(raw_command)
-        except ValueError:
-            tokens = raw_command.split()
-
+        tokens = _tokenize(raw_command)
         if not tokens:
             return None
-
         if tokens[0] != "ssh":
             return {"error": _("Only SSH commands are allowed. Example: ssh user@host")}
 
+        data = _empty_connection_data()
         args = tokens[1:]
-
-        connection_data = {
-            "nickname": "",
-            "host": "",
-            "hostname": "",
-            "username": "",
-            "port": 22,
-            "auth_method": 0,
-            "key_select_mode": 0,
-            "keyfile": "",
-            "certificate": "",
-            "x11_forwarding": False,
-            "forwarding_rules": [],
-            "proxy_jump": [],
-            "forward_agent": False,
-            "extra_ssh_config": "",
-            "unparsed_args": [],
-        }
-
         i = 0
         while i < len(args):
             arg = args[i]
+            has_next = i + 1 < len(args)
 
-            if arg == '-p' and i + 1 < len(args):
-                try:
-                    connection_data["port"] = int(args[i + 1])
-                    i += 2
-                    continue
-                except ValueError:
-                    pass
-            elif arg == '-i' and i + 1 < len(args):
-                connection_data["keyfile"] = args[i + 1]
-                connection_data["key_select_mode"] = 2
+            if arg == '-p' and has_next and _try_parse_int_option(data, "port", args[i + 1]):
                 i += 2
-                continue
-            elif arg == '-o' and i + 1 < len(args):
+            elif arg == '-i' and has_next:
+                data["keyfile"] = args[i + 1]
+                data["key_select_mode"] = 2
+                i += 2
+            elif arg == '-o' and has_next:
                 option = args[i + 1]
-                parsed = option.split('=', 1)
-                if len(parsed) == 2:
-                    key, value = parsed
-                    key_lower = key.lower()
-                    value = value.strip()
-                    if key_lower == 'user':
-                        connection_data["username"] = value
-                    elif key_lower == 'port':
-                        try:
-                            connection_data["port"] = int(value)
-                        except ValueError:
-                            pass
-                    elif key_lower == 'identityfile':
-                        connection_data["keyfile"] = value
-                        connection_data["key_select_mode"] = 2
-                    elif key_lower == 'identitiesonly':
-                        if value.lower() in ('yes', 'true', '1', 'on'):
-                            connection_data["key_select_mode"] = 1
-                        elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
-                            connection_data["key_select_mode"] = 2
-                    elif key_lower == 'forwardagent':
-                        connection_data["forward_agent"] = value.lower() in ('yes', 'true', '1', 'on')
-                    else:
-                        _append_extra_config(connection_data, f"{key} {value}")
+                if '=' in option:
+                    key, value = option.split('=', 1)
+                    _apply_o_option(data, key, value)
                 i += 2
-                continue
             elif arg.startswith('-o') and '=' in arg[2:]:
                 key, value = arg[2:].split('=', 1)
-                key_lower = key.lower()
-                value = value.strip()
-                if key_lower == 'identityfile':
-                    connection_data["keyfile"] = value
-                    connection_data["key_select_mode"] = 2
-                elif key_lower == 'identitiesonly':
-                    if value.lower() in ('yes', 'true', '1', 'on'):
-                        connection_data["key_select_mode"] = 1
-                    elif value.lower() in ('no', 'false', '0', 'off') and connection_data.get("keyfile"):
-                        connection_data["key_select_mode"] = 2
-                elif key_lower == 'user':
-                    connection_data["username"] = value
-                elif key_lower == 'port':
-                    try:
-                        connection_data["port"] = int(value)
-                    except ValueError:
-                        pass
-                elif key_lower == 'forwardagent':
-                    connection_data["forward_agent"] = value.lower() in ('yes', 'true', '1', 'on')
-                else:
-                    _append_extra_config(connection_data, f"{key} {value}")
+                _apply_o_option(data, key, value)
                 i += 1
-                continue
             elif arg == '-X':
-                connection_data["x11_forwarding"] = True
+                data["x11_forwarding"] = True
                 i += 1
-                continue
             elif arg == '-A':
-                connection_data["forward_agent"] = True
+                data["forward_agent"] = True
                 i += 1
-                continue
             elif arg == '-C':
-                _append_extra_config(connection_data, "Compression yes")
+                _append_extra_config(data, "Compression yes")
                 i += 1
-                continue
             elif arg == '-4':
-                _append_extra_config(connection_data, "AddressFamily inet")
+                _append_extra_config(data, "AddressFamily inet")
                 i += 1
-                continue
             elif arg == '-6':
-                _append_extra_config(connection_data, "AddressFamily inet6")
+                _append_extra_config(data, "AddressFamily inet6")
                 i += 1
-                continue
-            elif arg == '-J' and i + 1 < len(args):
-                connection_data["proxy_jump"] = [
+            elif arg == '-J' and has_next:
+                data["proxy_jump"] = [
                     h.strip() for h in args[i + 1].split(',') if h.strip()
                 ]
                 i += 2
-                continue
-            elif arg == '-L' and i + 1 < len(args):
+            elif arg == '-L' and has_next:
                 rule = _parse_forward_spec(args[i + 1], 'local')
                 if rule:
-                    connection_data["forwarding_rules"].append(rule)
+                    data["forwarding_rules"].append(rule)
                 i += 2
-                continue
-            elif arg == '-R' and i + 1 < len(args):
+            elif arg == '-R' and has_next:
                 rule = _parse_forward_spec(args[i + 1], 'remote')
                 if rule:
-                    connection_data["forwarding_rules"].append(rule)
+                    data["forwarding_rules"].append(rule)
                 i += 2
-                continue
-            elif arg == '-D' and i + 1 < len(args):
+            elif arg == '-D' and has_next:
                 rule = _parse_dynamic_spec(args[i + 1])
                 if rule:
-                    connection_data["forwarding_rules"].append(rule)
+                    data["forwarding_rules"].append(rule)
                 i += 2
-                continue
-            elif arg.startswith('-p'):
-                try:
-                    connection_data["port"] = int(arg[2:])
-                    i += 1
-                    continue
-                except ValueError:
-                    pass
-            elif arg.startswith('-i'):
-                connection_data["keyfile"] = arg[2:]
-                connection_data["key_select_mode"] = 2
+            elif arg.startswith('-p') and _try_parse_int_option(data, "port", arg[2:]):
                 i += 1
-                continue
+            elif arg.startswith('-i') and len(arg) > 2:
+                data["keyfile"] = arg[2:]
+                data["key_select_mode"] = 2
+                i += 1
             elif not arg.startswith('-'):
-                if not connection_data["host"]:
-                    if '@' in arg:
-                        username, host = arg.split('@', 1)
-                        connection_data["username"] = username
-                        connection_data["host"] = host
-                        connection_data["hostname"] = host
-                        connection_data["nickname"] = host
-                    else:
-                        connection_data["host"] = arg
-                        connection_data["hostname"] = arg
-                        connection_data["nickname"] = arg
+                if not data["host"]:
+                    _set_host_token(data, arg)
                 else:
-                    connection_data["unparsed_args"].append(arg)
+                    data["unparsed_args"].append(arg)
                 i += 1
             else:
-                option_key = arg
-                attached_value = ""
-                if option_key.startswith('--'):
-                    option_key, _sep, attached_value = option_key.partition('=')
-                elif option_key.startswith('-') and len(option_key) > 2:
-                    option_key, attached_value = option_key[:2], option_key[2:]
+                i = _consume_unknown_option(data, args, i)
 
-                expects_argument = option_key in SSH_OPTIONS_EXPECTING_ARGUMENT
-                if attached_value:
-                    connection_data["unparsed_args"].append(arg)
-                    i += 1
-                    continue
-
-                if expects_argument:
-                    if i + 1 < len(args) and not args[i + 1].startswith('-'):
-                        connection_data["unparsed_args"].extend([arg, args[i + 1]])
-                        i += 2
-                    else:
-                        connection_data["unparsed_args"].append(arg)
-                        i += 1
-                else:
-                    connection_data["unparsed_args"].append(arg)
-                    i += 1
-                continue
-
-        if not connection_data["host"]:
+        if not data["host"]:
             return None
 
-        if connection_data.get("keyfile") and connection_data.get("key_select_mode", 0) == 0:
-            connection_data["key_select_mode"] = 2
+        if data.get("keyfile") and data.get("key_select_mode", 0) == 0:
+            data["key_select_mode"] = 2
 
-        return connection_data
+        return data
 
     except Exception:
         # Last-resort fallback for bare user@host that somehow raised
@@ -362,16 +356,7 @@ def parse_ssh_command(command_text: str) -> Optional[dict]:
             try:
                 username, host = command_text.split('@', 1)
                 if host:
-                    return {
-                        "nickname": host,
-                        "host": host,
-                        "hostname": host,
-                        "username": username,
-                        "port": 22,
-                        "auth_method": 0,
-                        "key_select_mode": 0,
-                        "unparsed_args": [],
-                    }
+                    return _bare_user_host_data(username, host)
             except Exception:
                 pass
         return None

--- a/src/sshpilot/connection_manager.py
+++ b/src/sshpilot/connection_manager.py
@@ -129,6 +129,156 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
+def _unwrap_ssh_value(val: Any) -> Any:
+    """Strip matching surrounding quotes from an SSH config token."""
+    if isinstance(val, str) and len(val) >= 2:
+        if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+            return val[1:-1]
+    return val
+
+
+def _parse_forward_listen_spec(spec: str):
+    """Return ``(bind_addr, port)`` for a ``[bind_address:]port`` token, or None.
+
+    An omitted/empty bind address is returned as ``''`` (not coerced to
+    localhost); callers decide the default per forwarding type.
+    """
+    if ':' in spec:
+        bind_addr, port_str = spec.rsplit(':', 1)
+        bind_addr = bind_addr.strip().strip('[]')
+    else:
+        bind_addr, port_str = '', spec
+    port = _safe_int(port_str, None)
+    return None if port is None else (bind_addr, port)
+
+
+def _parse_host_port_dest(dest_spec: str):
+    """Parse ``host[:port]`` (default port 22). Returns ``(host, port)`` or None."""
+    if ':' in dest_spec:
+        host, port_str = dest_spec.rsplit(':', 1)
+        port = _safe_int(port_str, None)
+        return None if port is None else (host, port)
+    return dest_spec, 22
+
+
+def _parse_forwarding_rules_from_config(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Build ``forwarding_rules`` from LocalForward/RemoteForward/DynamicForward."""
+    rules: List[Dict[str, Any]] = []
+    for forward_type in ('localforward', 'remoteforward', 'dynamicforward'):
+        if forward_type not in config:
+            continue
+
+        forward_specs = config[forward_type]
+        if not isinstance(forward_specs, list):
+            forward_specs = [forward_specs]
+
+        for forward_spec in forward_specs:
+            if forward_type == 'dynamicforward':
+                listen = _parse_forward_listen_spec(forward_spec.strip())
+                if listen is None:
+                    continue
+                bind_addr, listen_port = listen
+                rules.append({
+                    'type': 'dynamic',
+                    'listen_addr': bind_addr or 'localhost',
+                    'listen_port': listen_port,
+                    'enabled': True,
+                })
+                continue
+
+            # LocalForward / RemoteForward: "[bind_address:]port [host:hostport]"
+            # RemoteForward may omit the destination (SOCKS proxy per ssh_config(5)).
+            parts = forward_spec.split()
+            if not parts:
+                continue
+            listen = _parse_forward_listen_spec(parts[0])
+            if listen is None:
+                continue
+            bind_addr, listen_port = listen
+            dest_spec = parts[1] if len(parts) >= 2 else None
+
+            if forward_type == 'localforward':
+                if dest_spec is None:
+                    continue
+                dest = _parse_host_port_dest(dest_spec)
+                if dest is None:
+                    continue
+                remote_host, remote_port = dest
+                rules.append({
+                    'type': 'local',
+                    'listen_addr': bind_addr or 'localhost',
+                    'listen_port': listen_port,
+                    'remote_host': remote_host,
+                    'remote_port': remote_port,
+                    'enabled': True,
+                })
+            else:
+                rule = {
+                    'type': 'remote',
+                    'listen_addr': bind_addr,
+                    'listen_port': listen_port,
+                    'enabled': True,
+                }
+                if dest_spec is None:
+                    rule['socks'] = True
+                else:
+                    dest = _parse_host_port_dest(dest_spec)
+                    if dest is None:
+                        continue
+                    local_host, local_port = dest
+                    rule['local_host'] = local_host
+                    rule['local_port'] = local_port
+                rules.append(rule)
+    return rules
+
+
+def _resolve_key_select_mode(config: Dict[str, Any], has_specific_key: bool) -> int:
+    """Map IdentitiesOnly / IdentityFile presence to UI key_select_mode."""
+    try:
+        ident_only_raw = config.get('identitiesonly')
+        ident_only_normalized = ident_only_raw
+        if ident_only_raw and not isinstance(ident_only_raw, str):
+            ident_only_normalized = str(ident_only_raw)
+
+        ident_only = ''
+        if isinstance(ident_only_normalized, str):
+            ident_only = ident_only_normalized.strip().lower()
+
+        if ident_only in ('yes', 'true', '1', 'on'):
+            return 1
+        if ident_only in ('no', 'false', '0', 'off'):
+            return 2 if has_specific_key else 0
+        if ident_only_raw is None or (isinstance(ident_only_raw, str) and not ident_only_raw.strip()):
+            return 2 if has_specific_key else 0
+        return 0
+    except Exception:
+        return 2 if has_specific_key else 0
+
+
+def _resolve_auth_method_from_config(config: Dict[str, Any]) -> Tuple[int, List[str], bool]:
+    """Return ``(auth_method, preferred_authentications, pubkey_auth_no)``."""
+    try:
+        prefer_auth_raw = str(config.get('preferredauthentications', '')).strip()
+        prefer_auth_list = [p.strip().lower() for p in prefer_auth_raw.split(',') if p.strip()]
+
+        pubkey_auth = str(config.get('pubkeyauthentication', '')).strip().lower()
+        pubkey_auth_no = (pubkey_auth == 'no')
+
+        if pubkey_auth == 'no':
+            return 1, prefer_auth_list, pubkey_auth_no
+
+        idx_pubkey = prefer_auth_list.index('publickey') if 'publickey' in prefer_auth_list else None
+        idx_password = prefer_auth_list.index('password') if 'password' in prefer_auth_list else None
+
+        if idx_pubkey is not None and (idx_password is None or idx_pubkey < idx_password):
+            return 0, prefer_auth_list, pubkey_auth_no
+        if idx_password is not None and (idx_pubkey is None or idx_password < idx_pubkey):
+            return 1, prefer_auth_list, pubkey_auth_no
+        return 0, prefer_auth_list, pubkey_auth_no
+    except Exception:
+        return 0, [], False
+
+
 class ConnectionState(enum.Enum):
     """Authoritative lifecycle state of a saved connection.
 
@@ -1434,18 +1584,12 @@ class ConnectionManager(GObject.Object):
     def parse_host_config(self, config: Dict[str, Any], source: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Parse host configuration from SSH config"""
         try:
-            def _unwrap(val: Any) -> Any:
-                if isinstance(val, str) and len(val) >= 2:
-                    if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
-                        return val[1:-1]
-                return val
-
-            host_token = _unwrap(config.get('host', ''))
+            host_token = _unwrap_ssh_value(config.get('host', ''))
             if not host_token:
                 return None
 
             raw_tokens = config.get('__host_tokens')
-            tokens = [_unwrap(t) for t in raw_tokens] if raw_tokens else [host_token]
+            tokens = [_unwrap_ssh_value(t) for t in raw_tokens] if raw_tokens else [host_token]
 
             config = dict(config)
             config.pop('__host_tokens', None)
@@ -1467,18 +1611,14 @@ class ConnectionManager(GObject.Object):
             # Determine whether the config explicitly defined a HostName value.
             has_explicit_hostname = 'hostname' in config and str(config['hostname']).strip() != ''
             hostname_value = config['hostname'] if has_explicit_hostname else None
-            parsed_host = _unwrap(hostname_value) if has_explicit_hostname else ''
+            parsed_host = _unwrap_ssh_value(hostname_value) if has_explicit_hostname else ''
 
             # IdentityFile/CertificateFile may appear multiple times; per
-            # ssh_config(5) they accumulate ("Multiple ... directives will add
-            # to the list"). Expand ~ and ${ENV} (but not the %-tokens, which are
-            # host/runtime specific and resolved via `ssh -G` when the real
-            # connection is built). An IdentityFile argument of ``none`` is a
-            # suppressor ("no identity files should be loaded"), not a path.
+            # ssh_config(5) they accumulate. Expand ~ and ${ENV} (but not the
+            # %-tokens, which are host/runtime specific and resolved via
+            # `ssh -G`). IdentityFile ``none`` suppresses identity loading.
             def _expand_path_value(val: Any) -> str:
-                # ~ + ${ENV} + the host-independent %-tokens (%d, %u, ...). Runtime
-                # tokens such as %h/%r are left intact for ssh / `ssh -G` to resolve.
-                return os.path.expanduser(os.path.expandvars(expand_ssh_tokens(_unwrap(val))))
+                return os.path.expanduser(os.path.expandvars(expand_ssh_tokens(_unwrap_ssh_value(val))))
 
             def _as_list(raw: Any) -> List[Any]:
                 if raw is None:
@@ -1488,7 +1628,7 @@ class ConnectionManager(GObject.Object):
             identity_files: List[str] = []
             identity_suppressed = False
             for entry in _as_list(config.get('identityfile')):
-                unwrapped = _unwrap(entry)
+                unwrapped = _unwrap_ssh_value(entry)
                 if isinstance(unwrapped, str) and unwrapped.strip().lower() == 'none':
                     identity_suppressed = True
                     continue
@@ -1498,30 +1638,22 @@ class ConnectionManager(GObject.Object):
             certificate_files: List[str] = [
                 _expand_path_value(entry)
                 for entry in _as_list(config.get('certificatefile'))
-                if _unwrap(entry)
+                if _unwrap_ssh_value(entry)
             ]
 
-            # Extract relevant configuration
             parsed = {
                 'nickname': host,
-                # Keep HostName empty when it was omitted in the original
-                # configuration but record the label separately via ``host`` so
-                # consumers can fall back to the alias when needed.
+                # Keep HostName empty when omitted; ``host`` holds the alias.
                 'hostname': parsed_host,
                 'host': host,
-
-                'port': _safe_int(_unwrap(config.get('port', 22)), 22),
-                'username': _unwrap(config.get('user', getpass.getuser())),
-                # previously: 'private_key': config.get('identityfile'),
-
-                # ``keyfile``/``certificate`` remain the primary (first) entry for
-                # backward compatibility; the full lists live alongside them.
+                'port': _safe_int(_unwrap_ssh_value(config.get('port', 22)), 22),
+                'username': _unwrap_ssh_value(config.get('user', getpass.getuser())),
                 'keyfile': identity_files[0] if identity_files else '',
                 'identity_files': identity_files,
                 'identity_file_none': identity_suppressed,
                 'certificate': certificate_files[0] if certificate_files else '',
                 'certificate_files': certificate_files,
-                'forwarding_rules': []
+                'forwarding_rules': _parse_forwarding_rules_from_config(config),
             }
             if has_explicit_hostname:
                 parsed['aliases'] = []
@@ -1533,108 +1665,12 @@ class ConnectionManager(GObject.Object):
                 if getattr(self, 'ssh_config_path', ''):
                     parsed['config_root'] = self.ssh_config_path
 
-
-            # Map ForwardX11 yes/no → x11_forwarding boolean
             try:
                 fwd_x11 = str(config.get('forwardx11', 'no')).strip().lower()
                 parsed['x11_forwarding'] = fwd_x11 in ('yes', 'true', '1', 'on')
             except Exception:
                 parsed['x11_forwarding'] = False
-            
-            # Handle port forwarding rules
-            for forward_type in ['localforward', 'remoteforward', 'dynamicforward']:
-                if forward_type not in config:
-                    continue
-                    
-                forward_specs = config[forward_type]
-                if not isinstance(forward_specs, list):
-                    forward_specs = [forward_specs]
-                    
-                def _parse_listen_spec(spec):
-                    """Return (bind_addr, port) for a "[bind_address:]port" token, or None.
 
-                    An omitted/empty bind address is returned as '' (not coerced to
-                    localhost); callers decide the default per forwarding type.
-                    """
-                    if ':' in spec:
-                        bind_addr, port_str = spec.rsplit(':', 1)
-                        bind_addr = bind_addr.strip().strip('[]')
-                    else:
-                        bind_addr, port_str = '', spec
-                    port = _safe_int(port_str, None)
-                    return None if port is None else (bind_addr, port)
-
-                for forward_spec in forward_specs:
-                    if forward_type == 'dynamicforward':
-                        # Format is usually "[bind_address:]port"
-                        listen = _parse_listen_spec(forward_spec.strip())
-                        if listen is None:
-                            continue
-                        bind_addr, listen_port = listen
-                        parsed['forwarding_rules'].append({
-                            'type': 'dynamic',
-                            'listen_addr': bind_addr or 'localhost',
-                            'listen_port': listen_port,
-                            'enabled': True
-                        })
-                    else:
-                        # LocalForward / RemoteForward:
-                        #   "[bind_address:]port [host:hostport]"
-                        # RemoteForward may omit the destination, in which case it
-                        # acts as a SOCKS proxy (ssh_config(5)).
-                        parts = forward_spec.split()
-                        if not parts:
-                            continue
-                        listen = _parse_listen_spec(parts[0])
-                        if listen is None:
-                            continue
-                        bind_addr, listen_port = listen
-                        dest_spec = parts[1] if len(parts) >= 2 else None
-
-                        if forward_type == 'localforward':
-                            # LocalForward requires a destination.
-                            if dest_spec is None:
-                                continue
-                            if ':' in dest_spec:
-                                remote_host, remote_port_str = dest_spec.rsplit(':', 1)
-                                remote_port = _safe_int(remote_port_str, None)
-                            else:
-                                remote_host, remote_port = dest_spec, 22
-                            if remote_port is None:
-                                continue
-                            parsed['forwarding_rules'].append({
-                                'type': 'local',
-                                'listen_addr': bind_addr or 'localhost',
-                                'listen_port': listen_port,
-                                'remote_host': remote_host,
-                                'remote_port': remote_port,
-                                'enabled': True
-                            })
-                        else:
-                            # RemoteForward: remote host/port listens, destination
-                            # (if any) is the local host/port.
-                            rule = {
-                                'type': 'remote',
-                                'listen_addr': bind_addr,   # remote host
-                                'listen_port': listen_port, # remote port
-                                'enabled': True,
-                            }
-                            if dest_spec is None:
-                                # Single-argument form → SOCKS proxy.
-                                rule['socks'] = True
-                            else:
-                                if ':' in dest_spec:
-                                    local_host, local_port_str = dest_spec.rsplit(':', 1)
-                                    local_port = _safe_int(local_port_str, None)
-                                else:
-                                    local_host, local_port = dest_spec, 22
-                                if local_port is None:
-                                    continue
-                                rule['local_host'] = local_host   # destination host (local)
-                                rule['local_port'] = local_port   # destination port (local)
-                            parsed['forwarding_rules'].append(rule)
-            
-            # Handle proxy settings if any
             if 'proxycommand' in config:
                 parsed['proxy_command'] = config['proxycommand']
             if 'proxyjump' in config:
@@ -1643,8 +1679,8 @@ class ConnectionManager(GObject.Object):
                     parsed['proxy_jump'] = [p.strip() for p in pj]
                 else:
                     parsed['proxy_jump'] = [p.strip() for p in re.split(r'[\s,]+', pj)]
-            # Agent / hardware key sources (kept verbatim — IdentityAgent may be
-            # a path, "none", or a $ENV reference; providers are library paths).
+
+            # Agent / hardware key sources (kept verbatim).
             for direct_key, parsed_key in (
                 ('identityagent', 'identity_agent'),
                 ('addkeystoagent', 'add_keys_to_agent'),
@@ -1652,37 +1688,30 @@ class ConnectionManager(GObject.Object):
                 ('securitykeyprovider', 'security_key_provider'),
             ):
                 if direct_key in config:
-                    val = _unwrap(config.get(direct_key))
+                    val = _unwrap_ssh_value(config.get(direct_key))
                     if val is not None and str(val).strip():
                         parsed[parsed_key] = str(val).strip()
 
             if 'forwardagent' in config:
-                fa_raw = str(_unwrap(config.get('forwardagent', ''))).strip()
+                fa_raw = str(_unwrap_ssh_value(config.get('forwardagent', ''))).strip()
                 fa = fa_raw.lower()
-                # ssh_config(5): the argument may be yes, no, an explicit path to
-                # an agent socket, or the name of an environment variable
-                # (beginning with '$'). Anything that is not an explicit "off"
-                # value enables agent forwarding.
+                # ssh_config(5): yes/no, socket path, or $ENV. Anything not an
+                # explicit "off" value enables agent forwarding.
                 if fa in ('no', 'false', '0', 'off', ''):
                     parsed['forward_agent'] = False
                 else:
                     parsed['forward_agent'] = True
-                    # Preserve a socket path / $ENV reference for callers that need it.
                     if fa not in ('yes', 'true', '1', 'on'):
                         parsed['forward_agent_target'] = fa_raw
-            
-            # Commands: LocalCommand requires PermitLocalCommand
+
             try:
                 def _unescape_cfg_value(val: str) -> str:
                     if not isinstance(val, str):
                         return val
                     v = val.strip()
-                    # If the value is wrapped in double quotes, strip only the outer quotes
                     if len(v) >= 2 and v.startswith('"') and v.endswith('"'):
                         v = v[1:-1]
-                    # Convert escaped quotes back for UI
-                    v = v.replace('\\"', '"').replace('\\\\', '\\')
-                    return v
+                    return v.replace('\\"', '"').replace('\\\\', '\\')
 
                 if '__pre_command' in config:
                     parsed['pre_command'] = config['__pre_command']
@@ -1690,66 +1719,24 @@ class ConnectionManager(GObject.Object):
                     parsed['local_command'] = _unescape_cfg_value(config.get('localcommand', ''))
                 if 'remotecommand' in config:
                     parsed['remote_command'] = _unescape_cfg_value(config.get('remotecommand', ''))
-                # Map RequestTTY to a boolean flag to aid terminal decisions if needed
                 if 'requesttty' in config:
-                    parsed['request_tty'] = str(config.get('requesttty', '')).strip().lower() in ('yes', 'force', 'true', '1', 'on')
+                    parsed['request_tty'] = str(config.get('requesttty', '')).strip().lower() in (
+                        'yes', 'force', 'true', '1', 'on'
+                    )
             except Exception:
                 pass
 
-            # Key selection mode defaults: prefer "specific key" when IdentityFile is explicit
             keyfile_value = parsed.get('keyfile', '')
             keyfile_path = keyfile_value.strip() if isinstance(keyfile_value, str) else ''
             has_specific_key = bool(keyfile_path and not keyfile_path.lower().startswith('select key file'))
-            try:
-                ident_only_raw = config.get('identitiesonly')
-                ident_only_normalized = ident_only_raw
-                if ident_only_raw and not isinstance(ident_only_raw, str):
-                    ident_only_normalized = str(ident_only_raw)
+            parsed['key_select_mode'] = _resolve_key_select_mode(config, has_specific_key)
 
-                ident_only = ''
-                if isinstance(ident_only_normalized, str):
-                    ident_only = ident_only_normalized.strip().lower()
+            auth_method, prefer_auth_list, pubkey_auth_no = _resolve_auth_method_from_config(config)
+            parsed['preferred_authentications'] = prefer_auth_list
+            parsed['pubkey_auth_no'] = pubkey_auth_no
+            parsed['auth_method'] = auth_method
 
-                if ident_only in ('yes', 'true', '1', 'on'):
-                    parsed['key_select_mode'] = 1
-                elif ident_only in ('no', 'false', '0', 'off'):
-                    parsed['key_select_mode'] = 2 if has_specific_key else 0
-                elif ident_only_raw is None or (isinstance(ident_only_raw, str) and not ident_only_raw.strip()):
-                    parsed['key_select_mode'] = 2 if has_specific_key else 0
-                else:
-                    parsed['key_select_mode'] = 0
-            except Exception:
-                parsed['key_select_mode'] = 2 if has_specific_key else 0
-
-            # Determine authentication method
-            try:
-                prefer_auth_raw = str(config.get('preferredauthentications', '')).strip()
-                # Split into an ordered list while normalizing case
-                prefer_auth_list = [p.strip().lower() for p in prefer_auth_raw.split(',') if p.strip()]
-                parsed['preferred_authentications'] = prefer_auth_list
-
-                pubkey_auth = str(config.get('pubkeyauthentication', '')).strip().lower()
-                parsed['pubkey_auth_no'] = (pubkey_auth == 'no')
-
-                if pubkey_auth == 'no':
-                    parsed['auth_method'] = 1
-                else:
-                    # Determine based on first occurrence of publickey or password
-                    idx_pubkey = prefer_auth_list.index('publickey') if 'publickey' in prefer_auth_list else None
-                    idx_password = prefer_auth_list.index('password') if 'password' in prefer_auth_list else None
-
-                    if idx_pubkey is not None and (idx_password is None or idx_pubkey < idx_password):
-                        parsed['auth_method'] = 0
-                    elif idx_password is not None and (idx_pubkey is None or idx_password < idx_pubkey):
-                        parsed['auth_method'] = 1
-                    else:
-                        parsed['auth_method'] = 0
-            except Exception:
-                parsed['auth_method'] = 0
-            
-            # Parse extra SSH config options (custom options not handled by standard fields)
-            extra_config_lines = []
-            # Only include options that are explicitly handled by the main UI fields
+            # Custom options not handled by standard UI fields
             standard_options = {
                 'host', 'hostname', 'aliases', 'port', 'user', 'identityfile', 'certificatefile',
                 'forwardx11', 'localforward', 'remoteforward', 'dynamicforward',
@@ -1758,22 +1745,19 @@ class ConnectionManager(GObject.Object):
                 'preferredauthentications', 'pubkeyauthentication',
                 'identityagent', 'addkeystoagent', 'pkcs11provider', 'securitykeyprovider',
             }
-            
+            extra_config_lines = []
             for key, value in config.items():
-                if key.lower() not in standard_options:
-                    # This is a custom SSH option (including Ciphers, Compression, etc.)
-                    if isinstance(value, list):
-                        # Handle multiple values for the same option
-                        for val in value:
-                            extra_config_lines.append(f"{key} {val}")
-                    else:
-                        extra_config_lines.append(f"{key} {value}")
-            
+                if key.lower() in standard_options:
+                    continue
+                if isinstance(value, list):
+                    extra_config_lines.extend(f"{key} {val}" for val in value)
+                else:
+                    extra_config_lines.append(f"{key} {value}")
             if extra_config_lines:
                 parsed['extra_ssh_config'] = '\n'.join(extra_config_lines)
-                
+
             return parsed
-            
+
         except Exception as e:
             logger.error(f"Error parsing host config: {e}", exc_info=True)
             return None

--- a/src/sshpilot/ssh_connection_builder.py
+++ b/src/sshpilot/ssh_connection_builder.py
@@ -552,6 +552,82 @@ def _get_stored_passphrase(
     return None
 
 
+# App-preference keys → OpenSSH ``-o`` option names for positive integers.
+_APP_POSITIVE_INT_OPTIONS = (
+    ('connection_timeout', 'ConnectTimeout'),
+    ('connection_attempts', 'ConnectionAttempts'),
+    ('keepalive_interval', 'ServerAliveInterval'),
+    ('keepalive_count_max', 'ServerAliveCountMax'),
+)
+
+
+def _append_positive_int_option(cmd: List[str], raw_value, option_name: str) -> None:
+    """Append ``-o Option=N`` when *raw_value* coerces to a positive int."""
+    if not raw_value:
+        return
+    try:
+        value = int(raw_value)
+    except (ValueError, TypeError):
+        return
+    if value > 0:
+        cmd.extend(['-o', f'{option_name}={value}'])
+
+
+def _append_app_ssh_overrides(cmd: List[str], app_ssh_config: dict, *, is_copy_id: bool) -> None:
+    """Apply app-level SSH prefs (verbosity, compression, timeouts, host keys)."""
+    verbosity = int(app_ssh_config.get('verbosity', 0) or 0)
+    if verbosity > 0 and not is_copy_id:
+        cmd.extend(['-v'] * min(verbosity, 3))
+
+    if bool(app_ssh_config.get('compression', False)) and not is_copy_id:
+        cmd.append('-C')
+
+    if bool(app_ssh_config.get('batch_mode', False)) and not is_copy_id:
+        cmd.extend(['-o', 'BatchMode=yes'])
+
+    for cfg_key, option_name in _APP_POSITIVE_INT_OPTIONS:
+        _append_positive_int_option(cmd, app_ssh_config.get(cfg_key), option_name)
+
+    strict_host = str(app_ssh_config.get('strict_host_key_checking', '') or '').strip()
+    auto_add = bool(app_ssh_config.get('auto_add_host_keys', True))
+    if strict_host:
+        cmd.extend(['-o', f'StrictHostKeyChecking={strict_host}'])
+    elif auto_add:
+        cmd.extend(['-o', 'StrictHostKeyChecking=accept-new'])
+
+
+def _append_identity_and_proxy(
+    cmd: List[str],
+    config: Dict[str, Union[str, List[str]]],
+    *,
+    is_copy_id: bool,
+) -> None:
+    """Append IdentityFile / CertificateFile / Proxy* from resolved SSH config."""
+    # Never for ssh-copy-id: there -i selects the key to install, and the
+    # operation must authenticate with the key being copied.
+    if not is_copy_id:
+        identity_files = _get_ssh_config_list(config, 'identityfile')
+        for identity_file in identity_files:
+            if identity_file and os.path.isfile(os.path.expanduser(identity_file)):
+                cmd.extend(['-i', os.path.expanduser(identity_file)])
+                # If IdentitiesOnly is set, only use this key
+                if _get_ssh_config_value(config, 'identitiesonly', '').lower() in ('yes', 'true', '1'):
+                    cmd.extend(['-o', 'IdentitiesOnly=yes'])
+                    break  # Only first key when IdentitiesOnly is set
+
+    cert_file = _get_ssh_config_value(config, 'certificatefile')
+    if cert_file and cert_file.strip() and os.path.isfile(os.path.expanduser(cert_file)):
+        cmd.extend(['-o', f'CertificateFile={cert_file}'])
+
+    proxy_command = _get_ssh_config_value(config, 'proxycommand')
+    if proxy_command and proxy_command.strip():
+        cmd.extend(['-o', f'ProxyCommand={proxy_command}'])
+
+    proxy_jump = [j for j in _get_ssh_config_list(config, 'proxyjump') if j and j.strip()]
+    if proxy_jump:
+        cmd.extend(['-o', f'ProxyJump={",".join(proxy_jump)}'])
+
+
 def _build_base_ssh_command(
     connection: any,
     config: Dict[str, Union[str, List[str]]],
@@ -562,7 +638,6 @@ def _build_base_ssh_command(
     Build base SSH command from SSH config and connection settings.
     This matches default SSH behavior as closely as possible.
     """
-    # Determine the SSH binary
     if command_type == 'scp':
         cmd = ['scp']
     elif command_type == 'sftp':
@@ -578,7 +653,6 @@ def _build_base_ssh_command(
     # would defeat its interactive purpose (first login usually needs a prompt).
     is_copy_id = (command_type == 'ssh-copy-id')
 
-    # Get app-level SSH settings
     app_ssh_config = {}
     if app_config:
         try:
@@ -586,108 +660,17 @@ def _build_base_ssh_command(
         except Exception:
             pass
 
-    # Apply app-level overrides (verbosity, compression, etc.)
-    verbosity = int(app_ssh_config.get('verbosity', 0) or 0)
-    if verbosity > 0 and not is_copy_id:
-        for _ in range(min(verbosity, 3)):
-            cmd.append('-v')
+    _append_app_ssh_overrides(cmd, app_ssh_config, is_copy_id=is_copy_id)
 
-    compression = bool(app_ssh_config.get('compression', False))
-    if compression and not is_copy_id:
-        cmd.append('-C')
-
-    if bool(app_ssh_config.get('batch_mode', False)) and not is_copy_id:
-        cmd.extend(['-o', 'BatchMode=yes'])
-
-    # Apply connection timeout if specified
-    connect_timeout = app_ssh_config.get('connection_timeout')
-    if connect_timeout:
-        try:
-            timeout = int(connect_timeout)
-            if timeout > 0:
-                cmd.extend(['-o', f'ConnectTimeout={timeout}'])
-        except (ValueError, TypeError):
-            pass
-    
-    # Apply connection attempts if specified
-    connection_attempts = app_ssh_config.get('connection_attempts')
-    if connection_attempts:
-        try:
-            attempts = int(connection_attempts)
-            if attempts > 0:
-                cmd.extend(['-o', f'ConnectionAttempts={attempts}'])
-        except (ValueError, TypeError):
-            pass
-
-    # Apply keepalive settings if specified
-    keepalive_interval = app_ssh_config.get('keepalive_interval')
-    if keepalive_interval:
-        try:
-            interval = int(keepalive_interval)
-            if interval > 0:
-                cmd.extend(['-o', f'ServerAliveInterval={interval}'])
-        except (ValueError, TypeError):
-            pass
-    
-    keepalive_count = app_ssh_config.get('keepalive_count_max')
-    if keepalive_count:
-        try:
-            count = int(keepalive_count)
-            if count > 0:
-                cmd.extend(['-o', f'ServerAliveCountMax={count}'])
-        except (ValueError, TypeError):
-            pass
-    
-    # Apply strict host key checking
-    strict_host = str(app_ssh_config.get('strict_host_key_checking', '') or '').strip()
-    auto_add = bool(app_ssh_config.get('auto_add_host_keys', True))
-    
-    if strict_host:
-        cmd.extend(['-o', f'StrictHostKeyChecking={strict_host}'])
-    elif auto_add:
-        cmd.extend(['-o', 'StrictHostKeyChecking=accept-new'])
-    
     # Apply port if specified and not default
     port = getattr(connection, 'port', None)
     if port and port != 22:
-        if command_type == 'scp':
-            cmd.extend(['-P', str(port)])
-        else:
-            cmd.extend(['-p', str(port)])
-    
-    # Apply IdentityFile from SSH config (SSH config is primary source).
-    # Never for ssh-copy-id: there -i selects the key to install, and the
-    # operation must authenticate with the key being copied.
-    if not is_copy_id:
-        identity_files = _get_ssh_config_list(config, 'identityfile')
-        for identity_file in identity_files:
-            if identity_file and os.path.isfile(os.path.expanduser(identity_file)):
-                cmd.extend(['-i', os.path.expanduser(identity_file)])
-                # If IdentitiesOnly is set, only use this key
-                if _get_ssh_config_value(config, 'identitiesonly', '').lower() in ('yes', 'true', '1'):
-                    cmd.extend(['-o', 'IdentitiesOnly=yes'])
-                    break  # Only first key when IdentitiesOnly is set
-    
-    # Apply CertificateFile if specified
-    cert_file = _get_ssh_config_value(config, 'certificatefile')
-    if cert_file and cert_file.strip() and os.path.isfile(os.path.expanduser(cert_file)):
-        cmd.extend(['-o', f'CertificateFile={cert_file}'])
-    
-    # Apply ProxyCommand/ProxyJump if specified
-    proxy_command = _get_ssh_config_value(config, 'proxycommand')
-    if proxy_command and proxy_command.strip():
-        cmd.extend(['-o', f'ProxyCommand={proxy_command}'])
-    
-    proxy_jump = _get_ssh_config_list(config, 'proxyjump')
-    if proxy_jump:
-        # Filter out empty values
-        proxy_jump_filtered = [j for j in proxy_jump if j and j.strip()]
-        if proxy_jump_filtered:
-            cmd.extend(['-o', f'ProxyJump={",".join(proxy_jump_filtered)}'])
-    
-    # Apply X11 forwarding if enabled. Only for ssh: scp -X selects the
-    # transfer protocol and sftp -X sets an sftp option, so a bare -X there
-    # would swallow the next argument.
+        cmd.extend(['-P' if command_type == 'scp' else '-p', str(port)])
+
+    _append_identity_and_proxy(cmd, config, is_copy_id=is_copy_id)
+
+    # X11 forwarding only for ssh: scp -X selects transfer protocol and sftp -X
+    # sets an sftp option, so a bare -X there would swallow the next argument.
     forward_x11 = _get_ssh_config_value(config, 'forwardx11', '').lower()
     if forward_x11 in ('yes', 'true', '1') and command_type == 'ssh':
         cmd.append('-X')

--- a/src/sshpilot/ssh_utils.py
+++ b/src/sshpilot/ssh_utils.py
@@ -4,7 +4,7 @@ SSH utilities for building consistent SSH options across the application
 
 import os
 import logging
-from typing import Dict
+from typing import Dict, List, Optional, Tuple
 
 from .platform_utils import is_flatpak
 
@@ -20,6 +20,12 @@ _SSH_AUTH_FAILURE_MARKERS = (
     'authentication failed',
     'too many authentication failures',
 )
+
+_COMBINED_AUTH = (
+    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,'
+    'keyboard-interactive,password'
+)
+_PASSWORD_AUTH = 'PreferredAuthentications=keyboard-interactive,password'
 
 
 def is_ssh_auth_failure_text(text: str) -> bool:
@@ -50,63 +56,51 @@ def ensure_writable_ssh_home(env: Dict[str, str]) -> None:
         env["HOME"] = alt_home
         logger.debug(f"Using temporary HOME for ssh-copy-id: {alt_home}")
 
-def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False):
-    """Build SSH options that match the exact connection settings used for SSH.
-    
-    This function replicates the SSH option building logic from terminal.py
-    to ensure ssh-copy-id and scp use the same settings as SSH connections.
-    
-    Args:
-        connection: The connection object
-        config: Optional config object
-        for_ssh_copy_id: If True, filter out options not supported by ssh-copy-id
-    """
-    options = []
-    
-    # Read SSH behavior from config with sane defaults (same as terminal.py)
+
+def _coerce_positive_int(value, default=None):
+    try:
+        coerced = int(str(value))
+        if coerced <= 0:
+            return default
+        return coerced
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_ssh_cfg(config) -> dict:
     try:
         if config is None:
             from .config import Config
             config = Config()
-        ssh_cfg = config.get_ssh_config() if hasattr(config, 'get_ssh_config') else {}
+        if hasattr(config, 'get_ssh_config'):
+            return config.get_ssh_config() or {}
     except Exception:
-        ssh_cfg = {}
+        pass
+    return {}
 
-    def _coerce_int(value, default=None):
-        try:
-            coerced = int(str(value))
-            if coerced <= 0:
-                return default
-            return coerced
-        except (TypeError, ValueError):
-            return default
 
-    connect_timeout = _coerce_int(ssh_cfg.get('connection_timeout'), None)
-    connection_attempts = _coerce_int(ssh_cfg.get('connection_attempts'), None)
-    keepalive_interval = _coerce_int(ssh_cfg.get('keepalive_interval'), None)
-    keepalive_count = _coerce_int(ssh_cfg.get('keepalive_count_max'), None)
-    strict_host = str(ssh_cfg.get('strict_host_key_checking', '') or '').strip()
-    auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))
-    batch_mode = bool(ssh_cfg.get('batch_mode', False))
-    compression = bool(ssh_cfg.get('compression', False))
-
-    # Determine auth method from connection and whether a password is available
-    password_auth_selected = False
-    has_saved_password = False
+def _auth_flags(connection) -> Tuple[bool, bool, bool]:
+    """Return (password_auth_selected, has_saved_password, using_password)."""
     try:
         # In our UI: 0 = key-based, 1 = password
-        auth_method = getattr(connection, 'auth_method', 0)
-        password_auth_selected = (auth_method == 1)
+        password_auth_selected = getattr(connection, 'auth_method', 0) == 1
         has_saved_password = bool(getattr(connection, 'password', None))
     except Exception:
-        password_auth_selected = False
-        has_saved_password = False
-    using_password = password_auth_selected or (not password_auth_selected and has_saved_password)
+        return False, False, False
+    using_password = password_auth_selected or has_saved_password
+    return password_auth_selected, has_saved_password, using_password
 
-    # Apply advanced args according to stored preferences (same as terminal.py)
-    # Only enable BatchMode when NOT doing password auth (BatchMode disables prompts)
-    if batch_mode and not using_password:
-        options.extend(['-o', 'BatchMode=yes'])
+
+def _append_cfg_int_options(options: List[str], ssh_cfg: dict, for_ssh_copy_id: bool) -> None:
+    """Append timeout / keepalive / host-key options from app SSH preferences."""
+    connect_timeout = _coerce_positive_int(ssh_cfg.get('connection_timeout'))
+    connection_attempts = _coerce_positive_int(ssh_cfg.get('connection_attempts'))
+    keepalive_interval = _coerce_positive_int(ssh_cfg.get('keepalive_interval'))
+    keepalive_count = _coerce_positive_int(ssh_cfg.get('keepalive_count_max'))
+    strict_host = str(ssh_cfg.get('strict_host_key_checking', '') or '').strip()
+    auto_add_host_keys = bool(ssh_cfg.get('auto_add_host_keys', True))
+    compression = bool(ssh_cfg.get('compression', False))
+
     if connect_timeout is not None:
         options.extend(['-o', f'ConnectTimeout={connect_timeout}'])
     if connection_attempts is not None:
@@ -119,28 +113,21 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
         options.extend(['-o', f'ServerAliveCountMax={keepalive_count}'])
     if strict_host:
         options.extend(['-o', f'StrictHostKeyChecking={strict_host}'])
+    elif auto_add_host_keys:
+        # Default to accepting new host keys non-interactively on fresh installs
+        options.extend(['-o', 'StrictHostKeyChecking=accept-new'])
     if compression and not for_ssh_copy_id:
         options.append('-C')
 
-    # Default to accepting new host keys non-interactively on fresh installs (same as terminal.py)
-    try:
-        if (not strict_host) and auto_add_host_keys:
-            options.extend(['-o', 'StrictHostKeyChecking=accept-new'])
-    except Exception:
-        pass
 
-    # Ensure SSH exits immediately on failure rather than waiting in background (same as terminal.py)
-    options.extend(['-o', 'ExitOnForwardFailure=yes'])
-    
-    # Only add verbose flag if explicitly enabled in config (same as terminal.py)
-    # Note: ssh-copy-id doesn't support -v flags, only -x for debug
+def _append_verbosity_options(options: List[str], ssh_cfg: dict, for_ssh_copy_id: bool) -> None:
+    """Map app verbosity/debug prefs to ``-v`` / ``LogLevel`` (ssh only)."""
     try:
         verbosity = int(ssh_cfg.get('verbosity', 0))
         debug_enabled = bool(ssh_cfg.get('debug_enabled', False))
         v = max(0, min(3, verbosity))
         if not for_ssh_copy_id:
-            for _ in range(v):
-                options.append('-v')
+            options.extend(['-v'] * v)
         # Map verbosity to LogLevel to ensure messages are not suppressed by defaults
         if v == 1:
             options.extend(['-o', 'LogLevel=VERBOSE'])
@@ -152,77 +139,114 @@ def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False)
             options.extend(['-o', 'LogLevel=DEBUG'])
     except Exception as e:
         logger.warning(f"Could not check SSH verbosity/debug settings: {e}")
-    
-    # Add key file/options only for key-based auth (same as terminal.py)
-    # Note: ssh-copy-id already specifies the key with -i, so we don't add it again
-    if not password_auth_selected:
-        # Get key selection mode
-        key_select_mode = 0
-        try:
-            key_select_mode = int(getattr(connection, 'key_select_mode', 0) or 0)
-        except Exception:
-            pass
-        
-        # Only add specific key when a dedicated key mode is selected
-        if key_select_mode in (1, 2) and hasattr(connection, 'keyfile') and connection.keyfile and \
-           os.path.isfile(connection.keyfile) and \
-           not connection.keyfile.startswith('Select key file'):
 
-            if not for_ssh_copy_id:
-                options.extend(['-i', connection.keyfile])
-            if key_select_mode == 1:
-                options.extend(['-o', 'IdentitiesOnly=yes'])
-            
-            # Add certificate if specified
-            if hasattr(connection, 'certificate') and connection.certificate and \
-               os.path.isfile(connection.certificate):
-                options.extend(['-o', f'CertificateFile={connection.certificate}'])
 
-            # If a password is available, allow all standard authentication methods
-            if has_saved_password:
-                options.extend([
-                    '-o',
-                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
-                ])
-        else:
-            # If no specific key or certificate, still append combined auth if password exists
-            if has_saved_password:
-                options.extend([
-                    '-o',
-                    'PreferredAuthentications=gssapi-with-mic,hostbased,publickey,keyboard-interactive,password'
-                ])
-    else:
-        # Force password authentication when user chose password auth (same as terminal.py)
-        # But don't disable pubkey auth for ssh-copy-id since we're installing a key
-        options.extend([
-            '-o',
-            'PreferredAuthentications=keyboard-interactive,password',
-        ])
-        if not for_ssh_copy_id and getattr(connection, 'pubkey_auth_no', False):
-            options.extend(['-o', 'PubkeyAuthentication=no'])
-    
-    # Add extra SSH config options from advanced tab (same as terminal.py)
+def _key_select_mode(connection) -> int:
+    try:
+        return int(getattr(connection, 'key_select_mode', 0) or 0)
+    except Exception:
+        return 0
+
+
+def _usable_keyfile(connection) -> Optional[str]:
+    keyfile = getattr(connection, 'keyfile', None)
+    if not keyfile or not os.path.isfile(keyfile):
+        return None
+    if keyfile.startswith('Select key file'):
+        return None
+    return keyfile
+
+
+def _append_key_auth_options(
+    options: List[str],
+    connection,
+    *,
+    has_saved_password: bool,
+    for_ssh_copy_id: bool,
+) -> None:
+    """Identity / certificate options for key-based auth."""
+    key_select_mode = _key_select_mode(connection)
+    keyfile = _usable_keyfile(connection) if key_select_mode in (1, 2) else None
+
+    if keyfile:
+        # ssh-copy-id already specifies the key with -i
+        if not for_ssh_copy_id:
+            options.extend(['-i', keyfile])
+        if key_select_mode == 1:
+            options.extend(['-o', 'IdentitiesOnly=yes'])
+
+        certificate = getattr(connection, 'certificate', None)
+        if certificate and os.path.isfile(certificate):
+            options.extend(['-o', f'CertificateFile={certificate}'])
+
+    if has_saved_password:
+        options.extend(['-o', _COMBINED_AUTH])
+
+
+def _append_password_auth_options(
+    options: List[str],
+    connection,
+    *,
+    for_ssh_copy_id: bool,
+) -> None:
+    options.extend(['-o', _PASSWORD_AUTH])
+    # Don't disable pubkey auth for ssh-copy-id — we're installing a key
+    if not for_ssh_copy_id and getattr(connection, 'pubkey_auth_no', False):
+        options.extend(['-o', 'PubkeyAuthentication=no'])
+
+
+def _append_extra_ssh_config(options: List[str], connection) -> None:
     extra_ssh_config = getattr(connection, 'extra_ssh_config', '').strip()
-    if extra_ssh_config:
-        logger.debug(f"Adding extra SSH config options: {extra_ssh_config}")
-        # Parse and add each extra SSH config option
-        for line in extra_ssh_config.split('\n'):
-            line = line.strip()
-            if line and not line.startswith('#'):  # Skip empty lines and comments
-                # Split on first space to separate option and value
-                parts = line.split(' ', 1)
-                if len(parts) == 2:
-                    option, value = parts
-                    options.extend(['-o', f"{option}={value}"])
-                    logger.debug(f"Added SSH option: {option}={value}")
-                elif len(parts) == 1:
-                    # Option without value (e.g., "Compression yes" becomes "Compression=yes")
-                    option = parts[0]
-                    options.extend(['-o', f"{option}=yes"])
-                    logger.debug(f"Added SSH option: {option}=yes")
+    if not extra_ssh_config:
+        return
+    logger.debug(f"Adding extra SSH config options: {extra_ssh_config}")
+    for line in extra_ssh_config.split('\n'):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split(' ', 1)
+        option = parts[0]
+        value = parts[1] if len(parts) == 2 else 'yes'
+        options.extend(['-o', f"{option}={value}"])
+        logger.debug(f"Added SSH option: {option}={value}")
+
+
+def build_connection_ssh_options(connection, config=None, for_ssh_copy_id=False):
+    """Build SSH options that match the exact connection settings used for SSH.
     
-    # Add X11 forwarding if enabled (same as terminal.py) - not supported by ssh-copy-id
-    if hasattr(connection, 'x11_forwarding') and connection.x11_forwarding and not for_ssh_copy_id:
+    This function replicates the SSH option building logic from terminal.py
+    to ensure ssh-copy-id and scp use the same settings as SSH connections.
+    
+    Args:
+        connection: The connection object
+        config: Optional config object
+        for_ssh_copy_id: If True, filter out options not supported by ssh-copy-id
+    """
+    options: List[str] = []
+    ssh_cfg = _load_ssh_cfg(config)
+    password_auth_selected, has_saved_password, using_password = _auth_flags(connection)
+
+    # Only enable BatchMode when NOT doing password auth (BatchMode disables prompts)
+    if bool(ssh_cfg.get('batch_mode', False)) and not using_password:
+        options.extend(['-o', 'BatchMode=yes'])
+
+    _append_cfg_int_options(options, ssh_cfg, for_ssh_copy_id)
+    # Ensure SSH exits immediately on failure rather than waiting in background
+    options.extend(['-o', 'ExitOnForwardFailure=yes'])
+    _append_verbosity_options(options, ssh_cfg, for_ssh_copy_id)
+
+    if password_auth_selected:
+        _append_password_auth_options(options, connection, for_ssh_copy_id=for_ssh_copy_id)
+    else:
+        _append_key_auth_options(
+            options, connection,
+            has_saved_password=has_saved_password,
+            for_ssh_copy_id=for_ssh_copy_id,
+        )
+
+    _append_extra_ssh_config(options, connection)
+
+    if getattr(connection, 'x11_forwarding', False) and not for_ssh_copy_id:
         options.append('-X')
-    
+
     return options


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scanned the codebase for oversized / deeply nested pure-logic functions and simplified the highest-impact ones without changing behavior.

### Changes
- **`command_converter.parse_ssh_command`** (~252 → ~112 lines): deduplicated duplicated `-o` handling; extracted helpers for bare `user@host`, host tokens, unknown flags, and option application.
- **`ssh_utils.build_connection_ssh_options`** (~176 → ~39 lines): split into focused helpers for config load, auth flags, timeouts/keepalive, verbosity, key/password auth, and extra config.
- **`ssh_connection_builder._build_base_ssh_command`** (~156 → ~63 lines): replaced four copy-pasted positive-int option blocks with a table + helper; extracted app-override and identity/proxy helpers.
- **`connection_manager.parse_host_config`** (~346 → ~180 lines): moved forwarding-rule parsing, key-select mode, and auth-method resolution to module-level helpers.

### Still large (not in this PR)
These remain the biggest complexity hotspots for follow-up (mostly UI builders / dispatchers):
- `preferences.setup_preferences` (~1700 lines)
- `sidebar.build_sidebar` (~800 lines)
- `file_manager_window._on_request_operation` (~630 lines, ~155 branches)
- `scp_window._prompt_scp_download` / `_show_scp_terminal_window`
- `askpass_utils.handle_askpass_cli` (duplicated prompt routing)

### Testing
- `pytest` on converter, SSH utils/builder, config parsing, forwarding, auth, and certificate-related unit tests: **176 passed, 1 skipped**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7aec06-e0bc-43c3-b7f8-d447bdc8276f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7aec06-e0bc-43c3-b7f8-d447bdc8276f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

