### PR TITLE
Split oversized askpass, preferences, sidebar, and FM dispatchers

### DIFF
--- a/src/sshpilot/askpass_utils.py
+++ b/src/sshpilot/askpass_utils.py
@@ -958,6 +958,185 @@ def _run_confirm_dialog(prompt: str, log_fn) -> "str | None":
     return result[0]
 
 
+def _looks_like_login_password(prompt: str, kind: "str | None") -> bool:
+    """True when *prompt* is a login-password ask (not a key passphrase)."""
+    if kind == 'password':
+        return True
+    if kind is not None:
+        return False
+    lowered = prompt.lower()
+    return "password" in lowered and "passphrase" not in lowered
+
+
+def _prompt_via_main_or_dialog(
+    prompt: str,
+    log_fn,
+    route_fn,
+    dialog_fn,
+    *,
+    map_routed=None,
+    success_log: str = "",
+    cancel_log: str = "",
+    dialog_success_log: str = "",
+    dialog_cancel_log: str = "",
+) -> "str | None":
+    """Try main-app IPC first; on fallback run the standalone dialog.
+
+    *map_routed* customizes how a successful IPC value is returned (presence
+    maps any non-None to ``\"\"``). When omitted, *routed* is returned as-is.
+    """
+    handled, routed = route_fn(prompt, log_fn)
+    if handled:
+        if map_routed is not None:
+            return map_routed(routed)
+        if routed is not None:
+            if success_log:
+                log_fn(success_log)
+            return routed
+        if cancel_log:
+            log_fn(cancel_log)
+        return None
+
+    value = dialog_fn(prompt, log_fn)
+    if value is not None:
+        if dialog_success_log:
+            log_fn(dialog_success_log)
+        return value
+    if dialog_cancel_log:
+        log_fn(dialog_cancel_log)
+    return None
+
+
+def _handle_presence_prompt(prompt: str, log_fn) -> "str | None":
+    """FIDO / presence reminder: success is empty string, cancel is None."""
+    return _prompt_via_main_or_dialog(
+        prompt,
+        log_fn,
+        _route_presence_to_main_app,
+        _run_presence_dialog,
+        map_routed=lambda routed: "" if routed is not None else None,
+    )
+
+
+def _handle_confirm_prompt(prompt: str, log_fn) -> "str | None":
+    return _prompt_via_main_or_dialog(
+        prompt, log_fn, _route_confirm_to_main_app, _run_confirm_dialog,
+    )
+
+
+def _handle_challenge_prompt(
+    prompt: str,
+    log_fn,
+    *,
+    success_log: str = "ASKPASS: Returning interactive response from main-app dialog",
+    dialog_success_log: str = "ASKPASS: Returning interactive response from GUI dialog",
+    dialog_cancel_log: str = "ASKPASS: No interactive response; exiting with code 1",
+) -> "str | None":
+    return _prompt_via_main_or_dialog(
+        prompt,
+        log_fn,
+        _route_challenge_to_main_app,
+        _run_challenge_dialog,
+        success_log=success_log,
+        cancel_log="ASKPASS: user cancelled interactive prompt",
+        dialog_success_log=dialog_success_log,
+        dialog_cancel_log=dialog_cancel_log,
+    )
+
+
+def _handle_password_prompt(prompt: str, log_fn) -> "str | None":
+    """Resolve from store, else ask via main app / standalone password dialog."""
+    value = _resolve_askpass_password(log_fn)
+    if value:
+        log_fn("ASKPASS: Returning password to caller")
+        return value
+    # No vault/session password — ask the user. prefer does not fall back
+    # to the TTY (same as MFA), so a dialog is required.
+    log_fn("ASKPASS: no stored password; asking user")
+
+    def _password_dialog(p, log):
+        # Standalone fallback: password-appropriate default so an empty prompt
+        # does not read as "verification code" (OTP/challenge default).
+        return _run_challenge_dialog(p or _standalone_password_label(), log)
+
+    return _prompt_via_main_or_dialog(
+        prompt,
+        log_fn,
+        _route_password_to_main_app,
+        _password_dialog,
+        success_log="ASKPASS: Returning password from main-app dialog",
+        cancel_log="ASKPASS: user cancelled password prompt",
+        dialog_success_log="ASKPASS: Returning password from GUI dialog",
+        dialog_cancel_log="ASKPASS: No password available; exiting with code 1",
+    )
+
+
+def _resolve_passphrase_for_askpass(key_path: str, log_fn) -> "str | None":
+    """Resolve a key passphrase from session file, local store, or main-app IPC."""
+    # Check one-shot session passphrase written by the main app
+    session_passphrase_file = os.environ.get("SSHPILOT_SESSION_PASSPHRASE_FILE", "")
+    if session_passphrase_file and os.path.exists(session_passphrase_file):
+        try:
+            with open(session_passphrase_file, encoding="utf-8") as f:
+                session_passphrase = f.read().strip()
+            if session_passphrase:
+                log_fn("ASKPASS: Found session passphrase from secure temp file")
+                try:
+                    os.unlink(session_passphrase_file)
+                except Exception:
+                    pass
+                return session_passphrase
+        except Exception as exc:
+            log_fn(f"ASKPASS: Error reading session passphrase file: {exc}")
+
+    # Resolve from storage. Two routes:
+    #   * local — read the selected backend in this subprocess. Instant for the
+    #     platform stores (libsecret/keyring), but for a session vault
+    #     (Bitwarden/Vaultwarden) it cold-starts `bw` (~1-2s) because the
+    #     in-memory vault cache lives in the *main* process, not here.
+    #   * main-app IPC — ask the running app, which already holds the unlocked
+    #     vault in memory (near-instant, no `bw` spawn).
+    # Session vault: IPC first. Platform stores: local first.
+    try:
+        from .secret_storage import get_secret_manager
+        _selected = (os.environ.get("SSHPILOT_SECRET_BACKEND") or "auto").strip().lower()
+        # Session backends (bw) hold the vault only in the main process, so IPC
+        # is the only warm route. rbw has a shared agent, but a local `rbw get`
+        # still costs ~1s per connect on a large vault — prefer IPC for it too.
+        prefer_ipc = bool(get_secret_manager().is_session_backed(_selected)) or _selected == "rbw"
+    except Exception:
+        prefer_ipc = False
+
+    def _resolve_local():
+        for candidate in _get_key_path_lookup_candidates(key_path):
+            passphrase = lookup_passphrase(candidate)
+            if passphrase:
+                log_fn(f"ASKPASS: Found passphrase for {candidate}")
+                return passphrase
+            log_fn(f"ASKPASS: No passphrase found for {candidate}")
+        return None
+
+    def _resolve_main_app():
+        value = _lookup_via_main_app(key_path, log_fn)
+        if value:
+            log_fn("ASKPASS: passphrase resolved via main-app cache")
+        return value
+
+    resolvers = ((_resolve_main_app, _resolve_local) if prefer_ipc
+                 else (_resolve_local, _resolve_main_app))
+    for resolve in resolvers:
+        value = resolve()
+        if value:
+            log_fn("ASKPASS: Returning passphrase to caller")
+            return value
+
+    # No stored passphrase — defer to SSH / the OS / ssh-agent.
+    # Login-password and MFA use the graphical path above; unstored key
+    # passphrases do not.
+    log_fn("ASKPASS: No stored passphrase; deferring to system/SSH")
+    return None
+
+
 def handle_askpass_cli(prompt: str) -> "str | None":
     """Handle --askpass CLI mode (re-invoked by SSH as SSH_ASKPASS handler).
 
@@ -991,9 +1170,7 @@ def handle_askpass_cli(prompt: str) -> "str | None":
     if (os.environ.get("SSHPILOT_ASKPASS_AUTOFILL_ONLY") or "").strip() == "1":
         only_kind = classify_prompt(prompt)
         lowered = prompt.lower()
-        if only_kind == 'password' or (
-                only_kind is None and "password" in lowered
-                and "passphrase" not in lowered):
+        if _looks_like_login_password(prompt, only_kind):
             value = _resolve_askpass_password(_log)
             _log("ASKPASS: autofill-only mode; "
                  + ("answered from store" if value else "no stored password, declining"))
@@ -1016,91 +1193,38 @@ def handle_askpass_cli(prompt: str) -> "str | None":
     # Official OpenSSH askpass UI hints (see readpass.c / notify_start).
     if hint == "none":
         _log("ASKPASS: SSH_ASKPASS_PROMPT=none (FIDO presence reminder)")
-        handled, routed = _route_presence_to_main_app(prompt, _log)
-        if handled:
-            return "" if routed is not None else None
-        return _run_presence_dialog(prompt, _log)
+        return _handle_presence_prompt(prompt, _log)
 
     if hint == "confirm":
         _log("ASKPASS: SSH_ASKPASS_PROMPT=confirm (yes/no)")
-        handled, routed = _route_confirm_to_main_app(prompt, _log)
-        if handled:
-            return routed
-        return _run_confirm_dialog(prompt, _log)
+        return _handle_confirm_prompt(prompt, _log)
 
     kind = classify_prompt(prompt)
     if kind == 'presence':
         _log("ASKPASS: presence prompt (classifier); reminder UI")
-        handled, routed = _route_presence_to_main_app(prompt, _log)
-        if handled:
-            return "" if routed is not None else None
-        return _run_presence_dialog(prompt, _log)
+        return _handle_presence_prompt(prompt, _log)
 
     if kind == 'interactive':
         # OpenSSH with SSH_ASKPASS_REQUIRE=prefer does NOT fall back to the
         # TTY when askpass fails — declining here leaves the user with no way
         # to enter an OTP. Prompt them (never autofill MFA from the vault).
         _log("ASKPASS: interactive prompt (OTP/PIN); asking user")
-        handled, routed = _route_challenge_to_main_app(prompt, _log)
-        if handled:
-            if routed is not None:
-                _log("ASKPASS: Returning interactive response from main-app dialog")
-                return routed
-            _log("ASKPASS: user cancelled interactive prompt")
-            return None
-        value = _run_challenge_dialog(prompt, _log)
-        if value is not None:
-            _log("ASKPASS: Returning interactive response from GUI dialog")
-            return value
-        _log("ASKPASS: No interactive response; exiting with code 1")
-        return None
+        return _handle_challenge_prompt(prompt, _log)
 
-    if kind == 'password' or (
-            kind is None
-            and "password" in prompt.lower()
-            and "passphrase" not in prompt.lower()):
-        value = _resolve_askpass_password(_log)
-        if value:
-            _log("ASKPASS: Returning password to caller")
-            return value
-        # No vault/session password — ask the user. prefer does not fall back
-        # to the TTY (same as MFA), so a dialog is required.
-        _log("ASKPASS: no stored password; asking user")
-        handled, routed = _route_password_to_main_app(prompt, _log)
-        if handled:
-            if routed is not None:
-                _log("ASKPASS: Returning password from main-app dialog")
-                return routed
-            _log("ASKPASS: user cancelled password prompt")
-            return None
-        # Standalone fallback (main app unreachable). Give the entry a
-        # password-appropriate default so an empty prompt does not read as
-        # "verification code" (that default belongs to the OTP/challenge path).
-        value = _run_challenge_dialog(prompt or _standalone_password_label(), _log)
-        if value is not None:
-            _log("ASKPASS: Returning password from GUI dialog")
-            return value
-        _log("ASKPASS: No password available; exiting with code 1")
-        return None
+    if _looks_like_login_password(prompt, kind):
+        return _handle_password_prompt(prompt, _log)
 
     if kind != 'passphrase' and "passphrase" not in prompt.lower():
         # Unknown keyboard-interactive / custom MFA text: prefer a typed
         # challenge dialog over exiting 1 (OpenSSH will not fall back to the
         # TTY once askpass was invoked under REQUIRE=prefer).
         _log("ASKPASS: unrecognized prompt; treating as interactive challenge")
-        handled, routed = _route_challenge_to_main_app(prompt, _log)
-        if handled:
-            if routed is not None:
-                _log("ASKPASS: Returning response from main-app dialog")
-                return routed
-            _log("ASKPASS: user cancelled interactive prompt")
-            return None
-        value = _run_challenge_dialog(prompt, _log)
-        if value is not None:
-            _log("ASKPASS: Returning response from GUI dialog")
-            return value
-        _log("ASKPASS: No interactive response; exiting with code 1")
-        return None
+        return _handle_challenge_prompt(
+            prompt,
+            _log,
+            success_log="ASKPASS: Returning response from main-app dialog",
+            dialog_success_log="ASKPASS: Returning response from GUI dialog",
+        )
 
     key_path = _extract_key_path(prompt)
     if not key_path:
@@ -1108,71 +1232,8 @@ def handle_askpass_cli(prompt: str) -> "str | None":
         return None
 
     _log(f"ASKPASS: Extracted key path: {key_path}")
+    return _resolve_passphrase_for_askpass(key_path, _log)
 
-    # Check one-shot session passphrase written by the main app
-    session_passphrase_file = os.environ.get("SSHPILOT_SESSION_PASSPHRASE_FILE", "")
-    if session_passphrase_file and os.path.exists(session_passphrase_file):
-        try:
-            with open(session_passphrase_file, encoding="utf-8") as f:
-                session_passphrase = f.read().strip()
-            if session_passphrase:
-                _log("ASKPASS: Found session passphrase from secure temp file")
-                try:
-                    os.unlink(session_passphrase_file)
-                except Exception:
-                    pass
-                return session_passphrase
-        except Exception as exc:
-            _log(f"ASKPASS: Error reading session passphrase file: {exc}")
-
-    # Resolve the passphrase from storage. Two routes:
-    #   * local — read the selected backend in this subprocess. Instant for the platform
-    #     stores (libsecret/keyring), but for a session vault (Bitwarden/Vaultwarden) it
-    #     cold-starts `bw` (~1-2s) because the in-memory vault cache lives in the *main*
-    #     process, not here.
-    #   * main-app IPC — ask the running app, which already holds the unlocked vault in
-    #     memory, to resolve from its warm cache (near-instant, no `bw` spawn).
-    # So for a session vault try IPC first (cache hit) and fall back to the local `bw`
-    # lookup; for platform stores do the instant local read first.
-    try:
-        from .secret_storage import get_secret_manager
-        _selected = (os.environ.get("SSHPILOT_SECRET_BACKEND") or "auto").strip().lower()
-        # Session backends (bw) hold the vault only in the main process, so IPC is the
-        # only warm route. rbw has a shared agent, but a local `rbw get` still costs ~1s
-        # per connect on a large vault — the main app's value cache (via IPC) makes repeat
-        # connects instant, so prefer IPC for it too.
-        prefer_ipc = bool(get_secret_manager().is_session_backed(_selected)) or _selected == "rbw"
-    except Exception:
-        prefer_ipc = False
-
-    def _resolve_local():
-        for candidate in _get_key_path_lookup_candidates(key_path):
-            passphrase = lookup_passphrase(candidate)
-            if passphrase:
-                _log(f"ASKPASS: Found passphrase for {candidate}")
-                return passphrase
-            _log(f"ASKPASS: No passphrase found for {candidate}")
-        return None
-
-    def _resolve_main_app():
-        value = _lookup_via_main_app(key_path, _log)
-        if value:
-            _log("ASKPASS: passphrase resolved via main-app cache")
-        return value
-
-    resolvers = ((_resolve_main_app, _resolve_local) if prefer_ipc
-                 else (_resolve_local, _resolve_main_app))
-    for resolve in resolvers:
-        value = resolve()
-        if value:
-            _log("ASKPASS: Returning passphrase to caller")
-            return value
-
-    # No stored passphrase — defer to SSH / the OS / ssh-agent (TTY or system
-    # prompt). Login-password and MFA prompts use the graphical askpass path
-    # above; unstored key passphrases do not.
-    _log("ASKPASS: No stored passphrase; deferring to system/SSH")
-    return None
 
 
 def run_askpass_and_write(prompt: str) -> int:

--- a/src/sshpilot/file_manager_window.py
+++ b/src/sshpilot/file_manager_window.py
@@ -1453,638 +1453,659 @@ class FileManagerWindow(Adw.Window):
 
     def _on_request_operation(self, pane: FilePane, action: str, payload, user_data=None) -> None:
         if action in {"copy", "cut"} and isinstance(payload, dict):
-            entries = list(payload.get("entries") or [])
-            if not entries:
-                pane.show_toast("Nothing selected")
-                return
+            self._op_copy_cut(pane, action, payload)
+        elif action == "paste":
+            self._op_paste(pane, payload)
+        elif action == "mkdir":
+            self._op_mkdir(pane)
+        elif action == "newfile":
+            self._op_newfile(pane)
+        elif action == "rename" and isinstance(payload, dict):
+            self._op_rename(pane, payload)
+        elif action == "delete" and isinstance(payload, dict):
+            self._op_delete(pane, payload)
+        elif action == "upload":
+            self._op_upload(pane, payload, user_data)
+        elif action == "download" and isinstance(payload, dict):
+            self._op_download(pane, payload, user_data)
 
-            directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
-            if pane is self._left_pane:
-                # Use the actual current path instead of the display path from path entry
-                # This handles Flatpak portal paths correctly
-                current_path = getattr(pane, '_current_path', None)
-                if current_path:
-                    directory = current_path
-                else:
-                    directory = self._normalize_local_path(directory)
+    def _op_copy_cut(self, pane, action, payload) -> None:
+        entries = list(payload.get("entries") or [])
+        if not entries:
+            pane.show_toast("Nothing selected")
+            return
+
+        directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
+        if pane is self._left_pane:
+            # Use the actual current path instead of the display path from path entry
+            # This handles Flatpak portal paths correctly
+            current_path = getattr(pane, '_current_path', None)
+            if current_path:
+                directory = current_path
             else:
-                directory = directory or "/"
+                directory = self._normalize_local_path(directory)
+        else:
+            directory = directory or "/"
 
-            self._clipboard_entries = [dataclasses.replace(entry) for entry in entries]
-            self._clipboard_directory = directory
-            self._clipboard_source_pane = pane
-            self._clipboard_operation = action
+        self._clipboard_entries = [dataclasses.replace(entry) for entry in entries]
+        self._clipboard_directory = directory
+        self._clipboard_source_pane = pane
+        self._clipboard_operation = action
+        self._update_paste_targets()
+
+        if len(entries) == 1:
+            message = f"{'Cut' if action == 'cut' else 'Copied'} {entries[0].name}"
+        else:
+            message = f"{'Cut' if action == 'cut' else 'Copied'} {len(entries)} items"
+        pane.show_toast(message)
+
+    def _op_paste(self, pane, payload) -> None:
+        if not self._clipboard_entries or self._clipboard_source_pane is None:
+            pane.show_toast("Clipboard is empty")
+            return
+
+        destination = ""
+        force_move = False
+        if isinstance(payload, dict):
+            destination = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
+            force_move = bool(payload.get("force_move"))
+        
+        # For local pane destinations, use actual current path instead of display path
+        if pane is self._left_pane:
+            current_path = getattr(pane, '_current_path', None)
+            if current_path:
+                destination = current_path
+            else:
+                destination = self._normalize_local_path(destination or pane.toolbar.path_entry.get_text() or "/")
+        else:
+            destination = pane.toolbar.path_entry.get_text() or "/"
+
+        move_requested = force_move or self._clipboard_operation == "cut"
+        source_pane = self._clipboard_source_pane
+        source_dir = self._clipboard_directory or "/"
+        entries = list(self._clipboard_entries)
+
+        if source_pane is self._left_pane and pane is self._left_pane:
+            self._perform_local_clipboard_operation(entries, source_dir, destination, move_requested)
+        elif source_pane is self._right_pane and pane is self._right_pane:
+            self._perform_remote_clipboard_operation(entries, source_dir, destination, move_requested)
+        elif source_pane is self._left_pane and pane is self._right_pane:
+            self._perform_local_to_remote_clipboard_operation(entries, source_dir, destination, move_requested)
+        elif source_pane is self._right_pane and pane is self._left_pane:
+            self._perform_remote_to_local_clipboard_operation(entries, source_dir, destination, move_requested)
+        else:
+            pane.show_toast("Paste target is unavailable")
+            return
+
+        if move_requested:
+            self._clear_clipboard()
+        else:
             self._update_paste_targets()
 
-            if len(entries) == 1:
-                message = f"{'Cut' if action == 'cut' else 'Copied'} {entries[0].name}"
-            else:
-                message = f"{'Cut' if action == 'cut' else 'Copied'} {len(entries)} items"
-            pane.show_toast(message)
-            return
+    def _op_mkdir(self, pane) -> None:
+        dialog = Adw.AlertDialog.new("New Folder", "Enter a name for the new folder")
+        entry = Gtk.Entry()
+        entry.set_text(_("New Folder"))
+        dialog.set_extra_child(entry)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("ok", _("Create"))
+        dialog.set_default_response("ok")
+        dialog.set_close_response("cancel")
 
-        if action == "paste":
-            if not self._clipboard_entries or self._clipboard_source_pane is None:
-                pane.show_toast("Clipboard is empty")
-                return
-
-            destination = ""
-            force_move = False
-            if isinstance(payload, dict):
-                destination = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
-                force_move = bool(payload.get("force_move"))
-            
-            # For local pane destinations, use actual current path instead of display path
-            if pane is self._left_pane:
-                current_path = getattr(pane, '_current_path', None)
-                if current_path:
-                    destination = current_path
-                else:
-                    destination = self._normalize_local_path(destination or pane.toolbar.path_entry.get_text() or "/")
-            else:
-                destination = pane.toolbar.path_entry.get_text() or "/"
-
-            move_requested = force_move or self._clipboard_operation == "cut"
-            source_pane = self._clipboard_source_pane
-            source_dir = self._clipboard_directory or "/"
-            entries = list(self._clipboard_entries)
-
-            if source_pane is self._left_pane and pane is self._left_pane:
-                self._perform_local_clipboard_operation(entries, source_dir, destination, move_requested)
-            elif source_pane is self._right_pane and pane is self._right_pane:
-                self._perform_remote_clipboard_operation(entries, source_dir, destination, move_requested)
-            elif source_pane is self._left_pane and pane is self._right_pane:
-                self._perform_local_to_remote_clipboard_operation(entries, source_dir, destination, move_requested)
-            elif source_pane is self._right_pane and pane is self._left_pane:
-                self._perform_remote_to_local_clipboard_operation(entries, source_dir, destination, move_requested)
-            else:
-                pane.show_toast("Paste target is unavailable")
-                return
-
-            if move_requested:
-                self._clear_clipboard()
-            else:
-                self._update_paste_targets()
-            return
-
-        if action == "mkdir":
-            dialog = Adw.AlertDialog.new("New Folder", "Enter a name for the new folder")
-            entry = Gtk.Entry()
-            entry.set_text(_("New Folder"))
-            dialog.set_extra_child(entry)
-            dialog.add_response("cancel", _("Cancel"))
-            dialog.add_response("ok", _("Create"))
-            dialog.set_default_response("ok")
-            dialog.set_close_response("cancel")
-
-            def _on_response(_dialog, response: str) -> None:
-                if response == "ok":
-                    name = entry.get_text().strip()
-                    if name:
-                        current_dir = pane.toolbar.path_entry.get_text() or "/"
-                        if pane is self._left_pane:
-                            target_dir = self._normalize_local_path(current_dir)
-                            new_path = os.path.join(target_dir, name)
-                        else:
-                            new_path = posixpath.join(current_dir or "/", name)
-                        if pane is self._left_pane:
-                            try:
-                                os.makedirs(new_path, exist_ok=False)
-                            except FileExistsError:
-                                pane.show_toast("Folder already exists")
-                            except Exception as exc:
-                                pane.show_toast(str(exc))
-                            else:
-                                # Refresh local listing
-                                self._pending_highlights[self._left_pane] = name
-                                self._load_local(os.path.dirname(new_path) or "/")
-                        else:
-                            future = self._manager.mkdir(new_path)
-                            
-                            # Simple direct refresh after operation completes
-                            def _on_mkdir_done(completed_future):
-                                try:
-                                    completed_future.result()  # Check for errors
-                                    logger.debug(f"mkdir completed successfully, refreshing pane")
-                                    # Direct refresh of the current directory
-                                    GLib.idle_add(lambda: self._force_refresh_pane(pane, highlight_name=name))
-                                except Exception as e:
-                                    logger.error(f"mkdir failed: {e}")
-                            
-                            future.add_done_callback(_on_mkdir_done)
-                dialog.close()
-
-            def _focus_entry():
-                entry.grab_focus()
-                entry.select_region(0, -1)  # Select all text
-
-            def _on_entry_activate(_entry):
-                # Trigger the "ok" response when Enter is pressed
-                _on_response(dialog, "ok")
-
-            entry.connect("activate", _on_entry_activate)
-            dialog.connect("response", _on_response)
-            dialog.present()
-            # Focus the entry after the dialog is shown
-            GLib.idle_add(_focus_entry)
-        elif action == "newfile":
-            dialog = Adw.AlertDialog.new("New File", "Enter a name for the new file")
-            entry = Gtk.Entry()
-            entry.set_text("untitled.txt")
-            dialog.set_extra_child(entry)
-            dialog.add_response("cancel", _("Cancel"))
-            dialog.add_response("ok", _("Create"))
-            dialog.set_default_response("ok")
-            dialog.set_close_response("cancel")
-
-            def _on_response(_dialog, response: str) -> None:
-                if response == "ok":
-                    name = entry.get_text().strip()
-                    if name:
-                        current_dir = pane.toolbar.path_entry.get_text() or "/"
-                        if pane is self._left_pane:
-                            target_dir = self._normalize_local_path(current_dir)
-                            new_path = os.path.join(target_dir, name)
-                            try:
-                                with open(new_path, "x"):
-                                    pass
-                            except FileExistsError:
-                                pane.show_toast("File already exists")
-                            except Exception as exc:
-                                pane.show_toast(str(exc))
-                            else:
-                                self._pending_highlights[self._left_pane] = name
-                                self._load_local(os.path.dirname(new_path) or "/")
-                                self._open_path_in_editor(pane, new_path, name)
-                        else:
-                            new_path = posixpath.join(current_dir or "/", name)
-                            future = self._manager.touch(new_path)
-
-                            def _on_touch_done(completed_future, p=new_path, n=name) -> None:
-                                try:
-                                    completed_future.result()
-                                except FileExistsError:
-                                    GLib.idle_add(pane.show_toast, "File already exists")
-                                    return
-                                except Exception as e:
-                                    GLib.idle_add(pane.show_toast, f"Failed to create file: {e}")
-                                    return
-
-                                def _after() -> bool:
-                                    self._force_refresh_pane(pane, highlight_name=n)
-                                    self._open_path_in_editor(pane, p, n)
-                                    return False
-
-                                GLib.idle_add(_after)
-
-                            future.add_done_callback(_on_touch_done)
-                dialog.close()
-
-            def _focus_entry():
-                entry.grab_focus()
-                # Pre-select the base name (before the extension) for quick typing.
-                text = entry.get_text()
-                dot = text.rfind(".")
-                entry.select_region(0, dot if dot > 0 else -1)
-
-            def _on_entry_activate(_entry):
-                _on_response(dialog, "ok")
-
-            entry.connect("activate", _on_entry_activate)
-            dialog.connect("response", _on_response)
-            dialog.present()
-            GLib.idle_add(_focus_entry)
-        elif action == "rename" and isinstance(payload, dict):
-            entries = payload.get("entries") or []
-            directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
-            if not entries:
-                return
-
-            entry = entries[0]
-
-            if pane is self._left_pane:
-                base_dir = self._normalize_local_path(directory)
-                source = os.path.join(base_dir, entry.name)
-                join = os.path.join
-            else:
-                base_dir = directory or "/"
-                source = posixpath.join(base_dir, entry.name)
-                join = posixpath.join
-
-            dialog = Adw.AlertDialog.new("Rename Item", f"Enter a new name for {entry.name}")
-            name_entry = Gtk.Entry()
-            name_entry.set_text(entry.name)
-            dialog.set_extra_child(name_entry)
-            dialog.add_response("cancel", _("Cancel"))
-            dialog.add_response("ok", _("Rename"))
-            dialog.set_default_response("ok")
-            dialog.set_close_response("cancel")
-
-            def _on_rename(_dialog, response: str) -> None:
-                if response != "ok":
-                    dialog.close()
-                    return
-                new_name = name_entry.get_text().strip()
-                if not new_name:
-                    pane.show_toast("Name cannot be empty")
-                    dialog.close()
-                    return
-                if new_name == entry.name:
-                    dialog.close()
-                    return
-                target = join(base_dir, new_name)
-                if pane is self._left_pane:
-                    try:
-                        os.rename(source, target)
-                    except Exception as exc:
-                        pane.show_toast(str(exc))
+        def _on_response(_dialog, response: str) -> None:
+            if response == "ok":
+                name = entry.get_text().strip()
+                if name:
+                    current_dir = pane.toolbar.path_entry.get_text() or "/"
+                    if pane is self._left_pane:
+                        target_dir = self._normalize_local_path(current_dir)
+                        new_path = os.path.join(target_dir, name)
                     else:
-                        pane.show_toast(f"Renamed to {new_name}")
-                        self._pending_highlights[self._left_pane] = new_name
-                        self._load_local(base_dir)
-                else:
-                    future = self._manager.rename(source, target)
-                    
-                    # Simple direct refresh after operation completes
-                    def _on_rename_done(completed_future):
+                        new_path = posixpath.join(current_dir or "/", name)
+                    if pane is self._left_pane:
                         try:
-                            completed_future.result()  # Check for errors
-                            logger.debug(f"rename completed successfully, refreshing pane")
-                            # Direct refresh of the current directory
-                            GLib.idle_add(lambda: self._force_refresh_pane(pane, highlight_name=new_name))
-                        except Exception as e:
-                            logger.error(f"rename failed: {e}")
-                    
-                    future.add_done_callback(_on_rename_done)
-                    pane.show_toast(f"Renaming to {new_name}…")
-                dialog.close()
-
-            def _focus_entry():
-                name_entry.grab_focus()
-                name_entry.select_region(0, -1)  # Select all text
-
-            def _on_entry_activate(_entry):
-                # Trigger the "ok" response when Enter is pressed
-                _on_rename(dialog, "ok")
-
-            name_entry.connect("activate", _on_entry_activate)
-            dialog.connect("response", _on_rename)
-            dialog.present()
-            # Focus the entry after the dialog is shown
-            GLib.idle_add(_focus_entry)
-        elif action == "delete" and isinstance(payload, dict):
-            entries = payload.get("entries") or []
-            directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
-            if not entries:
-                return
-
-            if pane is self._left_pane:
-                base_dir = self._normalize_local_path(directory)
-            else:
-                base_dir = directory or "/"
-
-            count = len(entries)
-            if count == 1:
-                message = f"Delete {entries[0].name}?"
-                title = "Delete Item"
-            else:
-                message = f"Delete {count} items?"
-                title = "Delete Items"
-
-            dialog = Adw.AlertDialog.new(title, message)
-            dialog.add_response("cancel", _("Cancel"))
-            dialog.add_response("ok", _("Delete"))
-            dialog.set_default_response("cancel")
-            dialog.set_close_response("cancel")
-
-            def _on_delete(_dialog, response: str) -> None:
-                if response != "ok":
-                    dialog.close()
-                    return
-                if pane is self._left_pane:
-                    deleted = 0
-                    errors: List[str] = []
-                    for selected_entry in entries:
-                        target_path = os.path.join(base_dir, selected_entry.name)
-                        try:
-                            if selected_entry.is_dir:
-                                shutil.rmtree(target_path)
-                            else:
-                                os.remove(target_path)
-                            deleted += 1
-                        except FileNotFoundError:
-                            errors.append(f"{selected_entry.name} no longer exists")
+                            os.makedirs(new_path, exist_ok=False)
+                        except FileExistsError:
+                            pane.show_toast("Folder already exists")
                         except Exception as exc:
-                            errors.append(str(exc))
-                    if deleted:
-                        message = (
-                            "Deleted 1 item"
-                            if deleted == 1
-                            else f"Deleted {deleted} items"
-                        )
-                        pane.show_toast(message)
-                        self._load_local(base_dir)
-                    if errors:
-                        pane.show_toast(errors[0])
-                else:
-                    # Delete entries sequentially to avoid race conditions and hangs
-                    errors: List[str] = []
-                    total_count = len(entries)
-                    
-                    logger.info(f"Starting sequential deletion of {total_count} remote entries")
-                    
-                    def _delete_next(index: int) -> None:
-                        """Delete the next entry in the list, then continue with the next one."""
-                        if index >= total_count:
-                            # All deletions complete
-                            logger.info(f"All {total_count} deletions completed, refreshing pane")
-                            GLib.idle_add(
-                                lambda: self._on_all_deletes_complete(pane, base_dir, errors, total_count)
-                            )
-                            return
+                            pane.show_toast(str(exc))
+                        else:
+                            # Refresh local listing
+                            self._pending_highlights[self._left_pane] = name
+                            self._load_local(os.path.dirname(new_path) or "/")
+                    else:
+                        future = self._manager.mkdir(new_path)
                         
-                        selected_entry = entries[index]
-                        target_path = posixpath.join(base_dir, selected_entry.name)
-                        entry_name = selected_entry.name
-                        
-                        logger.info(f"Deleting {index + 1}/{total_count}: '{entry_name}'")
-                        
-                        def _on_delete_done(future_result: Future) -> None:
+                        # Simple direct refresh after operation completes
+                        def _on_mkdir_done(completed_future):
                             try:
-                                future_result.result()  # Check for errors
-                                logger.info(f"Successfully deleted '{entry_name}'")
+                                completed_future.result()  # Check for errors
+                                logger.debug(f"mkdir completed successfully, refreshing pane")
+                                # Direct refresh of the current directory
+                                GLib.idle_add(lambda: self._force_refresh_pane(pane, highlight_name=name))
                             except Exception as e:
-                                error_msg = f"Failed to delete {entry_name}: {e!s}"
-                                logger.error(f"Delete failed for '{entry_name}': {error_msg}", exc_info=True)
-                                errors.append(error_msg)
-                            
-                            # Continue with next deletion on the main loop
-                            GLib.idle_add(lambda: _delete_next(index + 1))
+                                logger.error(f"mkdir failed: {e}")
                         
+                        future.add_done_callback(_on_mkdir_done)
+            dialog.close()
+
+        def _focus_entry():
+            entry.grab_focus()
+            entry.select_region(0, -1)  # Select all text
+
+        def _on_entry_activate(_entry):
+            # Trigger the "ok" response when Enter is pressed
+            _on_response(dialog, "ok")
+
+        entry.connect("activate", _on_entry_activate)
+        dialog.connect("response", _on_response)
+        dialog.present()
+        # Focus the entry after the dialog is shown
+        GLib.idle_add(_focus_entry)
+
+    def _op_newfile(self, pane) -> None:
+        dialog = Adw.AlertDialog.new("New File", "Enter a name for the new file")
+        entry = Gtk.Entry()
+        entry.set_text("untitled.txt")
+        dialog.set_extra_child(entry)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("ok", _("Create"))
+        dialog.set_default_response("ok")
+        dialog.set_close_response("cancel")
+
+        def _on_response(_dialog, response: str) -> None:
+            if response == "ok":
+                name = entry.get_text().strip()
+                if name:
+                    current_dir = pane.toolbar.path_entry.get_text() or "/"
+                    if pane is self._left_pane:
+                        target_dir = self._normalize_local_path(current_dir)
+                        new_path = os.path.join(target_dir, name)
                         try:
-                            future = self._manager.remove(target_path)
-                            future.add_done_callback(_on_delete_done)
+                            with open(new_path, "x"):
+                                pass
+                        except FileExistsError:
+                            pane.show_toast("File already exists")
                         except Exception as exc:
-                            logger.error(f"Failed to create remove future for {entry_name}: {exc}", exc_info=True)
-                            errors.append(f"Failed to delete {entry_name}: {exc!s}")
-                            GLib.idle_add(lambda: _delete_next(index + 1))
-                    
-                    # Start sequential deletion
-                    _delete_next(0)
-                    
-                    pane.show_toast(
-                        "Deleting 1 item…" if count == 1 else f"Deleting {count} items…"
-                    )
-                dialog.close()
-
-            dialog.connect("response", _on_delete)
-            
-            # Get the correct parent widget (handles both embedded tab and separate window cases)
-            # Adw.AlertDialog.present() accepts a Gtk.Widget, so we can pass the embedded parent directly
-            try:
-                dialog_parent = self
-                if self._embedded_parent is not None:
-                    # If embedded as a tab, use the parent widget directly
-                    dialog_parent = self._embedded_parent
-                else:
-                    # If standalone window, try to get transient parent if any
-                    try:
-                        transient = self.get_transient_for()
-                        if transient is not None:
-                            dialog_parent = transient
-                    except Exception:
-                        pass
-                
-                dialog.present(dialog_parent)  # Present with correct parent to center properly
-            except Exception as e:
-                # Fallback: present without parent if there's an error
-                logger.error(f"Failed to present delete dialog with parent: {e}", exc_info=True)
-                dialog.present()  # Present without parent as fallback
-        elif action == "upload":
-            # Upload can be triggered from either pane, but we need to determine the target pane
-            if pane is self._left_pane:
-                # Upload from local to remote
-                target_pane = self._right_pane
-            elif pane is self._right_pane:
-                # Upload from local to remote (when triggered from remote pane)
-                target_pane = pane
-            else:
-                return
-
-            remote_root = target_pane.toolbar.path_entry.get_text() or "/"
-            raw_items: object | None = None
-
-            move_sources: List[pathlib.Path] = []
-            move_source_dir: Optional[str] = None
-            if isinstance(user_data, dict):
-                move_sources = list(user_data.get("move_sources") or [])
-                move_source_dir = user_data.get("move_source_dir")
-            move_sources_set = {path.resolve() for path in move_sources}
-
-            if isinstance(payload, dict):
-                destination = payload.get("destination")
-                if isinstance(destination, pathlib.Path):
-                    remote_root = destination.as_posix()
-                elif isinstance(destination, str) and destination:
-                    remote_root = destination
-                raw_items = payload.get("paths")
-            else:
-                raw_items = payload
-
-            paths: List[pathlib.Path] = []
-
-            def _collect(item: object | None) -> None:
-                if item is None:
-                    return
-                if isinstance(item, (list, tuple, set, frozenset)):
-                    for value in item:
-                        _collect(value)
-                    return
-                if isinstance(item, pathlib.Path):
-                    paths.append(item)
-                elif isinstance(item, Gio.File):
-                    local_path = item.get_path()
-                    if local_path:
-                        paths.append(pathlib.Path(local_path))
-                elif isinstance(item, str):
-                    paths.append(pathlib.Path(item))
-
-            _collect(raw_items)
-
-            if not paths:
-                pane.show_toast("No files selected for upload")
-                return
-
-            available_paths: List[pathlib.Path] = []
-            missing: List[pathlib.Path] = []
-            for candidate in paths:
-                try:
-                    if candidate.exists():
-                        available_paths.append(candidate)
-                    else:
-                        missing.append(candidate)
-                except OSError:
-                    missing.append(candidate)
-
-            if missing and not available_paths:
-                pane.show_toast("Selected items are not accessible")
-                return
-            if missing and available_paths:
-                pane.show_toast(f"Skipping inaccessible items: {missing[0].name}")
-
-            # Prepare list of files to transfer for conflict checking
-            files_to_transfer = []
-            for path_obj in available_paths:
-                destination = posixpath.join(remote_root or "/", path_obj.name)
-                files_to_transfer.append((str(path_obj), destination))
-            
-            # Check for conflicts and handle accordingly  
-            def _proceed_with_upload(resolved_files: List[Tuple[str, str]]) -> None:
-                if not resolved_files:
-                    logger.warning("_proceed_with_upload: No files to upload")
-                    return
-                
-                # Check if manager is still available and connected
-                if self._manager is None:
-                    pane.show_toast("Upload failed: Connection lost")
-                    logger.error("_proceed_with_upload: Manager is None")
-                    return
-                
-                # Check if SFTP connection is still valid
-                try:
-                    with self._manager._lock:
-                        if self._manager._sftp is None:
-                            pane.show_toast("Upload failed: Connection closed. Please reconnect.")
-                            logger.error("_proceed_with_upload: SFTP connection is None")
-                            return
-                except Exception as e:
-                    logger.error(f"_proceed_with_upload: Error checking connection: {e}")
-                    pane.show_toast(f"Upload failed: {e!s}")
-                    return
-                
-                total_files = len(resolved_files)
-                logger.info(
-                    "Starting upload of %d file%s",
-                    total_files, "" if total_files == 1 else "s",
-                )
-                
-                for local_path_str, destination in resolved_files:
-                    path_obj = pathlib.Path(local_path_str)
-
-                    try:
-                        logger.debug(f"_proceed_with_upload: Starting upload of {path_obj.name}")
-                        if path_obj.is_dir():
-                            future = self._manager.upload_directory(path_obj, destination)
+                            pane.show_toast(str(exc))
                         else:
-                            future = self._manager.upload(path_obj, destination)
+                            self._pending_highlights[self._left_pane] = name
+                            self._load_local(os.path.dirname(new_path) or "/")
+                            self._open_path_in_editor(pane, new_path, name)
+                    else:
+                        new_path = posixpath.join(current_dir or "/", name)
+                        future = self._manager.touch(new_path)
 
-                        # Show progress dialog for upload (pass total_files for multi-file support)
-                        self._show_progress_dialog(
-                            "upload", path_obj.name, future,
-                            total_files=total_files,
-                            source_path=str(path_obj),
-                            destination_path=destination,
-                        )
-                        self._attach_refresh(
-                            future,
-                            refresh_remote=target_pane,
-                            highlight_name=path_obj.name,
-                        )
-                        if move_sources_set and path_obj.resolve() in move_sources_set:
-                            cleanup_dir = move_source_dir or str(path_obj.parent)
-                            self._schedule_local_move_cleanup(future, path_obj, cleanup_dir)
+                        def _on_touch_done(completed_future, p=new_path, n=name) -> None:
+                            try:
+                                completed_future.result()
+                            except FileExistsError:
+                                GLib.idle_add(pane.show_toast, "File already exists")
+                                return
+                            except Exception as e:
+                                GLib.idle_add(pane.show_toast, f"Failed to create file: {e}")
+                                return
+
+                            def _after() -> bool:
+                                self._force_refresh_pane(pane, highlight_name=n)
+                                self._open_path_in_editor(pane, p, n)
+                                return False
+
+                            GLib.idle_add(_after)
+
+                        future.add_done_callback(_on_touch_done)
+            dialog.close()
+
+        def _focus_entry():
+            entry.grab_focus()
+            # Pre-select the base name (before the extension) for quick typing.
+            text = entry.get_text()
+            dot = text.rfind(".")
+            entry.select_region(0, dot if dot > 0 else -1)
+
+        def _on_entry_activate(_entry):
+            _on_response(dialog, "ok")
+
+        entry.connect("activate", _on_entry_activate)
+        dialog.connect("response", _on_response)
+        dialog.present()
+        GLib.idle_add(_focus_entry)
+
+    def _op_rename(self, pane, payload) -> None:
+        entries = payload.get("entries") or []
+        directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
+        if not entries:
+            return
+
+        entry = entries[0]
+
+        if pane is self._left_pane:
+            base_dir = self._normalize_local_path(directory)
+            source = os.path.join(base_dir, entry.name)
+            join = os.path.join
+        else:
+            base_dir = directory or "/"
+            source = posixpath.join(base_dir, entry.name)
+            join = posixpath.join
+
+        dialog = Adw.AlertDialog.new("Rename Item", f"Enter a new name for {entry.name}")
+        name_entry = Gtk.Entry()
+        name_entry.set_text(entry.name)
+        dialog.set_extra_child(name_entry)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("ok", _("Rename"))
+        dialog.set_default_response("ok")
+        dialog.set_close_response("cancel")
+
+        def _on_rename(_dialog, response: str) -> None:
+            if response != "ok":
+                dialog.close()
+                return
+            new_name = name_entry.get_text().strip()
+            if not new_name:
+                pane.show_toast("Name cannot be empty")
+                dialog.close()
+                return
+            if new_name == entry.name:
+                dialog.close()
+                return
+            target = join(base_dir, new_name)
+            if pane is self._left_pane:
+                try:
+                    os.rename(source, target)
+                except Exception as exc:
+                    pane.show_toast(str(exc))
+                else:
+                    pane.show_toast(f"Renamed to {new_name}")
+                    self._pending_highlights[self._left_pane] = new_name
+                    self._load_local(base_dir)
+            else:
+                future = self._manager.rename(source, target)
+                
+                # Simple direct refresh after operation completes
+                def _on_rename_done(completed_future):
+                    try:
+                        completed_future.result()  # Check for errors
+                        logger.debug(f"rename completed successfully, refreshing pane")
+                        # Direct refresh of the current directory
+                        GLib.idle_add(lambda: self._force_refresh_pane(pane, highlight_name=new_name))
                     except Exception as e:
-                        error_msg = str(e)
-                        logger.error(f"_proceed_with_upload: Error uploading {path_obj.name}: {error_msg}", exc_info=True)
-                        pane.show_toast(f"Error uploading {path_obj.name}: {error_msg}")
+                        logger.error(f"rename failed: {e}")
+                
+                future.add_done_callback(_on_rename_done)
+                pane.show_toast(f"Renaming to {new_name}…")
+            dialog.close()
 
-            self._check_file_conflicts(files_to_transfer, "upload", _proceed_with_upload)
-        elif action == "download" and isinstance(payload, dict):
-            logger.debug("=== DOWNLOAD OPERATION CALLED ===")
-            logger.debug("Payload: %s", payload)
+        def _focus_entry():
+            name_entry.grab_focus()
+            name_entry.select_region(0, -1)  # Select all text
 
-            if pane is self._left_pane and payload.get("entries"):
+        def _on_entry_activate(_entry):
+            # Trigger the "ok" response when Enter is pressed
+            _on_rename(dialog, "ok")
+
+        name_entry.connect("activate", _on_entry_activate)
+        dialog.connect("response", _on_rename)
+        dialog.present()
+        # Focus the entry after the dialog is shown
+        GLib.idle_add(_focus_entry)
+
+    def _op_delete(self, pane, payload) -> None:
+        entries = payload.get("entries") or []
+        directory = payload.get("directory") or pane.toolbar.path_entry.get_text() or "/"
+        if not entries:
+            return
+
+        if pane is self._left_pane:
+            base_dir = self._normalize_local_path(directory)
+        else:
+            base_dir = directory or "/"
+
+        count = len(entries)
+        if count == 1:
+            message = f"Delete {entries[0].name}?"
+            title = "Delete Item"
+        else:
+            message = f"Delete {count} items?"
+            title = "Delete Items"
+
+        dialog = Adw.AlertDialog.new(title, message)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("ok", _("Delete"))
+        dialog.set_default_response("cancel")
+        dialog.set_close_response("cancel")
+
+        def _on_delete(_dialog, response: str) -> None:
+            if response != "ok":
+                dialog.close()
+                return
+            if pane is self._left_pane:
+                deleted = 0
+                errors: List[str] = []
+                for selected_entry in entries:
+                    target_path = os.path.join(base_dir, selected_entry.name)
+                    try:
+                        if selected_entry.is_dir:
+                            shutil.rmtree(target_path)
+                        else:
+                            os.remove(target_path)
+                        deleted += 1
+                    except FileNotFoundError:
+                        errors.append(f"{selected_entry.name} no longer exists")
+                    except Exception as exc:
+                        errors.append(str(exc))
+                if deleted:
+                    message = (
+                        "Deleted 1 item"
+                        if deleted == 1
+                        else f"Deleted {deleted} items"
+                    )
+                    pane.show_toast(message)
+                    self._load_local(base_dir)
+                if errors:
+                    pane.show_toast(errors[0])
+            else:
+                # Delete entries sequentially to avoid race conditions and hangs
+                errors: List[str] = []
+                total_count = len(entries)
+                
+                logger.info(f"Starting sequential deletion of {total_count} remote entries")
+                
+                def _delete_next(index: int) -> None:
+                    """Delete the next entry in the list, then continue with the next one."""
+                    if index >= total_count:
+                        # All deletions complete
+                        logger.info(f"All {total_count} deletions completed, refreshing pane")
+                        GLib.idle_add(
+                            lambda: self._on_all_deletes_complete(pane, base_dir, errors, total_count)
+                        )
+                        return
+                    
+                    selected_entry = entries[index]
+                    target_path = posixpath.join(base_dir, selected_entry.name)
+                    entry_name = selected_entry.name
+                    
+                    logger.info(f"Deleting {index + 1}/{total_count}: '{entry_name}'")
+                    
+                    def _on_delete_done(future_result: Future) -> None:
+                        try:
+                            future_result.result()  # Check for errors
+                            logger.info(f"Successfully deleted '{entry_name}'")
+                        except Exception as e:
+                            error_msg = f"Failed to delete {entry_name}: {e!s}"
+                            logger.error(f"Delete failed for '{entry_name}': {error_msg}", exc_info=True)
+                            errors.append(error_msg)
+                        
+                        # Continue with next deletion on the main loop
+                        GLib.idle_add(lambda: _delete_next(index + 1))
+                    
+                    try:
+                        future = self._manager.remove(target_path)
+                        future.add_done_callback(_on_delete_done)
+                    except Exception as exc:
+                        logger.error(f"Failed to create remove future for {entry_name}: {exc}", exc_info=True)
+                        errors.append(f"Failed to delete {entry_name}: {exc!s}")
+                        GLib.idle_add(lambda: _delete_next(index + 1))
+                
+                # Start sequential deletion
+                _delete_next(0)
+                
+                pane.show_toast(
+                    "Deleting 1 item…" if count == 1 else f"Deleting {count} items…"
+                )
+            dialog.close()
+
+        dialog.connect("response", _on_delete)
+        
+        # Get the correct parent widget (handles both embedded tab and separate window cases)
+        # Adw.AlertDialog.present() accepts a Gtk.Widget, so we can pass the embedded parent directly
+        try:
+            dialog_parent = self
+            if self._embedded_parent is not None:
+                # If embedded as a tab, use the parent widget directly
+                dialog_parent = self._embedded_parent
+            else:
+                # If standalone window, try to get transient parent if any
+                try:
+                    transient = self.get_transient_for()
+                    if transient is not None:
+                        dialog_parent = transient
+                except Exception:
+                    pass
+            
+            dialog.present(dialog_parent)  # Present with correct parent to center properly
+        except Exception as e:
+            # Fallback: present without parent if there's an error
+            logger.error(f"Failed to present delete dialog with parent: {e}", exc_info=True)
+            dialog.present()  # Present without parent as fallback
+
+    def _op_upload(self, pane, payload, user_data=None) -> None:
+        # Upload can be triggered from either pane, but we need to determine the target pane
+        if pane is self._left_pane:
+            # Upload from local to remote
+            target_pane = self._right_pane
+        elif pane is self._right_pane:
+            # Upload from local to remote (when triggered from remote pane)
+            target_pane = pane
+        else:
+            return
+
+        remote_root = target_pane.toolbar.path_entry.get_text() or "/"
+        raw_items: object | None = None
+
+        move_sources: List[pathlib.Path] = []
+        move_source_dir: Optional[str] = None
+        if isinstance(user_data, dict):
+            move_sources = list(user_data.get("move_sources") or [])
+            move_source_dir = user_data.get("move_source_dir")
+        move_sources_set = {path.resolve() for path in move_sources}
+
+        if isinstance(payload, dict):
+            destination = payload.get("destination")
+            if isinstance(destination, pathlib.Path):
+                remote_root = destination.as_posix()
+            elif isinstance(destination, str) and destination:
+                remote_root = destination
+            raw_items = payload.get("paths")
+        else:
+            raw_items = payload
+
+        paths: List[pathlib.Path] = []
+
+        def _collect(item: object | None) -> None:
+            if item is None:
+                return
+            if isinstance(item, (list, tuple, set, frozenset)):
+                for value in item:
+                    _collect(value)
+                return
+            if isinstance(item, pathlib.Path):
+                paths.append(item)
+            elif isinstance(item, Gio.File):
+                local_path = item.get_path()
+                if local_path:
+                    paths.append(pathlib.Path(local_path))
+            elif isinstance(item, str):
+                paths.append(pathlib.Path(item))
+
+        _collect(raw_items)
+
+        if not paths:
+            pane.show_toast("No files selected for upload")
+            return
+
+        available_paths: List[pathlib.Path] = []
+        missing: List[pathlib.Path] = []
+        for candidate in paths:
+            try:
+                if candidate.exists():
+                    available_paths.append(candidate)
+                else:
+                    missing.append(candidate)
+            except OSError:
+                missing.append(candidate)
+
+        if missing and not available_paths:
+            pane.show_toast("Selected items are not accessible")
+            return
+        if missing and available_paths:
+            pane.show_toast(f"Skipping inaccessible items: {missing[0].name}")
+
+        # Prepare list of files to transfer for conflict checking
+        files_to_transfer = []
+        for path_obj in available_paths:
+            destination = posixpath.join(remote_root or "/", path_obj.name)
+            files_to_transfer.append((str(path_obj), destination))
+        
+        # Check for conflicts and handle accordingly  
+        def _proceed_with_upload(resolved_files: List[Tuple[str, str]]) -> None:
+            if not resolved_files:
+                logger.warning("_proceed_with_upload: No files to upload")
+                return
+            
+            # Check if manager is still available and connected
+            if self._manager is None:
+                pane.show_toast("Upload failed: Connection lost")
+                logger.error("_proceed_with_upload: Manager is None")
+                return
+            
+            # Check if SFTP connection is still valid
+            try:
+                with self._manager._lock:
+                    if self._manager._sftp is None:
+                        pane.show_toast("Upload failed: Connection closed. Please reconnect.")
+                        logger.error("_proceed_with_upload: SFTP connection is None")
+                        return
+            except Exception as e:
+                logger.error(f"_proceed_with_upload: Error checking connection: {e}")
+                pane.show_toast(f"Upload failed: {e!s}")
+                return
+            
+            total_files = len(resolved_files)
+            logger.info(
+                "Starting upload of %d file%s",
+                total_files, "" if total_files == 1 else "s",
+            )
+            
+            for local_path_str, destination in resolved_files:
+                path_obj = pathlib.Path(local_path_str)
+
+                try:
+                    logger.debug(f"_proceed_with_upload: Starting upload of {path_obj.name}")
+                    if path_obj.is_dir():
+                        future = self._manager.upload_directory(path_obj, destination)
+                    else:
+                        future = self._manager.upload(path_obj, destination)
+
+                    # Show progress dialog for upload (pass total_files for multi-file support)
+                    self._show_progress_dialog(
+                        "upload", path_obj.name, future,
+                        total_files=total_files,
+                        source_path=str(path_obj),
+                        destination_path=destination,
+                    )
+                    self._attach_refresh(
+                        future,
+                        refresh_remote=target_pane,
+                        highlight_name=path_obj.name,
+                    )
+                    if move_sources_set and path_obj.resolve() in move_sources_set:
+                        cleanup_dir = move_source_dir or str(path_obj.parent)
+                        self._schedule_local_move_cleanup(future, path_obj, cleanup_dir)
+                except Exception as e:
+                    error_msg = str(e)
+                    logger.error(f"_proceed_with_upload: Error uploading {path_obj.name}: {error_msg}", exc_info=True)
+                    pane.show_toast(f"Error uploading {path_obj.name}: {error_msg}")
+
+        self._check_file_conflicts(files_to_transfer, "upload", _proceed_with_upload)
+
+    def _op_download(self, pane, payload, user_data=None) -> None:
+        logger.debug("=== DOWNLOAD OPERATION CALLED ===")
+        logger.debug("Payload: %s", payload)
+
+        if pane is self._left_pane and payload.get("entries"):
+            remote_pane = getattr(self, "_right_pane", None)
+            if isinstance(remote_pane, FilePane):
+                pane = remote_pane
+
+        move_remote_sources: List[str] = []
+        move_remote_pane: Optional[FilePane] = None
+        if isinstance(user_data, dict):
+            move_remote_sources = list(user_data.get("move_remote_sources") or [])
+            move_remote_pane = user_data.get("move_remote_pane")
+        move_remote_set = set(move_remote_sources)
+
+        entries = payload.get("entries") or []
+        directory = payload.get("directory")
+        logger.debug("Entries to download: %s", [e.name for e in entries])
+        logger.debug("Directory: %s", directory)
+        if not directory:
+            if pane is self._right_pane:
+                directory = pane.toolbar.path_entry.get_text() or "/"
+            else:
                 remote_pane = getattr(self, "_right_pane", None)
                 if isinstance(remote_pane, FilePane):
-                    pane = remote_pane
-
-            move_remote_sources: List[str] = []
-            move_remote_pane: Optional[FilePane] = None
-            if isinstance(user_data, dict):
-                move_remote_sources = list(user_data.get("move_remote_sources") or [])
-                move_remote_pane = user_data.get("move_remote_pane")
-            move_remote_set = set(move_remote_sources)
-
-            entries = payload.get("entries") or []
-            directory = payload.get("directory")
-            logger.debug("Entries to download: %s", [e.name for e in entries])
-            logger.debug("Directory: %s", directory)
-            if not directory:
-                if pane is self._right_pane:
-                    directory = pane.toolbar.path_entry.get_text() or "/"
+                    directory = remote_pane.toolbar.path_entry.get_text() or "/"
                 else:
-                    remote_pane = getattr(self, "_right_pane", None)
-                    if isinstance(remote_pane, FilePane):
-                        directory = remote_pane.toolbar.path_entry.get_text() or "/"
+                    directory = "/"
+        destination_base = payload.get("destination")
+
+        if not entries or destination_base is None:
+            pane.show_toast("Invalid download request")
+            return
+
+        if not isinstance(destination_base, pathlib.Path):
+            destination_base = pathlib.Path(destination_base)
+
+        # Prepare list of files to transfer for conflict checking
+        files_to_transfer = []
+        for entry in entries:
+            source = posixpath.join(directory or "/", entry.name)
+            target_path = destination_base / entry.name
+            files_to_transfer.append((source, str(target_path)))
+        
+        # Check for conflicts and handle accordingly
+        def _proceed_with_download(resolved_files: List[Tuple[str, str]]) -> None:
+            total_files = len(resolved_files)
+            for idx, (source, target_path_str) in enumerate(resolved_files):
+                target_path = pathlib.Path(target_path_str)
+                entry_name = os.path.basename(target_path_str)
+
+                # Find the original entry to check if it's a directory
+                entry_is_dir = False
+                for entry in entries:
+                    if entry.name == entry_name:
+                        entry_is_dir = entry.is_dir
+                        break
+                
+                try:
+                    if entry_is_dir:
+                        future = self._manager.download_directory(source, target_path)
                     else:
-                        directory = "/"
-            destination_base = payload.get("destination")
-
-            if not entries or destination_base is None:
-                pane.show_toast("Invalid download request")
-                return
-
-            if not isinstance(destination_base, pathlib.Path):
-                destination_base = pathlib.Path(destination_base)
-
-            # Prepare list of files to transfer for conflict checking
-            files_to_transfer = []
-            for entry in entries:
-                source = posixpath.join(directory or "/", entry.name)
-                target_path = destination_base / entry.name
-                files_to_transfer.append((source, str(target_path)))
-            
-            # Check for conflicts and handle accordingly
-            def _proceed_with_download(resolved_files: List[Tuple[str, str]]) -> None:
-                total_files = len(resolved_files)
-                for idx, (source, target_path_str) in enumerate(resolved_files):
-                    target_path = pathlib.Path(target_path_str)
-                    entry_name = os.path.basename(target_path_str)
-
-                    # Find the original entry to check if it's a directory
-                    entry_is_dir = False
-                    for entry in entries:
-                        if entry.name == entry_name:
-                            entry_is_dir = entry.is_dir
-                            break
-                    
-                    try:
-                        if entry_is_dir:
-                            future = self._manager.download_directory(source, target_path)
-                        else:
-                            future = self._manager.download(source, target_path)
-                        # Pass total_files so dialog can be reused for multiple files
-                        self._show_progress_dialog(
-                            "download", entry_name, future,
-                            total_files=total_files,
-                            source_path=source,
-                            destination_path=str(target_path),
-                        )
-                        self._attach_refresh(
+                        future = self._manager.download(source, target_path)
+                    # Pass total_files so dialog can be reused for multiple files
+                    self._show_progress_dialog(
+                        "download", entry_name, future,
+                        total_files=total_files,
+                        source_path=source,
+                        destination_path=str(target_path),
+                    )
+                    self._attach_refresh(
+                        future,
+                        refresh_local_path=str(destination_base),
+                        highlight_name=entry_name,
+                    )
+                    if move_remote_set and source in move_remote_set:
+                        self._schedule_remote_move_cleanup(
                             future,
-                            refresh_local_path=str(destination_base),
-                            highlight_name=entry_name,
+                            source,
+                            move_remote_pane or pane,
                         )
-                        if move_remote_set and source in move_remote_set:
-                            self._schedule_remote_move_cleanup(
-                                future,
-                                source,
-                                move_remote_pane or pane,
-                            )
-                    except Exception as e:
-                        pane.show_toast(f"Error downloading {entry_name}: {e!s}")
+                except Exception as e:
+                    pane.show_toast(f"Error downloading {entry_name}: {e!s}")
 
-            self._check_file_conflicts(files_to_transfer, "download", _proceed_with_download)
+        self._check_file_conflicts(files_to_transfer, "download", _proceed_with_download)
+
 
 
     def _on_window_resize(self, window, pspec) -> None:

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -405,1691 +405,1729 @@ class PreferencesWindow(Adw.Dialog):
                 title = row.get_title() or ""
                 self._update_header_title(title)
     
+    def _build_terminal_preferences_page(self):
+        """Build the Terminal preferences page."""
+        # Create Terminal preferences page
+        terminal_page = Adw.PreferencesPage()
+        terminal_page.set_title(_("Terminal"))
+        terminal_page.set_icon_name("utilities-terminal-symbolic")
+
+        # Terminal appearance group
+        appearance_group = Adw.PreferencesGroup(title=_("Appearance"))
+
+        # Font selection row
+        self.font_row = Adw.ActionRow()
+        self.font_row.set_title(_("Font"))
+        current_font = self.config.get_setting('terminal.font', 'Monospace 12')
+        self.font_row.set_subtitle(current_font)
+
+        font_button = Gtk.Button()
+        font_button.set_label(_("Choose"))
+        font_button.set_valign(Gtk.Align.CENTER)
+        font_button.connect('clicked', self.on_font_button_clicked)
+        self.font_row.add_suffix(font_button)
+
+        appearance_group.add(self.font_row)
+
+        # Terminal color scheme
+        self.color_scheme_row = Adw.ComboRow()
+        self.color_scheme_row.set_title(_("Color Scheme"))
+        self.color_scheme_row.set_subtitle(_("Terminal color theme"))
+
+        # Names come straight from Config.terminal_themes (single source of truth)
+        themes = getattr(self.config, 'terminal_themes', {}) or {}
+        color_schemes = Gtk.StringList()
+        for key in SCHEME_KEYS:
+            color_schemes.append(themes.get(key, {}).get('name', key))
+        self.color_scheme_row.set_model(color_schemes)
+
+        # Select the saved scheme; fall back to the first entry if unknown
+        current_scheme_key = self.config.get_setting('terminal.theme', 'default')
+        try:
+            current_index = SCHEME_KEYS.index(current_scheme_key)
+        except ValueError:
+            current_index = 0
+            self.config.set_setting('terminal.theme', SCHEME_KEYS[0])
+        self.color_scheme_row.set_selected(current_index)
+
+        self.color_scheme_row.connect('notify::selected', self.on_color_scheme_changed)
+
+        appearance_group.add(self.color_scheme_row)
+
+        self._initialize_encoding_selector(appearance_group)
+
+        # Color scheme preview
+        preview_group = Adw.PreferencesGroup(title=_("Preview"))
+        preview_group.set_margin_top(18)  # Add more spacing above "Preview" label
+
+        # Create preview terminal widget
+        self.color_preview_terminal = Gtk.DrawingArea()
+        self.color_preview_terminal.set_draw_func(self.draw_color_preview)
+        self.color_preview_terminal.set_size_request(400, 120)
+        self.color_preview_terminal.add_css_class("terminal-preview")
+
+        # Create a standard Adwaita container with rounded corners
+        preview_container = Adw.Bin()
+        preview_container.add_css_class("card")
+        preview_container.set_margin_top(6)  # Reduce spacing between label and preview
+
+        # Add some margin around the preview
+        preview_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        preview_box.set_margin_top(12)
+        preview_box.set_margin_bottom(12)
+        preview_box.set_margin_start(12)
+        preview_box.set_margin_end(12)
+        preview_box.append(self.color_preview_terminal)
+
+        preview_container.set_child(preview_box)
+        preview_group.add(preview_container)
+        appearance_group.add(preview_group)
+        terminal_page.add(appearance_group)
+
+        # Terminal backend selection group
+        backend_group = Adw.PreferencesGroup(title=_("Backend"))
+
+        # Build backend choices
+        self._backend_choice_data = self._build_backend_choices()
+
+        # Create combo row for backend selection
+        self.backend_row = Adw.ComboRow()
+        self.backend_row.set_title(_("Terminal Backend"))
+        self.backend_row.set_subtitle(_("Choose the terminal rendering backend"))
+
+        # Create model from choices
+        backend_model = Gtk.StringList()
+        for choice in self._backend_choice_data:
+            backend_model.append(choice['label'])
+        self.backend_row.set_model(backend_model)
+
+        # Set current backend
+        current_backend = self.config.get_setting('terminal.backend', 'vte')
+        # Reset to VTE if pyxterm is configured on macOS (not supported)
+        if is_macos() and current_backend and current_backend.lower() == 'pyxterm':
+            current_backend = 'vte'
+            self.config.set_setting('terminal.backend', 'vte')
+        current_index = 0
+        for i, choice in enumerate(self._backend_choice_data):
+            if choice['id'] == current_backend:
+                current_index = i
+                break
+        self.backend_row.set_selected(current_index)
+        self._backend_last_valid_index = current_index
+        self._update_backend_row_subtitle(current_index)
+
+        # Connect change handler
+        self.backend_row.connect('notify::selected', self._on_backend_row_changed)
+
+        backend_group.add(self.backend_row)
+        terminal_page.add(backend_group)
+
+        keyboard_group = Adw.PreferencesGroup(title=_("Keyboard"))
+
+        self.pass_through_switch = Adw.SwitchRow()
+        self.pass_through_switch.set_title(_("Terminal Shortcut Pass-through"))
+        self.pass_through_switch.set_subtitle(
+            _("Disable all keyboard shortcuts, pass all key events directly to terminal")
+        )
+        pass_through_active = bool(self.config.get_setting('terminal.pass_through_mode', False))
+        self._pass_through_enabled = pass_through_active
+        self.pass_through_switch.set_active(pass_through_active)
+        self.pass_through_switch.connect('notify::active', self.on_pass_through_mode_toggled)
+        keyboard_group.add(self.pass_through_switch)
+
+        self.autocomplete_switch = Adw.SwitchRow()
+        self.autocomplete_switch.set_title(_("Command autocomplete"))
+        self.autocomplete_switch.set_subtitle(
+            _("Suggest commands from history and snippets as you type (embedded terminal)")
+        )
+        self.autocomplete_switch.set_active(
+            bool(self.config.get_setting('terminal.autocomplete', True))
+        )
+        self.autocomplete_switch.connect('notify::active', self.on_autocomplete_toggled)
+        keyboard_group.add(self.autocomplete_switch)
+
+        self.autocomplete_remote_switch = Adw.SwitchRow()
+        self.autocomplete_remote_switch.set_title(_("Suggest from remote history"))
+        self.autocomplete_remote_switch.set_subtitle(
+            _("Also fetch the remote host's shell history over SSH (applies to new tabs)")
+        )
+        self.autocomplete_remote_switch.set_active(
+            bool(self.config.get_setting('terminal.autocomplete_remote', False))
+        )
+        self.autocomplete_remote_switch.connect(
+            'notify::active', self.on_autocomplete_remote_toggled)
+        keyboard_group.add(self.autocomplete_remote_switch)
+
+        terminal_page.add(keyboard_group)
+
+        # Mouse behavior group
+        mouse_group = Adw.PreferencesGroup(title=_("Mouse"))
+
+        self.copy_on_select_switch = Adw.SwitchRow()
+        self.copy_on_select_switch.set_title(_("Copy on selection"))
+        self.copy_on_select_switch.set_subtitle(
+            _("Automatically copy selected text to the clipboard")
+        )
+        copy_on_select_active = bool(self.config.get_setting('terminal.copy_on_select', False))
+        self.copy_on_select_switch.set_active(copy_on_select_active)
+        self.copy_on_select_switch.connect('notify::active', self.on_copy_on_select_toggled)
+        mouse_group.add(self.copy_on_select_switch)
+
+        self.paste_on_right_click_switch = Adw.SwitchRow()
+        self.paste_on_right_click_switch.set_title(_("Paste on right-click"))
+        self.paste_on_right_click_switch.set_subtitle(
+            _("Right-click pastes; Shift+right-click opens the menu")
+        )
+        paste_on_right_click_active = bool(self.config.get_setting('terminal.paste_on_right_click', False))
+        self.paste_on_right_click_switch.set_active(paste_on_right_click_active)
+        self.paste_on_right_click_switch.connect(
+            'notify::active', self.on_paste_on_right_click_toggled
+        )
+        mouse_group.add(self.paste_on_right_click_switch)
+
+        terminal_page.add(mouse_group)
+
+        # Preferred Terminal group (shown when external terminals are available)
+        if not should_hide_external_terminal_options():
+            terminal_choice_group = Adw.PreferencesGroup(title=_("Preferred Terminal"))
+
+            # Radio buttons for terminal choice
+            self.builtin_terminal_radio = Gtk.CheckButton(label=_("Use built-in terminal"))
+            self.builtin_terminal_radio.set_can_focus(True)
+            self.external_terminal_radio = Gtk.CheckButton(label=_("Use other terminal"))
+            self.external_terminal_radio.set_can_focus(True)
+
+            # Make them behave like radio buttons
+            self.external_terminal_radio.set_group(self.builtin_terminal_radio)
+
+            # Set current preference
+            use_external = self.config.get_setting('use-external-terminal', False)
+            if use_external:
+                self.external_terminal_radio.set_active(True)
+            else:
+                self.builtin_terminal_radio.set_active(True)
+
+            # Connect radio button changes
+            self.builtin_terminal_radio.connect('toggled', self.on_terminal_choice_changed)
+            self.external_terminal_radio.connect('toggled', self.on_terminal_choice_changed)
+
+            # Add radio buttons to group
+            terminal_choice_group.add(self.builtin_terminal_radio)
+            terminal_choice_group.add(self.external_terminal_radio)
+
+            # External terminal dropdown and custom path
+            self.external_terminal_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            self.external_terminal_box.set_margin_start(24)
+            self.external_terminal_box.set_margin_top(6)
+            self.external_terminal_box.set_margin_bottom(6)
+
+            # Terminal dropdown
+            self.terminal_dropdown = Gtk.DropDown()
+            self.terminal_dropdown.set_can_focus(True)
+
+            # Populate dropdown with available terminals
+            self._populate_terminal_dropdown()
+
+            # Set current selection
+            current_terminal = self.config.get_setting('external-terminal', 'gnome-terminal')
+
+            # Connect dropdown changes
+            self.terminal_dropdown.connect('notify::selected', self.on_terminal_dropdown_changed)
+
+            # Custom path entry (initially hidden)
+            self.custom_terminal_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            self.custom_terminal_entry = Gtk.Entry()
+            self.custom_terminal_entry.set_placeholder_text("/usr/bin/gnome-terminal")
+            self.custom_terminal_entry.set_can_focus(True)
+
+            # Set current custom path if any
+            custom_path = self.config.get_setting('custom-terminal-path', '')
+            if custom_path:
+                self.custom_terminal_entry.set_text(custom_path)
+
+            # Connect custom path changes
+            self.custom_terminal_entry.connect('changed', self.on_custom_terminal_path_changed)
+
+            self.custom_terminal_box.append(self.custom_terminal_entry)
+
+            # Add dropdown and custom path to box
+            self.external_terminal_box.append(self.terminal_dropdown)
+            self.external_terminal_box.append(self.custom_terminal_box)
+
+            # Now set the dropdown selection and show/hide custom path entry
+            self._set_terminal_dropdown_selection(current_terminal)
+
+            # Initial sensitivity will be set by radio button state
+
+            # Add to group
+            terminal_choice_group.add(self.external_terminal_box)
+
+            # Set initial sensitivity based on radio button state
+            self.external_terminal_box.set_sensitive(self.external_terminal_radio.get_active())
+
+            terminal_page.add(terminal_choice_group)
+
+        return terminal_page
+
+    def _build_groups_preferences_page(self):
+        """Build the Groups preferences page."""
+        # Create Groups preferences page
+        groups_page = Adw.PreferencesPage()
+        groups_page.set_title(_("Groups"))
+        groups_page.set_icon_name("folder-open-symbolic")
+
+        group_appearance_group = Adw.PreferencesGroup(title=_("Group Appearance"))
+
+        # Sidebar group color display mode
+        self._group_color_display_values = ['fill', 'badge', 'bar', 'dot']
+        self.group_color_display_row = Adw.ComboRow()
+        self.group_color_display_row.set_title(_("Sidebar Group Colors"))
+        self.group_color_display_row.set_subtitle(
+            _("Choose how group colors are shown in the sidebar")
+        )
+
+        color_display_options = Gtk.StringList()
+        color_display_options.append("Colored Rows")
+        color_display_options.append("Color Badges")
+        color_display_options.append("Accent Bars")
+        color_display_options.append("Color Dots")
+        self.group_color_display_row.set_model(color_display_options)
+
+        current_mode = 'fill'
+        try:
+            current_mode = str(
+                self.config.get_setting('ui.group_color_display', 'fill')
+            ).lower()
+        except Exception:
+            current_mode = 'fill'
+        if current_mode not in self._group_color_display_values:
+            current_mode = 'fill'
+
+        self._group_display_sync = True
+        try:
+            self.group_color_display_row.set_selected(
+                self._group_color_display_values.index(current_mode)
+            )
+        finally:
+            self._group_display_sync = False
+
+        self.group_color_display_row.connect(
+            'notify::selected', self.on_group_color_display_changed
+        )
+
+        group_appearance_group.add(self.group_color_display_row)
+
+        # Toggle for extending group colors to member connection rows
+        self.child_rows_color_row = Adw.SwitchRow()
+        self.child_rows_color_row.set_title(_("Use Group Color for Child Rows"))
+        self.child_rows_color_row.set_subtitle(
+            _("Apply the group's color to its connection rows as well")
+        )
+        try:
+            child_rows_pref = bool(
+                self.config.get_setting('ui.group_color_child_rows', False)
+            )
+        except Exception:
+            child_rows_pref = False
+        self.child_rows_color_row.set_active(child_rows_pref)
+        self.child_rows_color_row.connect(
+            'notify::active', self.on_group_color_child_rows_toggled
+        )
+        group_appearance_group.add(self.child_rows_color_row)
+
+        # Toggle for coloring tabs using group colors
+        self.tab_group_color_row = Adw.SwitchRow()
+        self.tab_group_color_row.set_title(_("Show Group Color in Tabs"))
+        self.tab_group_color_row.set_subtitle(
+            _("Show the selected group's color badge in the terminal tabs")
+        )
+        try:
+            tab_pref = bool(
+                self.config.get_setting('ui.use_group_color_in_tab', False)
+            )
+        except Exception:
+            tab_pref = False
+        self.tab_group_color_row.set_active(tab_pref)
+        self.tab_group_color_row.connect(
+            'notify::active', self.on_use_group_color_in_tab_toggled
+        )
+        group_appearance_group.add(self.tab_group_color_row)
+
+        # Toggle for applying group colors inside terminals
+        self.terminal_group_color_row = Adw.SwitchRow()
+        self.terminal_group_color_row.set_title(_("Use Group Color in Terminals"))
+        self.terminal_group_color_row.set_subtitle(
+            _("Use parent group's color as terminal background")
+        )
+        try:
+            terminal_pref = bool(
+                self.config.get_setting('ui.use_group_color_in_terminal', False)
+            )
+        except Exception:
+            terminal_pref = False
+        self.terminal_group_color_row.set_active(terminal_pref)
+        self.terminal_group_color_row.connect(
+            'notify::active', self.on_use_group_color_in_terminal_toggled
+        )
+        group_appearance_group.add(self.terminal_group_color_row)
+
+
+        groups_page.add(group_appearance_group)
+
+        # Group display layout section (shown after appearance options)
+        group_layout_group = Adw.PreferencesGroup(title=_("Group Layout"))
+
+        self._group_display_preview_rows = {}
+        _install_group_display_preview_css()
+
+        self._group_display_modes = ['fullwidth', 'nested']
+        self.group_display_toggle_row = Adw.ActionRow()
+        self.group_display_toggle_row.set_title(_("Group Display"))
+        self.group_display_toggle_row.set_subtitle(
+            _("Choose how grouped connections appear in the sidebar")
+        )
+        self.group_display_toggle_row.set_activatable(False)
+        try:
+            self.group_display_toggle_row.set_focusable(False)
+        except Exception:
+            pass
+
+        self.group_display_toggle_group = None
+        self._group_display_toggle_controller = None
+
+        if hasattr(Adw, 'ToggleGroup') and hasattr(Adw.ToggleGroup, 'new'):
+            toggle_group = Adw.ToggleGroup.new()
+            toggle_group.set_orientation(Gtk.Orientation.HORIZONTAL)
+            toggle_group.add_css_class('linked')
+            toggle_group.set_hexpand(True)
+            try:
+                toggle_group.set_homogeneous(True)
+            except Exception:
+                pass
+
+            self.group_display_toggle_fullwidth = Adw.Toggle.new()
+            self.group_display_toggle_fullwidth.props.name = 'fullwidth'
+            self.group_display_toggle_fullwidth.set_label(_('Fullwidth'))
+
+            self.group_display_toggle_nested = Adw.Toggle.new()
+            self.group_display_toggle_nested.props.name = 'nested'
+            self.group_display_toggle_nested.set_label(_('Nested'))
+
+            toggle_group.add(self.group_display_toggle_fullwidth)
+            toggle_group.add(self.group_display_toggle_nested)
+            self.group_display_toggle_row.set_child(toggle_group)
+
+            self.group_display_toggle_group = toggle_group
+            self._group_display_toggle_controller = toggle_group
+        else:
+            fallback_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+            fallback_box.add_css_class('linked')
+            fallback_box.set_hexpand(True)
+
+            self.group_display_toggle_fullwidth = Gtk.ToggleButton(label=_('Fullwidth'))
+            self.group_display_toggle_fullwidth.props.name = 'fullwidth'
+            self.group_display_toggle_fullwidth.set_hexpand(True)
+
+            self.group_display_toggle_nested = Gtk.ToggleButton(label=_('Nested'))
+            self.group_display_toggle_nested.props.name = 'nested'
+            self.group_display_toggle_nested.set_hexpand(True)
+
+            fallback_box.append(self.group_display_toggle_fullwidth)
+            fallback_box.append(self.group_display_toggle_nested)
+            self.group_display_toggle_row.set_child(fallback_box)
+
+            buttons = {
+                'fullwidth': self.group_display_toggle_fullwidth,
+                'nested': self.group_display_toggle_nested,
+            }
+            self._group_display_toggle_controller = _GroupDisplayToggleFallback(buttons)
+
+        current_display_mode = 'nested'
+        try:
+            current_display_mode = str(
+                self.config.get_setting('ui.group_row_display', 'nested')
+            ).lower()
+        except Exception:
+            current_display_mode = 'nested'
+        if current_display_mode not in self._group_display_modes:
+            current_display_mode = 'nested'
+
+        self._group_display_toggle_sync = True
+        try:
+            if self._group_display_toggle_controller:
+                self._group_display_toggle_controller.set_active_name(current_display_mode)
+        finally:
+            self._group_display_toggle_sync = False
+
+        if isinstance(self._group_display_toggle_controller, _GroupDisplayToggleFallback):
+            self._group_display_toggle_controller.connect(
+                self.on_group_row_display_changed
+            )
+        elif self.group_display_toggle_group is not None:
+            self.group_display_toggle_group.connect(
+                'notify::active-name', self.on_group_row_display_changed
+            )
+
+        group_layout_group.add(self.group_display_toggle_row)
+
+        # Preview showing both layout styles
+        self.group_display_preview_row = Adw.ActionRow()
+        self.group_display_preview_row.set_title(_("Layout Preview"))
+        self.group_display_preview_row.set_activatable(False)
+        try:
+            self.group_display_preview_row.set_focusable(False)
+        except Exception:
+            pass
+
+        preview_stack = Gtk.Stack()
+        preview_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
+        preview_stack.set_transition_duration(150)
+
+        preview_stack.set_margin_top(4)
+        preview_stack.set_margin_bottom(4)
+
+        preview_fullwidth_wrapper, preview_fullwidth_row = self._create_group_display_preview(
+            'fullwidth', 'Fullwidth'
+        )
+        preview_nested_wrapper, preview_nested_row = self._create_group_display_preview(
+            'nested', 'Nested'
+        )
+
+        preview_stack.add_named(preview_fullwidth_wrapper, 'fullwidth')
+        preview_stack.add_named(preview_nested_wrapper, 'nested')
+
+        self.group_display_preview_row.set_child(preview_stack)
+        self._group_display_preview_rows = {
+            'fullwidth': preview_fullwidth_row,
+            'nested': preview_nested_row,
+        }
+        self._group_display_preview_stack = preview_stack
+
+        self._update_group_display_preview(current_display_mode)
+
+        group_layout_group.add(self.group_display_preview_row)
+        groups_page.add(group_layout_group)
+
+        return groups_page
+
+    def _build_interface_preferences_page(self):
+        """Build the Interface preferences page."""
+        # Create Interface preferences page
+        interface_page = Adw.PreferencesPage()
+        interface_page.set_title(_("Interface"))
+        interface_page.set_icon_name("applications-graphics-symbolic")
+
+        # Language — first group on the page. Always shown: "System Default"
+        # plus every catalogue that can actually be loaded (English included,
+        # it being the source language and the way back from a translation).
+        language_group = Adw.PreferencesGroup(title=_("Language"))
+
+        self.language_row = Adw.ComboRow()
+        self.language_row.set_title(_("Interface Language"))
+        self.language_row.set_subtitle(_("Takes effect after restarting SSH Pilot"))
+
+        language_names = Gtk.StringList()
+        language_names.append(_("System Default"))
+        self._language_codes = ['']
+        for code, display_name in available_languages():
+            language_names.append(display_name)
+            self._language_codes.append(code)
+        self.language_row.set_model(language_names)
+
+        saved_language = self.config.get_setting('ui.language', '')
+        if saved_language and saved_language not in self._language_codes:
+            # The catalogue went away (uninstalled, or the setting came from
+            # another machine). Showing "System Default" while the config
+            # still names the missing language would keep applying it at
+            # every start, so clear it to match what the row now says.
+            logger.info("Interface language %r is no longer installed; "
+                        "falling back to the system default", saved_language)
+            self.config.set_setting('ui.language', '')
+            saved_language = ''
+        self.language_row.set_selected(
+            self._language_codes.index(saved_language)
+            if saved_language in self._language_codes else 0)
+
+        self.language_row.connect('notify::selected', self.on_language_changed)
+        language_group.add(self.language_row)
+        interface_page.add(language_group)
+
+        # App startup behavior
+        startup_group = Adw.PreferencesGroup(title=_("App Startup"))
+
+        # Radio buttons for startup behavior
+        self.terminal_startup_radio = Gtk.CheckButton(label=_("Show Terminal"))
+        self.terminal_startup_radio.set_can_focus(True)
+        self.welcome_startup_radio = Gtk.CheckButton(label=_("Show Start Page"))
+        self.welcome_startup_radio.set_can_focus(True)
+        self.previous_session_startup_radio = Gtk.CheckButton(label=_("Restore previous session"))
+        self.previous_session_startup_radio.set_can_focus(True)
+        self.saved_session_startup_radio = Gtk.CheckButton(label=_("Open a saved session"))
+        self.saved_session_startup_radio.set_can_focus(True)
+
+        # Make them behave like radio buttons
+        self.welcome_startup_radio.set_group(self.terminal_startup_radio)
+        self.previous_session_startup_radio.set_group(self.terminal_startup_radio)
+        self.saved_session_startup_radio.set_group(self.terminal_startup_radio)
+
+        # Set current preference (default to welcome/start page)
+        startup_behavior = self.config.get_setting('app-startup-behavior', 'welcome')
+        if startup_behavior == 'terminal':
+            self.terminal_startup_radio.set_active(True)
+        elif startup_behavior == 'previous-session':
+            self.previous_session_startup_radio.set_active(True)
+        elif startup_behavior == 'saved-session':
+            self.saved_session_startup_radio.set_active(True)
+        else:
+            self.welcome_startup_radio.set_active(True)
+
+        # Selector for which saved session to open on startup. This is built
+        # as a plain (non-row) widget so it stacks directly below the
+        # "Open a saved session" radio rather than being hoisted into the
+        # group's internal list box above the bare check buttons.
+        self._startup_session_names = []
+        try:
+            session_manager = getattr(self.parent_window, 'session_manager', None)
+            if session_manager is not None:
+                self._startup_session_names = list(session_manager.list_session_names())
+        except Exception:
+            self._startup_session_names = []
+
+        session_model = Gtk.StringList()
+        if self._startup_session_names:
+            for name in self._startup_session_names:
+                session_model.append(name)
+        else:
+            session_model.append("(no saved sessions)")
+
+        self.startup_session_row = Gtk.DropDown()
+        self.startup_session_row.set_model(session_model)
+        self.startup_session_row.set_valign(Gtk.Align.CENTER)
+
+        self.startup_session_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        self.startup_session_box.set_margin_start(24)
+        self.startup_session_box.set_margin_top(2)
+        session_label = Gtk.Label(label=_("Saved session"))
+        session_label.set_xalign(0)
+        session_label.set_hexpand(True)
+        self.startup_session_box.append(session_label)
+        self.startup_session_box.append(self.startup_session_row)
+
+        selected_session = self.config.get_setting('app-startup-session-name', '')
+        if selected_session in self._startup_session_names:
+            self.startup_session_row.set_selected(
+                self._startup_session_names.index(selected_session)
+            )
+        self.startup_session_box.set_sensitive(
+            bool(self._startup_session_names)
+            and self.saved_session_startup_radio.get_active()
+        )
+
+        # Connect radio button changes
+        self.terminal_startup_radio.connect('toggled', self.on_startup_behavior_changed)
+        self.welcome_startup_radio.connect('toggled', self.on_startup_behavior_changed)
+        self.previous_session_startup_radio.connect('toggled', self.on_startup_behavior_changed)
+        self.saved_session_startup_radio.connect('toggled', self.on_startup_behavior_changed)
+        self.startup_session_row.connect('notify::selected', self.on_startup_session_changed)
+
+        # Add radio buttons to group, with the saved-session selector placed
+        # immediately below its corresponding radio option.
+        startup_group.add(self.terminal_startup_radio)
+        startup_group.add(self.welcome_startup_radio)
+        startup_group.add(self.previous_session_startup_radio)
+        startup_group.add(self.saved_session_startup_radio)
+        startup_group.add(self.startup_session_box)
+
+        interface_page.add(startup_group)
+
+        # Appearance group
+        interface_appearance_group = Adw.PreferencesGroup(title=_("Appearance"))
+
+        # Theme selection
+        self.theme_row = Adw.ComboRow()
+        self.theme_row.set_title(_("Application Theme"))
+        self.theme_row.set_subtitle(_("Choose light, dark, or follow system theme"))
+
+        themes = Gtk.StringList()
+        themes.append("Follow System")
+        themes.append("Light")
+        themes.append("Dark")
+        self.theme_row.set_model(themes)
+
+        # Load saved theme preference
+        saved_theme = self.config.get_setting('app-theme', 'default')
+        theme_mapping = {'default': 0, 'light': 1, 'dark': 2}
+        self.theme_row.set_selected(theme_mapping.get(saved_theme, 0))
+
+        self.theme_row.connect('notify::selected', self.on_theme_changed)
+
+        interface_appearance_group.add(self.theme_row)
+
+
+        # Color overrides section
+        color_override_group = Adw.PreferencesGroup(title=_("Color Overrides"))
+        color_override_group.set_description(_("Override the accent color"))
+
+        # Accent color override
+        self.accent_color_row = Adw.ActionRow()
+        self.accent_color_row.set_title(_("Accent Color"))
+        self.accent_color_row.set_subtitle(_("Override the accent color for highlights"))
+
+        self.accent_color_button = Gtk.ColorButton()
+        self.accent_color_button.set_use_alpha(False)
+        self.accent_color_button.set_tooltip_text(_("Choose accent color"))
+        self.accent_color_button.set_valign(Gtk.Align.CENTER)
+        self.accent_color_button.set_size_request(60, 32)
+        self.accent_color_button.connect('color-set', self.on_accent_color_changed)
+        self.accent_color_row.add_suffix(self.accent_color_button)
+        color_override_group.add(self.accent_color_row)
+
+        # Reset colors button
+        reset_colors_row = Adw.ActionRow()
+        reset_colors_row.set_title(_("Reset to Default"))
+        reset_colors_row.set_subtitle(_("Remove the accent override and use the system accent"))
+
+        reset_button = Gtk.Button()
+        reset_button.set_label(_("Reset"))
+        reset_button.add_css_class("destructive-action")
+        reset_button.set_valign(Gtk.Align.CENTER)
+        reset_button.connect('clicked', self.on_reset_colors_clicked)
+        reset_colors_row.add_suffix(reset_button)
+        color_override_group.add(reset_colors_row)
+
+        interface_page.add(interface_appearance_group)
+        interface_page.add(color_override_group)
+
+        # Initialize color button states
+        self.refresh_color_buttons()
+
+        # Window group
+        window_group = Adw.PreferencesGroup(title=_("Window"))
+
+        # Remember window size switch
+        remember_size_switch = Adw.SwitchRow()
+        remember_size_switch.set_title(_("Remember Window Size"))
+        remember_size_switch.set_subtitle(_("Restore window size on startup"))
+        remember_size_switch.set_active(True)
+
+        window_group.add(remember_size_switch)
+        interface_page.add(window_group)
+
+        # Sidebar group (at bottom of Interface page)
+        sidebar_group = Adw.PreferencesGroup(title=_("Sidebar"))
+
+        # Maximum width slider
+        max_width_row = Adw.ActionRow()
+        max_width_row.set_title(_("Maximum Width"))
+
+        # Load saved value or use default
+        saved_max_width = self.config.get_setting('ui.max-sidebar-width', 280)
+
+        # Create a scale/slider for max width (100-800 sp)
+        max_width_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 100, 800, 10)
+        max_width_scale.set_draw_value(True)
+        max_width_scale.set_value_pos(Gtk.PositionType.RIGHT)
+        max_width_scale.set_size_request(200, -1)
+        max_width_scale.set_valign(Gtk.Align.CENTER)
+        max_width_scale.set_value(float(saved_max_width))
+
+        # Update subtitle with current value
+        def update_subtitle(value):
+            max_width_row.set_subtitle(
+                _("Adjust the maximum width of the sidebar ({width} sp)").format(width=int(value)))
+
+        update_subtitle(saved_max_width)
+
+        # Connect change handler
+        def on_max_width_changed(scale):
+            value = int(scale.get_value())
+            update_subtitle(value)
+            self.config.set_setting('ui.max-sidebar-width', value)
+            # Update main window if available
+            if self.parent_window and hasattr(self.parent_window, 'update_sidebar_max_width'):
+                self.parent_window.update_sidebar_max_width(value)
+
+        max_width_scale.connect('value-changed', on_max_width_changed)
+
+        max_width_row.add_suffix(max_width_scale)
+        sidebar_group.add(max_width_row)
+
+        flat_rows_switch = Adw.SwitchRow()
+        flat_rows_switch.set_title(_("Flat Sidebar Rows"))
+        flat_rows_switch.set_subtitle(
+            _("Use flat list rows instead of cards in the connection sidebar")
+        )
+        flat_rows_switch.set_active(
+            bool(self.config.get_setting('ui.sidebar_flat_rows', False))
+        )
+        flat_rows_switch.connect(
+            'notify::active', self.on_sidebar_flat_rows_changed
+        )
+        sidebar_group.add(flat_rows_switch)
+
+        # Display user@hostname toggle
+        show_user_hostname_switch = Adw.SwitchRow()
+        show_user_hostname_switch.set_title(_("Display user@hostname"))
+        show_user_hostname_switch.set_subtitle(_("Show username@hostname in connection rows"))
+        show_user_hostname_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_user_hostname', True)
+        )
+        show_user_hostname_switch.connect('notify::active', self.on_sidebar_show_user_hostname_changed)
+        sidebar_group.add(show_user_hostname_switch)
+
+        # Display connection count in groups toggle
+        show_group_count_switch = Adw.SwitchRow()
+        show_group_count_switch.set_title(_("Display Connection Count in Groups"))
+        show_group_count_switch.set_subtitle(_("Show the number of connections in each group"))
+        show_group_count_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_group_count', True)
+        )
+        show_group_count_switch.connect('notify::active', self.on_sidebar_show_group_count_changed)
+        sidebar_group.add(show_group_count_switch)
+
+        # Display connection status toggle
+        show_status_switch = Adw.SwitchRow()
+        show_status_switch.set_title(_("Display Connection Status"))
+        show_status_switch.set_subtitle(_("Show connection status indicator in connection rows"))
+        show_status_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_connection_status', True)
+        )
+        show_status_switch.connect('notify::active', self.on_sidebar_show_connection_status_changed)
+        sidebar_group.add(show_status_switch)
+
+        # Display port forwarding labels toggle
+        show_port_forwarding_switch = Adw.SwitchRow()
+        show_port_forwarding_switch.set_title(_("Display Port Forwarding Labels"))
+        show_port_forwarding_switch.set_subtitle(_("Show port forwarding indicators (L/R/D) in connection rows"))
+        show_port_forwarding_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_port_forwarding', True)
+        )
+        show_port_forwarding_switch.connect('notify::active', self.on_sidebar_show_port_forwarding_changed)
+        sidebar_group.add(show_port_forwarding_switch)
+
+        # Display connection icon toggle
+        show_connection_icon_switch = Adw.SwitchRow()
+        show_connection_icon_switch.set_title(_("Display Connection Icon"))
+        show_connection_icon_switch.set_subtitle(_("Show the computer icon in connection rows"))
+        show_connection_icon_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_connection_icon', True)
+        )
+        show_connection_icon_switch.connect('notify::active', self.on_sidebar_show_connection_icon_changed)
+        sidebar_group.add(show_connection_icon_switch)
+
+        # Display group icon toggle
+        show_group_icon_switch = Adw.SwitchRow()
+        show_group_icon_switch.set_title(_("Display Group Icon"))
+        show_group_icon_switch.set_subtitle(_("Show the folder icon in group rows"))
+        show_group_icon_switch.set_active(
+            self.config.get_setting('ui.sidebar_show_group_icon', True)
+        )
+        show_group_icon_switch.connect('notify::active', self.on_sidebar_show_group_icon_changed)
+        sidebar_group.add(show_group_icon_switch)
+
+        interface_page.add(sidebar_group)
+
+        # Sidebar behavior
+        sidebar_behavior_group = Adw.PreferencesGroup(title=_("Sidebar behavior"))
+
+        hide_on_startup_switch = Adw.SwitchRow()
+        hide_on_startup_switch.set_title(_("Hide Sidebar on Startup"))
+        hide_on_startup_switch.set_subtitle(_("Start with the sidebar collapsed"))
+        hide_on_startup_switch.set_active(
+            bool(self.config.get_setting('ui.sidebar_hide_on_startup', False))
+        )
+        hide_on_startup_switch.connect(
+            'notify::active',
+            lambda r, _p: self.config.set_setting('ui.sidebar_hide_on_startup', bool(r.get_active())),
+        )
+        sidebar_behavior_group.add(hide_on_startup_switch)
+
+        hide_on_terminal_switch = Adw.SwitchRow()
+        hide_on_terminal_switch.set_title(_("Hide When a Terminal Opens"))
+        hide_on_terminal_switch.set_subtitle(_("Collapse the sidebar when any session opens, including local terminals"))
+        hide_on_terminal_switch.set_active(
+            bool(self.config.get_setting('ui.sidebar_hide_on_terminal_open', False))
+        )
+        hide_on_terminal_switch.connect(
+            'notify::active',
+            lambda r, _p: self.config.set_setting('ui.sidebar_hide_on_terminal_open', bool(r.get_active())),
+        )
+        sidebar_behavior_group.add(hide_on_terminal_switch)
+
+        show_when_no_tabs_switch = Adw.SwitchRow()
+        show_when_no_tabs_switch.set_title(_("Show When No Tab Is Open"))
+        show_when_no_tabs_switch.set_subtitle(_("Reveal the sidebar when returning to the welcome screen"))
+        show_when_no_tabs_switch.set_active(
+            bool(self.config.get_setting('ui.sidebar_show_when_no_tabs', False))
+        )
+        show_when_no_tabs_switch.connect(
+            'notify::active',
+            lambda r, _p: self.config.set_setting('ui.sidebar_show_when_no_tabs', bool(r.get_active())),
+        )
+        sidebar_behavior_group.add(show_when_no_tabs_switch)
+
+        interface_page.add(sidebar_behavior_group)
+
+        # Header bar button visibility
+        headerbar_group = Adw.PreferencesGroup(title=_("Header Bar Buttons"))
+
+        def _add_headerbar_switch(title, subtitle, key, default=True):
+            row = Adw.SwitchRow()
+            row.set_title(title)
+            row.set_subtitle(subtitle)
+            row.set_active(bool(self.config.get_setting(key, default)))
+
+            def _on_toggled(r, _p, _k=key):
+                self.config.set_setting(_k, bool(r.get_active()))
+                if self.parent_window and hasattr(self.parent_window, 'update_headerbar_buttons'):
+                    self.parent_window.update_headerbar_buttons()
+
+            row.connect('notify::active', _on_toggled)
+            headerbar_group.add(row)
+
+        _add_headerbar_switch(
+            "Split View Button",
+            "Show the split-view button (the grid icon that starts a split view)",
+            'ui.headerbar_show_split_view',
+            default=False,
+        )
+        _add_headerbar_switch(
+            "Commands Button",
+            "Show the command snippets toggle button",
+            'ui.headerbar_show_commands',
+        )
+        _add_headerbar_switch(
+            "Theme Menu",
+            "Show the application theme menu beside the commands button",
+            'ui.headerbar_show_theme_toggle',
+        )
+        _add_headerbar_switch(
+            "Local Terminal Button",
+            "Show the button that opens a local terminal",
+            'ui.headerbar_show_local_terminal',
+        )
+
+        interface_page.add(headerbar_group)
+
+        # Tips group at the bottom of the Interface page. Lets users
+        # re-enable the terminal tips banner after dismissing it with
+        # "Don't show again".
+        tips_group = Adw.PreferencesGroup(title=_("Tips"))
+        show_tips_switch = Adw.SwitchRow()
+        show_tips_switch.set_title(_("Show Terminal Tips"))
+        show_tips_switch.set_subtitle(_("Show usage tips in a banner when a terminal opens"))
+        show_tips_switch.set_active(
+            bool(self.config.get_setting('terminal.show_tips', True))
+        )
+        show_tips_switch.connect('notify::active', self.on_show_tips_toggled)
+        tips_group.add(show_tips_switch)
+        interface_page.add(tips_group)
+
+        return interface_page
+
+    def _build_shortcuts_preferences_page(self):
+        """Build the Shortcuts preferences page."""
+        # Shortcuts page with inline editor
+        shortcuts_page = Adw.PreferencesPage()
+        shortcuts_page.set_title(_("Shortcuts"))
+        shortcuts_page.set_icon_name("preferences-desktop-keyboard-shortcuts-symbolic")
+
+        shortcuts_intro_group = Adw.PreferencesGroup(title=_("Keyboard Shortcuts"))
+
+        shortcuts_button_row = Adw.ActionRow()
+        shortcuts_button_row.set_title(_("Shortcut Overview"))
+        shortcuts_button_row.set_subtitle(_("Open the shortcuts window for a full reference"))
+
+        shortcuts_button = Gtk.Button(label=_("Open"))
+        try:
+            shortcuts_button.add_css_class("flat")
+        except Exception:
+            pass
+        shortcuts_button.set_valign(Gtk.Align.CENTER)
+        shortcuts_button.connect('clicked', self.on_view_shortcuts_clicked)
+        shortcuts_button_row.add_suffix(shortcuts_button)
+        shortcuts_button_row.set_activatable_widget(shortcuts_button)
+
+        self._shortcuts_row = shortcuts_button_row
+        self._shortcuts_button = shortcuts_button
+
+        shortcuts_intro_group.add(shortcuts_button_row)
+        shortcuts_page.add(shortcuts_intro_group)
+
+        try:
+            self.shortcuts_editor_page = ShortcutsPreferencesPage(
+                parent_widget=self.parent_window,
+                app=self.parent_window.get_application() if self.parent_window else None,
+                config=self.config,
+                owner_window=self.parent_window,
+            )
+
+            groups_added = len(list(self.shortcuts_editor_page.iter_groups()))
+            self.shortcuts_editor_page.create_editor_widget()
+
+            notice_widget = getattr(
+                self.shortcuts_editor_page, 'get_pass_through_notice_widget', None
+            )
+            if callable(notice_widget):
+                notice_widget = notice_widget()
+            if notice_widget is not None:
+                parent = notice_widget.get_parent()
+                if parent is not None:
+                    remove_method = getattr(parent, 'remove', None)
+                    if callable(remove_method):
+                        remove_method(notice_widget)
+                    else:
+                        remove_child = getattr(parent, 'remove_child', None)
+                        if callable(remove_child):
+                            remove_child(notice_widget)
+
+                # Create a preferences group for the notice widget
+                # Adw.PreferencesGroup accepts Adw.ActionRow, so we need to wrap it
+                notice_group = Adw.PreferencesGroup()
+
+                # Try to add the widget directly first (works for some widget types)
+                try:
+                    notice_group.add(notice_widget)
+                except (TypeError, AttributeError):
+                    # If direct add fails, wrap in an ActionRow
+                    # For Banner/Label widgets, we'll create a simple row
+                    notice_row = Adw.ActionRow()
+                    notice_row.set_activatable(False)
+                    notice_row.set_selectable(False)
+                    # Set the notice widget as the child of the row
+                    notice_row.set_child(notice_widget)
+                    notice_group.add(notice_row)
+
+                shortcuts_page.add(notice_group)
+
+            for group in self.shortcuts_editor_page.iter_groups():
+                parent = group.get_parent()
+                if parent is not None:
+                    remove_method = getattr(parent, 'remove', None)
+                    if callable(remove_method):
+                        remove_method(group)
+                    else:
+                        remove_child = getattr(parent, 'remove_child', None)
+                        if callable(remove_child):
+                            remove_child(group)
+                shortcuts_page.add(group)
+            logger.debug(
+                "Added shortcut editor widget with %d groups", groups_added
+            )
+
+            try:
+                self.shortcuts_editor_page.set_pass_through_enabled(
+                    getattr(self, '_pass_through_enabled', False)
+                )
+            except Exception:
+                pass
+
+            logger.info(f"Shortcut editor successfully added to preferences with {groups_added} groups")
+        except Exception as e:
+            logger.error(f"Failed to create shortcut editor: {e}", exc_info=True)
+            # Add a fallback message to the shortcuts page
+            fallback_group = Adw.PreferencesGroup(title=_("Shortcut Editor"))
+            fallback_row = Adw.ActionRow()
+            fallback_row.set_title(_("Shortcut Editor Unavailable"))
+            fallback_row.set_subtitle(_("The shortcut editor could not be loaded. Please check the logs for details."))
+            fallback_group.add(fallback_row)
+            shortcuts_page.add(fallback_group)
+
+        return shortcuts_page
+
+    def _build_advanced_and_security_pages(self):
+        """Build Advanced and Security & Credentials pages (interleaved groups)."""
+        # Advanced SSH settings
+        advanced_page = Adw.PreferencesPage()
+        advanced_page.set_title(_("Advanced"))
+        advanced_page.set_icon_name("applications-system-symbolic")
+
+        # Security & Credentials page — secret storage + identity provider live here
+        # (built below alongside the Advanced page, then registered as its own page).
+        security_page = Adw.PreferencesPage()
+        security_page.set_title(_("Security & Credentials"))
+        security_page.set_icon_name("dialog-password-symbolic")
+
+        # Operation mode selection
+        operation_group = Adw.PreferencesGroup(title=_("Operation Mode"))
+
+
+        # Default mode row
+        self.default_mode_row = Adw.ActionRow()
+        self.default_mode_row.set_title(_("Default Mode"))
+        self.default_mode_row.set_subtitle(_("SSH Pilot loads and modifies ~/.ssh/config"))
+        self.default_mode_radio = Gtk.CheckButton()
+
+
+        # Isolated mode row
+        self.isolated_mode_row = Adw.ActionRow()
+        self.isolated_mode_row.set_title(_("Isolated Mode"))
+        config_path = get_config_dir()
+        self.isolated_mode_row.set_subtitle(
+            _("SSH Pilot stores its configuration file in {path}/").format(path=config_path)
+        )
+        self.isolated_mode_radio = Gtk.CheckButton()
+
+        # Group the radios for exclusive selection
+        self.isolated_mode_radio.set_group(self.default_mode_radio)
+
+        self.default_mode_row.add_prefix(self.default_mode_radio)
+        self.default_mode_row.set_activatable_widget(self.default_mode_radio)
+
+        operation_group.add(self.default_mode_row)
+
+        self.isolated_mode_row.add_prefix(self.isolated_mode_radio)
+        self.isolated_mode_row.set_activatable_widget(self.isolated_mode_radio)
+        operation_group.add(self.isolated_mode_row)
+
+        use_isolated = bool(self.config.get_setting('ssh.use_isolated_config', False))
+        self.isolated_mode_radio.set_active(use_isolated)
+        self.default_mode_radio.set_active(not use_isolated)
+
+        self.default_mode_radio.connect('toggled', self.on_operation_mode_toggled)
+        self.isolated_mode_radio.connect('toggled', self.on_operation_mode_toggled)
+
+        self._update_operation_mode_styles()
+
+        advanced_page.add(operation_group)
+
+        # Secret storage backend selection
+        secrets_group = Adw.PreferencesGroup(
+            title=_("Secret Storage"),
+            description=_(
+                "Where sshPilot stores passwords and key passphrases. "
+                "Switching does not migrate existing secrets.\n"
+                "Note: Bitwarden/Vaultwarden keep the unlocked session token in the "
+                "environment while sshPilot runs, so other programs running as your "
+                "user can read the vault until you quit."
+            ),
+        )
+        self.secret_backend_row = Adw.ComboRow()
+        self.secret_backend_row.set_title(_("Secret storage backend"))
+        try:
+            from .secret_storage import get_secret_manager
+            self._secret_backend_mgr = get_secret_manager()
+            registered = self._secret_backend_mgr.registered_backends()
+        except Exception:
+            self._secret_backend_mgr = None
+            registered = []
+        current_backend = str(self.config.get_setting('secrets.backend', 'auto'))
+        if current_backend.strip().lower() == 'vaultwarden':
+            current_backend = 'bitwarden'   # merged into one bw backend
+        self._secret_backend_labels = {
+            'libsecret': _("System keyring (libsecret)"),
+            'keyring': _("System keyring"),
+            'pass': _("pass (password store)"),
+            'bitwarden': _("Bitwarden / Vaultwarden (bw CLI)"),
+            'rbw': _("Bitwarden via rbw (agent)"),
+            'keepassxc': _("KeePass database (.kdbx)"),
+            'agent': _("SSH Agent Only"),
+        }
+        # Offer EVERY registered backend (not just the available ones). Unavailable
+        # ones are labelled so the choice is honest.
+        preferred_order = ['libsecret', 'keyring', 'pass', 'bitwarden', 'rbw', 'keepassxc', 'agent']
+        ordered_names = [n for n in preferred_order if n in registered]
+        ordered_names += [n for n in registered if n not in preferred_order]
+        self._secret_backend_ids = ['auto'] + ordered_names
+        self._secret_backend_ordered = ordered_names
+        # Keep an unknown saved backend visible so the UI matches the config.
+        if current_backend not in self._secret_backend_ids:
+            self._secret_backend_ids.append(current_backend)
+            self._secret_backend_ordered = ordered_names + [current_backend]
+        # Probing availability (keyring/keepassxc is_available) costs ~400ms on
+        # the main thread, so show every backend without the "(unavailable)"
+        # suffix now and refine off-thread once the window is up.
+        self._set_secret_backend_model(set(self._secret_backend_ids))
+        try:
+            current_index = self._secret_backend_ids.index(current_backend)
+        except ValueError:
+            current_index = 0
+        self.secret_backend_row.set_selected(current_index)
+        self.secret_backend_row.connect('notify::selected', self.on_secret_backend_changed)
+        secrets_group.add(self.secret_backend_row)
+
+        self.bw_status_row = Adw.ActionRow()
+        self.bw_status_row.set_title(_("Bitwarden status"))
+        self.bw_status_row.set_subtitle(_("Checking…"))
+        self._bw_status_btn = Gtk.Button(label=_("Set up…"))
+        self._bw_status_btn.set_valign(Gtk.Align.CENTER)
+        self._bw_status_btn.connect('clicked', self.on_bw_setup_clicked)
+        self.bw_status_row.add_suffix(self._bw_status_btn)
+        self._bw_logout_btn = Gtk.Button(label=_("Log out"))
+        self._bw_logout_btn.set_valign(Gtk.Align.CENTER)
+        self._bw_logout_btn.add_css_class('destructive-action')
+        self._bw_logout_btn.connect('clicked', self.on_bw_logout_clicked)
+        self.bw_status_row.add_suffix(self._bw_logout_btn)
+        secrets_group.add(self.bw_status_row)
+
+        # rbw (github.com/doy/rbw) status + setup — only shown for the rbw backend.
+        self.rbw_status_row = Adw.ActionRow()
+        self.rbw_status_row.set_title(_("rbw status"))
+        self.rbw_status_row.set_subtitle(_("Checking…"))
+        self._rbw_status_btn = Gtk.Button(label=_("Set up…"))
+        self._rbw_status_btn.set_valign(Gtk.Align.CENTER)
+        self._rbw_status_btn.connect('clicked', self.on_rbw_setup_clicked)
+        self.rbw_status_row.add_suffix(self._rbw_status_btn)
+        self._rbw_lock_btn = Gtk.Button(label=_("Lock"))
+        self._rbw_lock_btn.set_valign(Gtk.Align.CENTER)
+        self._rbw_lock_btn.connect('clicked', self.on_rbw_lock_clicked)
+        self.rbw_status_row.add_suffix(self._rbw_lock_btn)
+        secrets_group.add(self.rbw_status_row)
+
+        # Bitwarden CLI account/profile (BITWARDENCLI_APPDATA_DIR) — a data dir for a
+        # specific account (incl. a self-hosted Vaultwarden). Empty = default account.
+        # Only shown when the Bitwarden backend is selected.
+        self.bw_profile_row = Adw.EntryRow(title=_("bw data directory (account/profile)"))
+        self.bw_profile_row.set_text(
+            str(self.config.get_setting('secrets.bitwarden.profile', '') or '')
+        )
+        try:
+            from .platform_utils import is_flatpak
+            flatpak_note = _(
+                " Under Flatpak, use the host path (e.g. /home/you/.config/Bitwarden CLI) "
+                "or leave empty for the host default — the app runs `bw` on the host."
+            ) if is_flatpak() else ""
+            self.bw_profile_row.set_tooltip_text(_(
+                "Optional. Path to a `bw` data directory (BITWARDENCLI_APPDATA_DIR) for "
+                "a specific account. Empty = the default account. Leave empty for a "
+                "single Bitwarden account.{flatpak_note}"
+            ).format(flatpak_note=flatpak_note))
+        except Exception:
+            pass
+        browse_btn = Gtk.Button(icon_name='folder-open-symbolic')
+        browse_btn.set_valign(Gtk.Align.CENTER)
+        browse_btn.add_css_class('flat')
+        browse_btn.set_tooltip_text(_("Choose data directory"))
+        browse_btn.connect('clicked', self.on_bw_profile_browse)
+        self.bw_profile_row.add_suffix(browse_btn)
+        self.bw_profile_row.connect('changed', self.on_bw_profile_changed)
+        secrets_group.add(self.bw_profile_row)
+
+        # KeePass (.kdbx) database + optional key file — only shown for the KeePassXC
+        # backend. The master password is typed per launch (not stored here).
+        self.kdbx_db_row = Adw.EntryRow(title=_("KeePass database (.kdbx)"))
+        self.kdbx_db_row.set_text(
+            str(self.config.get_setting('secrets.keepassxc.database', '') or ''))
+        kdbx_new_btn = Gtk.Button(icon_name='document-new-symbolic')
+        kdbx_new_btn.set_valign(Gtk.Align.CENTER)
+        kdbx_new_btn.add_css_class('flat')
+        kdbx_new_btn.set_tooltip_text(_("Create new database"))
+        kdbx_new_btn.connect('clicked', self.on_kdbx_create_database)
+        self.kdbx_db_row.add_suffix(kdbx_new_btn)
+        kdbx_db_btn = Gtk.Button(icon_name='document-open-symbolic')
+        kdbx_db_btn.set_valign(Gtk.Align.CENTER)
+        kdbx_db_btn.add_css_class('flat')
+        kdbx_db_btn.set_tooltip_text(_("Choose database file"))
+        kdbx_db_btn.connect('clicked', self.on_kdbx_database_browse)
+        self.kdbx_db_row.add_suffix(kdbx_db_btn)
+        self.kdbx_db_row.connect('changed', self.on_kdbx_database_changed)
+        secrets_group.add(self.kdbx_db_row)
+
+        self.kdbx_keyfile_row = Adw.EntryRow(title=_("Key file (optional)"))
+        self.kdbx_keyfile_row.set_text(
+            str(self.config.get_setting('secrets.keepassxc.keyfile', '') or ''))
+        kdbx_kf_btn = Gtk.Button(icon_name='document-open-symbolic')
+        kdbx_kf_btn.set_valign(Gtk.Align.CENTER)
+        kdbx_kf_btn.add_css_class('flat')
+        kdbx_kf_btn.set_tooltip_text(_("Choose key file"))
+        kdbx_kf_btn.connect('clicked', self.on_kdbx_keyfile_browse)
+        self.kdbx_keyfile_row.add_suffix(kdbx_kf_btn)
+        self.kdbx_keyfile_row.connect('changed', self.on_kdbx_keyfile_changed)
+        secrets_group.add(self.kdbx_keyfile_row)
+
+        # Idle minutes before a session-backed vault (Bitwarden/Vaultwarden)
+        # re-asks for the master password. 0 = keep unlocked until app exit.
+        self.secret_session_timeout_row = Adw.SpinRow.new_with_range(0, 1440, 5)
+        self.secret_session_timeout_row.set_title(_("Vault lock timeout (minutes)"))
+        self.secret_session_timeout_row.set_subtitle(
+            _("Re-ask for the master password after this idle time. 0 = until app exits.")
+        )
+        self.secret_session_timeout_row.set_value(
+            int(self.config.get_setting('secrets.session_timeout', 0) or 0)
+        )
+        self.secret_session_timeout_row.connect(
+            'notify::value', self.on_secret_session_timeout_changed
+        )
+        secrets_group.add(self.secret_session_timeout_row)
+
+        # Forget a remembered master password (saved in the OS keyring via the unlock
+        # dialog's "Remember" option). This is the only way to clear it once saved,
+        # since auto-unlock then skips the dialog. Shown for session-backed backends.
+        self.forget_master_row = Adw.ActionRow(title=_("Saved master password"))
+        forget_btn = Gtk.Button(label=_("Forget"))
+        forget_btn.set_valign(Gtk.Align.CENTER)
+        forget_btn.add_css_class('destructive-action')
+        forget_btn.connect('clicked', self.on_forget_master_password)
+        self.forget_master_row.add_suffix(forget_btn)
+        self._forget_master_btn = forget_btn
+        secrets_group.add(self.forget_master_row)
+
+        self.agent_no_store_row = Adw.ActionRow()
+        self.agent_no_store_row.set_title(_("No secret storage"))
+        self.agent_no_store_row.set_subtitle(_(
+            "Passwords and passphrases are not saved by sshPilot. Use ssh-agent "
+            "and SSH's own prompts instead."
+        ))
+        secrets_group.add(self.agent_no_store_row)
+
+        # Show the bw/timeout/forget rows only when they apply to the
+        # currently-selected backend. Backend probes (``bw status``, rbw, …)
+        # run only when the user opens this page — not on every Settings open.
+        self._update_secret_rows_visibility(current_backend, defer_status_probe=True)
+
+        security_page.add(secrets_group)
+        self._secrets_page_id = self._page_id("Security & Credentials")
+
+        # --- SSH identity provider (parallel to Secret Storage) ---
+        identity_group = Adw.PreferencesGroup(
+            title=_("SSH Identity"),
+            description=_(
+                "Default identity provider whose agent/keys are offered to "
+                "connections. The per-connection key is set on each connection "
+                "(IdentityFile); this is the global default."
+            ),
+        )
+        self.identity_provider_row = Adw.ComboRow()
+        self.identity_provider_row.set_title(_("Default SSH agent"))
+        try:
+            from .identity import get_identity_manager
+            _imgr = get_identity_manager()
+            id_registered = _imgr.registered_providers()
+            id_available = {p.name for p in _imgr.available_providers()}
+        except Exception:
+            id_registered = ['system-agent']
+            id_available = set()
+        id_labels = {'onepassword': _("1Password")}
+        current_provider = str(
+            self.config.get_setting('identity.provider', 'auto')
+        ).strip().lower()
+        # 'auto' already means the system ssh-agent, so it is not listed twice;
+        # 'file-key' is per-key, not a global default. 'custom' is a free-form socket.
+        id_order = [n for n in id_registered
+                    if n not in ('system-agent', 'file-key')]
+        self._identity_provider_ids = ['auto'] + id_order + ['custom']
+        id_model = Gtk.StringList()
+        id_model.append(_("Automatic (system ssh-agent)"))
+        for name in id_order:
+            label = id_labels.get(name, name)
+            if name not in id_available:
+                label = _("{provider} (unavailable)").format(provider=label)
+            id_model.append(label)
+        id_model.append(_("Custom socket…"))
+        if current_provider not in self._identity_provider_ids:
+            self._identity_provider_ids.append(current_provider)
+            id_model.append(_("{provider} (unavailable)").format(
+                provider=id_labels.get(current_provider, current_provider)))
+        self.identity_provider_row.set_model(id_model)
+        try:
+            id_index = self._identity_provider_ids.index(current_provider)
+        except ValueError:
+            id_index = 0
+        self.identity_provider_row.set_selected(id_index)
+        self.identity_provider_row.connect(
+            'notify::selected', self.on_identity_provider_changed)
+        identity_group.add(self.identity_provider_row)
+
+        # Custom agent socket — only shown when "Custom socket…" is selected. Written
+        # as a global `Host *` IdentityAgent directive to ~/.ssh/config.
+        self.identity_agent_socket_row = Adw.EntryRow(
+            title=_("Custom agent socket (IdentityAgent)"))
+        self.identity_agent_socket_row.set_text(
+            str(self.config.get_setting('identity.agent_socket', '') or ''))
+        self.identity_agent_socket_row.connect(
+            'changed', self.on_identity_agent_socket_changed)
+        identity_group.add(self.identity_agent_socket_row)
+        self._update_identity_rows_visibility(current_provider)
+
+        security_page.add(identity_group)
+
+        # Application behavior group
+        behavior_group = Adw.PreferencesGroup(title=_("Application Behavior"))
+
+        # Confirm before disconnecting
+        self.confirm_disconnect_switch = Adw.SwitchRow()
+        self.confirm_disconnect_switch.set_title(_("Confirm before disconnecting"))
+        self.confirm_disconnect_switch.set_subtitle(_("Show a confirmation dialog when disconnecting from a host"))
+        self.confirm_disconnect_switch.set_active(
+            self.config.get_setting('confirm-disconnect', True)
+        )
+        self.confirm_disconnect_switch.connect('notify::active', self.on_confirm_disconnect_changed)
+        behavior_group.add(self.confirm_disconnect_switch)
+
+        # ssh.agent_preload_keys stays on by default (no Preferences toggle):
+        # the terminal worker force-unlocks configured identities into the
+        # agent so locked gcr keys cannot fall through to the system askpass.
+
+        advanced_page.add(behavior_group)
+
+        # Logging group ------------------------------------------------
+        logging_group = Adw.PreferencesGroup(title=_("Logging"))
+        logging_group.set_description(
+            _("Controls how verbose sshPilot is in the console and the rotated log file. "
+            "The command-line flags --verbose / --quiet always override this.")
+        )
+
+        self.logging_level_row = Adw.ComboRow()
+        self.logging_level_row.set_title(_("Log Level"))
+        self.logging_level_row.set_subtitle(
+            _("Default is concise; switch to Debug if you're filing a bug or chasing an issue")
+        )
+        log_levels_model = Gtk.StringList()
+        log_levels_model.append("Info — concise (recommended)")
+        log_levels_model.append("Debug — verbose")
+        self.logging_level_row.set_model(log_levels_model)
+        saved_level = str(
+            self.config.get_setting('logging.level', 'info') or 'info'
+        ).lower()
+        self.logging_level_row.set_selected(1 if saved_level == 'debug' else 0)
+        self.logging_level_row.connect(
+            'notify::selected', self.on_logging_level_changed
+        )
+        logging_group.add(self.logging_level_row)
+        advanced_page.add(logging_group)
+
+        # File management preferences moved to dedicated page
+        return (advanced_page, security_page)
+
+    def _build_ssh_settings_preferences_page(self):
+        """Build the SSH Options preferences page."""
+        ssh_settings_page = Adw.PreferencesPage()
+        ssh_settings_page.set_title("SSH")
+        ssh_settings_page.set_icon_name("network-workgroup-symbolic")
+
+        help_group = Adw.PreferencesGroup()
+        help_row = Adw.ActionRow()
+        help_row.set_title(_("Custom SSH Options"))
+        help_row.set_subtitle(
+            _("These settings override values from your ~/.ssh/config.")
+        )
+        if hasattr(help_row, "set_activatable"):
+            help_row.set_activatable(False)
+        if hasattr(help_row, "set_selectable"):
+            help_row.set_selectable(False)
+        help_group.add(help_row)
+
+        advanced_group = Adw.PreferencesGroup(title=_("SSH Settings"))
+
+        # Connect timeout
+        self.connect_timeout_row = Adw.SpinRow.new_with_range(0, 120, 1)
+        self.connect_timeout_row.set_title(_("Connect Timeout (s)"))
+        connect_timeout_value = self.config.get_setting('ssh.connection_timeout', None)
+        try:
+            connect_timeout_value = int(connect_timeout_value)
+        except (TypeError, ValueError):
+            connect_timeout_value = 0
+        if connect_timeout_value < 0:
+            connect_timeout_value = 0
+        self.connect_timeout_row.set_value(connect_timeout_value)
+        advanced_group.add(self.connect_timeout_row)
+
+        # Connection attempts
+        self.connection_attempts_row = Adw.SpinRow.new_with_range(0, 10, 1)
+        self.connection_attempts_row.set_title(_("Connection Attempts"))
+        connection_attempts_value = self.config.get_setting('ssh.connection_attempts', None)
+        try:
+            connection_attempts_value = int(connection_attempts_value)
+        except (TypeError, ValueError):
+            connection_attempts_value = 0
+        if connection_attempts_value < 0:
+            connection_attempts_value = 0
+        self.connection_attempts_row.set_value(connection_attempts_value)
+        advanced_group.add(self.connection_attempts_row)
+
+        # Default keepalive opt-out. When on (default) and the user hasn't
+        # set an explicit ServerAlive interval below or in ~/.ssh/config,
+        # SSH Pilot applies a sane default so dropped links are detected.
+        self.apply_default_keepalive_row = Adw.SwitchRow()
+        self.apply_default_keepalive_row.set_title(_("Apply default keepalive"))
+        self.apply_default_keepalive_row.set_subtitle(
+            _("Detect dropped connections automatically when no ServerAlive "
+            "value is set here or in ~/.ssh/config. Explicit values always win.")
+        )
+        self.apply_default_keepalive_row.set_active(
+            bool(self.config.get_setting('ssh.apply_default_keepalive', True))
+        )
+        advanced_group.add(self.apply_default_keepalive_row)
+
+        # Keepalive interval
+        self.keepalive_interval_row = Adw.SpinRow.new_with_range(0, 300, 5)
+        self.keepalive_interval_row.set_title(_("ServerAlive Interval (s)"))
+        keepalive_interval_value = self.config.get_setting('ssh.keepalive_interval', None)
+        try:
+            keepalive_interval_value = int(keepalive_interval_value)
+        except (TypeError, ValueError):
+            keepalive_interval_value = 0
+        if keepalive_interval_value < 0:
+            keepalive_interval_value = 0
+        self.keepalive_interval_row.set_value(keepalive_interval_value)
+        advanced_group.add(self.keepalive_interval_row)
+
+        # Keepalive count max
+        self.keepalive_count_row = Adw.SpinRow.new_with_range(0, 10, 1)
+        self.keepalive_count_row.set_title(_("ServerAlive CountMax"))
+        keepalive_count_value = self.config.get_setting('ssh.keepalive_count_max', None)
+        try:
+            keepalive_count_value = int(keepalive_count_value)
+        except (TypeError, ValueError):
+            keepalive_count_value = 0
+        if keepalive_count_value < 0:
+            keepalive_count_value = 0
+        self.keepalive_count_row.set_value(keepalive_count_value)
+        advanced_group.add(self.keepalive_count_row)
+
+        # Strict host key checking
+        self.strict_host_row = Adw.ComboRow()
+        self.strict_host_row.set_title(_("StrictHostKeyChecking"))
+        strict_model = Gtk.StringList()
+        for item in ["accept-new", "yes", "no", "ask"]:
+            strict_model.append(item)
+        self.strict_host_row.set_model(strict_model)
+        # Map current value
+        current_strict = str(self.config.get_setting('ssh.strict_host_key_checking', 'accept-new'))
+        try:
+            idx = ["accept-new", "yes", "no", "ask"].index(current_strict)
+        except ValueError:
+            idx = 0
+        self.strict_host_row.set_selected(idx)
+        advanced_group.add(self.strict_host_row)
+
+        # BatchMode (non-interactive)
+        self.batch_mode_row = Adw.SwitchRow()
+        self.batch_mode_row.set_title(_("BatchMode (disable prompts)"))
+        self.batch_mode_row.set_active(bool(self.config.get_setting('ssh.batch_mode', False)))
+        advanced_group.add(self.batch_mode_row)
+
+        # Compression
+        self.compression_row = Adw.SwitchRow()
+        self.compression_row.set_title(_("Enable Compression (-C)"))
+        self.compression_row.set_active(bool(self.config.get_setting('ssh.compression', False)))
+        advanced_group.add(self.compression_row)
+
+        # Connection multiplexing (ControlMaster). When on, the first
+        # connection to a host opens a master socket that later connections
+        # reuse (no re-handshake) — faster reconnects and chatty operations.
+        self.controlmaster_row = Adw.SwitchRow()
+        self.controlmaster_row.set_title(_("Enable SSH connection multiplexing"))
+        self.controlmaster_row.set_subtitle(
+            _("Reuse one connection per host (ControlMaster) for faster reconnects")
+        )
+        self.controlmaster_row.set_active(bool(self.config.get_setting('ssh.controlmaster', False)))
+        advanced_group.add(self.controlmaster_row)
+
+        # SSH verbosity (-v levels)
+        self.verbosity_row = Adw.SpinRow.new_with_range(0, 3, 1)
+        self.verbosity_row.set_title(_("SSH Verbosity (-v)"))
+        self.verbosity_row.set_value(int(self.config.get_setting('ssh.verbosity', 0)))
+        advanced_group.add(self.verbosity_row)
+
+        # Debug logging toggle
+        self.debug_enabled_row = Adw.SwitchRow()
+        self.debug_enabled_row.set_title(_("Enable SSH Debug Logging"))
+        self.debug_enabled_row.set_active(bool(self.config.get_setting('ssh.debug_enabled', False)))
+        advanced_group.add(self.debug_enabled_row)
+
+
+        # Reset button
+        # Add spacing before reset button
+        advanced_group.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # Use Adw.ActionRow for proper spacing and layout
+        reset_row = Adw.ActionRow()
+        reset_row.set_title(_("Reset Advanced SSH Settings"))
+        reset_row.set_subtitle(_("Restore all advanced SSH settings to their default values"))
+
+        reset_btn = Gtk.Button.new_with_label("Reset")
+        reset_btn.add_css_class('destructive-action')
+        reset_btn.set_valign(Gtk.Align.CENTER)
+        reset_btn.connect('clicked', self.on_reset_advanced_ssh)
+        reset_row.add_suffix(reset_btn)
+
+        advanced_group.add(reset_row)
+
+        ssh_settings_page.add(help_group)
+        ssh_settings_page.add(advanced_group)
+
+        # Ensure shortcut overview controls reflect current state
+        self._set_shortcut_controls_enabled(not self._pass_through_enabled)
+
+        return ssh_settings_page
+
+    def _build_file_management_preferences_page(self):
+        """Build the File Management preferences page."""
+        # Create File Management preferences page
+        file_management_page = Adw.PreferencesPage()
+        file_management_page.set_title(_("File Management"))
+        file_management_page.set_icon_name("folder-symbolic")
+
+        # File Management group
+        if has_internal_file_manager():
+            file_manager_group = Adw.PreferencesGroup(title=_("File Manager Options"))
+            file_manager_group.set_description(
+                _("These preferences only affect sshPilot's built-in SFTP file manager.")
+            )
+
+            self.force_internal_file_manager_row = None
+            if should_show_force_internal_file_manager_toggle():
+                self.force_internal_file_manager_row = Adw.SwitchRow()
+                self.force_internal_file_manager_row.set_title(_("Always Use Built-in File Manager"))
+                self.force_internal_file_manager_row.set_subtitle(
+                    _("Use the in-app file manager even when system integrations are available")
+                )
+                self.force_internal_file_manager_row.set_active(
+                    bool(self.config.get_setting('file_manager.force_internal', False))
+                )
+                self.force_internal_file_manager_row.connect(
+                    'notify::active', self.on_force_internal_file_manager_changed
+                )
+
+                file_manager_group.add(self.force_internal_file_manager_row)
+
+            self.open_file_manager_externally_row = Adw.SwitchRow()
+            self.open_file_manager_externally_row.set_title(_("Open File Manager in Separate Window"))
+            self.open_file_manager_externally_row.set_subtitle(
+                _("Show the built-in file manager in its own window instead of a tab")
+            )
+            self.open_file_manager_externally_row.set_active(
+                bool(self.config.get_setting('file_manager.open_externally', False))
+            )
+            self.open_file_manager_externally_row.connect(
+                'notify::active', self.on_open_file_manager_externally_changed
+            )
+
+            file_manager_group.add(self.open_file_manager_externally_row)
+
+            file_manager_defaults = {}
+            try:
+                defaults = self.config.get_default_config()
+                file_manager_defaults = defaults.get('file_manager', {}) if isinstance(defaults, dict) else {}
+            except Exception:
+                file_manager_defaults = {}
+
+            file_manager_config: Dict[str, Any] = {}
+            if hasattr(self.config, 'get_file_manager_config'):
+                try:
+                    file_manager_config = self.config.get_file_manager_config() or {}
+                except Exception as exc:
+                    logger.debug("Failed to read file manager configuration: %s", exc)
+                    file_manager_config = {}
+
+            def _fm_default_int(key: str, fallback: int = 0) -> int:
+                value = 0
+                if isinstance(file_manager_defaults, dict):
+                    try:
+                        value = int(file_manager_defaults.get(key, fallback))
+                    except (TypeError, ValueError):
+                        value = fallback
+                else:
+                    value = fallback
+                return value if value >= 0 else fallback
+
+            def _fm_config_int(key: str, fallback: int) -> int:
+                if isinstance(file_manager_config, dict):
+                    try:
+                        value = int(file_manager_config.get(key, fallback))
+                    except (TypeError, ValueError):
+                        value = fallback
+                    if value < 0:
+                        return fallback
+                    return value
+                return fallback
+
+            keepalive_interval_default = _fm_default_int('sftp_keepalive_interval', 0)
+            keepalive_interval_value = _fm_config_int('sftp_keepalive_interval', keepalive_interval_default)
+            keepalive_interval_value = max(0, min(keepalive_interval_value, 3600))
+
+            sftp_advanced_group = Adw.PreferencesGroup(title=_("Advanced SFTP Settings"))
+            sftp_advanced_group.set_description(
+                _("Fine-tune options that only apply to sshPilot's built-in SFTP file manager.")
+            )
+
+
+            self.sftp_keepalive_interval_row = Adw.SpinRow.new_with_range(0, 3600, 5)
+            self.sftp_keepalive_interval_row.set_title(_("SFTP Keepalive Interval (seconds)"))
+            self.sftp_keepalive_interval_row.set_subtitle(
+                _("How often the built-in file manager sends keepalives. "
+                "Set to 0 to disable.")
+            )
+            self.sftp_keepalive_interval_row.set_value(keepalive_interval_value)
+            sftp_advanced_group.add(self.sftp_keepalive_interval_row)
+
+
+            keepalive_count_default = _fm_default_int('sftp_keepalive_count_max', 0)
+            keepalive_count_value = _fm_config_int('sftp_keepalive_count_max', keepalive_count_default)
+            keepalive_count_value = max(0, min(keepalive_count_value, 10))
+
+            self.sftp_keepalive_count_row = Adw.SpinRow.new_with_range(0, 10, 1)
+            self.sftp_keepalive_count_row.set_title(_("SFTP Keepalive Retry Limit"))
+            self.sftp_keepalive_count_row.set_subtitle(
+                _("Number of failed keepalives tolerated by the built-in file "
+                "manager before raising an error.")
+            )
+            self.sftp_keepalive_count_row.set_value(keepalive_count_value)
+            sftp_advanced_group.add(self.sftp_keepalive_count_row)
+
+
+            connect_timeout_default = _fm_default_int('sftp_connect_timeout', 0)
+            connect_timeout_value = _fm_config_int('sftp_connect_timeout', connect_timeout_default)
+            connect_timeout_value = max(0, min(connect_timeout_value, 600))
+
+            self.sftp_connect_timeout_row = Adw.SpinRow.new_with_range(0, 600, 1)
+            self.sftp_connect_timeout_row.set_title(_("SFTP Connection Timeout (seconds)"))
+            self.sftp_connect_timeout_row.set_subtitle(
+                _("Time allowed for the built-in file manager to establish a "
+                "session; 0 uses the default.")
+            )
+            self.sftp_connect_timeout_row.set_value(connect_timeout_value)
+            sftp_advanced_group.add(self.sftp_connect_timeout_row)
+
+
+            self._update_external_file_manager_row()
+            file_management_page.add(file_manager_group)
+            file_management_page.add(sftp_advanced_group)
+        else:
+            # If no internal file manager, create empty page with message
+            no_file_manager_group = Adw.PreferencesGroup(title=_("File Manager"))
+            no_file_manager_row = Adw.ActionRow()
+            no_file_manager_row.set_title(_("File Manager Not Available"))
+            no_file_manager_row.set_subtitle(_("Built-in file manager is not available on this system"))
+            no_file_manager_group.add(no_file_manager_row)
+            file_management_page.add(no_file_manager_group)
+        return file_management_page
+
+    def _build_updates_preferences_page(self):
+        """Build the Updates preferences page."""
+        # Updates page
+        updates_page = Adw.PreferencesPage()
+        updates_page.set_title(_("Updates"))
+        updates_page.set_icon_name("software-update-available-symbolic")
+
+        updates_group = Adw.PreferencesGroup(title=_("Update Notifications"))
+        updates_group.set_description(_("Configure how SSH Pilot checks for updates"))
+
+        # Check for updates on startup switch
+        self.check_updates_switch = Adw.SwitchRow()
+        self.check_updates_switch.set_title(_("Check for updates on startup"))
+        self.check_updates_switch.set_subtitle(_("Automatically check for new versions when the application starts"))
+        self.check_updates_switch.set_active(
+            self.config.get_setting('updates.check_on_startup', True)
+        )
+        self.check_updates_switch.connect('notify::active', self.on_check_updates_changed)
+        updates_group.add(self.check_updates_switch)
+
+        updates_page.add(updates_group)
+        return updates_page
+
     def setup_preferences(self):
         """Set up preferences UI with current values"""
         try:
-            # Create Terminal preferences page
-            terminal_page = Adw.PreferencesPage()
-            terminal_page.set_title(_("Terminal"))
-            terminal_page.set_icon_name("utilities-terminal-symbolic")
-            
-            # Terminal appearance group
-            appearance_group = Adw.PreferencesGroup(title=_("Appearance"))
-            
-            # Font selection row
-            self.font_row = Adw.ActionRow()
-            self.font_row.set_title(_("Font"))
-            current_font = self.config.get_setting('terminal.font', 'Monospace 12')
-            self.font_row.set_subtitle(current_font)
-            
-            font_button = Gtk.Button()
-            font_button.set_label(_("Choose"))
-            font_button.set_valign(Gtk.Align.CENTER)
-            font_button.connect('clicked', self.on_font_button_clicked)
-            self.font_row.add_suffix(font_button)
-            
-            appearance_group.add(self.font_row)
-            
-            # Terminal color scheme
-            self.color_scheme_row = Adw.ComboRow()
-            self.color_scheme_row.set_title(_("Color Scheme"))
-            self.color_scheme_row.set_subtitle(_("Terminal color theme"))
-            
-            # Names come straight from Config.terminal_themes (single source of truth)
-            themes = getattr(self.config, 'terminal_themes', {}) or {}
-            color_schemes = Gtk.StringList()
-            for key in SCHEME_KEYS:
-                color_schemes.append(themes.get(key, {}).get('name', key))
-            self.color_scheme_row.set_model(color_schemes)
-
-            # Select the saved scheme; fall back to the first entry if unknown
-            current_scheme_key = self.config.get_setting('terminal.theme', 'default')
-            try:
-                current_index = SCHEME_KEYS.index(current_scheme_key)
-            except ValueError:
-                current_index = 0
-                self.config.set_setting('terminal.theme', SCHEME_KEYS[0])
-            self.color_scheme_row.set_selected(current_index)
-
-            self.color_scheme_row.connect('notify::selected', self.on_color_scheme_changed)
-
-            appearance_group.add(self.color_scheme_row)
-
-            self._initialize_encoding_selector(appearance_group)
-
-            # Color scheme preview
-            preview_group = Adw.PreferencesGroup(title=_("Preview"))
-            preview_group.set_margin_top(18)  # Add more spacing above "Preview" label
-            
-            # Create preview terminal widget
-            self.color_preview_terminal = Gtk.DrawingArea()
-            self.color_preview_terminal.set_draw_func(self.draw_color_preview)
-            self.color_preview_terminal.set_size_request(400, 120)
-            self.color_preview_terminal.add_css_class("terminal-preview")
-            
-            # Create a standard Adwaita container with rounded corners
-            preview_container = Adw.Bin()
-            preview_container.add_css_class("card")
-            preview_container.set_margin_top(6)  # Reduce spacing between label and preview
-            
-            # Add some margin around the preview
-            preview_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-            preview_box.set_margin_top(12)
-            preview_box.set_margin_bottom(12)
-            preview_box.set_margin_start(12)
-            preview_box.set_margin_end(12)
-            preview_box.append(self.color_preview_terminal)
-            
-            preview_container.set_child(preview_box)
-            preview_group.add(preview_container)
-            appearance_group.add(preview_group)
-            terminal_page.add(appearance_group)
-
-            # Terminal backend selection group
-            backend_group = Adw.PreferencesGroup(title=_("Backend"))
-            
-            # Build backend choices
-            self._backend_choice_data = self._build_backend_choices()
-            
-            # Create combo row for backend selection
-            self.backend_row = Adw.ComboRow()
-            self.backend_row.set_title(_("Terminal Backend"))
-            self.backend_row.set_subtitle(_("Choose the terminal rendering backend"))
-            
-            # Create model from choices
-            backend_model = Gtk.StringList()
-            for choice in self._backend_choice_data:
-                backend_model.append(choice['label'])
-            self.backend_row.set_model(backend_model)
-            
-            # Set current backend
-            current_backend = self.config.get_setting('terminal.backend', 'vte')
-            # Reset to VTE if pyxterm is configured on macOS (not supported)
-            if is_macos() and current_backend and current_backend.lower() == 'pyxterm':
-                current_backend = 'vte'
-                self.config.set_setting('terminal.backend', 'vte')
-            current_index = 0
-            for i, choice in enumerate(self._backend_choice_data):
-                if choice['id'] == current_backend:
-                    current_index = i
-                    break
-            self.backend_row.set_selected(current_index)
-            self._backend_last_valid_index = current_index
-            self._update_backend_row_subtitle(current_index)
-            
-            # Connect change handler
-            self.backend_row.connect('notify::selected', self._on_backend_row_changed)
-            
-            backend_group.add(self.backend_row)
-            terminal_page.add(backend_group)
-
-            keyboard_group = Adw.PreferencesGroup(title=_("Keyboard"))
-
-            self.pass_through_switch = Adw.SwitchRow()
-            self.pass_through_switch.set_title(_("Terminal Shortcut Pass-through"))
-            self.pass_through_switch.set_subtitle(
-                _("Disable all keyboard shortcuts, pass all key events directly to terminal")
-            )
-            pass_through_active = bool(self.config.get_setting('terminal.pass_through_mode', False))
-            self._pass_through_enabled = pass_through_active
-            self.pass_through_switch.set_active(pass_through_active)
-            self.pass_through_switch.connect('notify::active', self.on_pass_through_mode_toggled)
-            keyboard_group.add(self.pass_through_switch)
-
-            self.autocomplete_switch = Adw.SwitchRow()
-            self.autocomplete_switch.set_title(_("Command autocomplete"))
-            self.autocomplete_switch.set_subtitle(
-                _("Suggest commands from history and snippets as you type (embedded terminal)")
-            )
-            self.autocomplete_switch.set_active(
-                bool(self.config.get_setting('terminal.autocomplete', True))
-            )
-            self.autocomplete_switch.connect('notify::active', self.on_autocomplete_toggled)
-            keyboard_group.add(self.autocomplete_switch)
-
-            self.autocomplete_remote_switch = Adw.SwitchRow()
-            self.autocomplete_remote_switch.set_title(_("Suggest from remote history"))
-            self.autocomplete_remote_switch.set_subtitle(
-                _("Also fetch the remote host's shell history over SSH (applies to new tabs)")
-            )
-            self.autocomplete_remote_switch.set_active(
-                bool(self.config.get_setting('terminal.autocomplete_remote', False))
-            )
-            self.autocomplete_remote_switch.connect(
-                'notify::active', self.on_autocomplete_remote_toggled)
-            keyboard_group.add(self.autocomplete_remote_switch)
-
-            terminal_page.add(keyboard_group)
-
-            # Mouse behavior group
-            mouse_group = Adw.PreferencesGroup(title=_("Mouse"))
-
-            self.copy_on_select_switch = Adw.SwitchRow()
-            self.copy_on_select_switch.set_title(_("Copy on selection"))
-            self.copy_on_select_switch.set_subtitle(
-                _("Automatically copy selected text to the clipboard")
-            )
-            copy_on_select_active = bool(self.config.get_setting('terminal.copy_on_select', False))
-            self.copy_on_select_switch.set_active(copy_on_select_active)
-            self.copy_on_select_switch.connect('notify::active', self.on_copy_on_select_toggled)
-            mouse_group.add(self.copy_on_select_switch)
-
-            self.paste_on_right_click_switch = Adw.SwitchRow()
-            self.paste_on_right_click_switch.set_title(_("Paste on right-click"))
-            self.paste_on_right_click_switch.set_subtitle(
-                _("Right-click pastes; Shift+right-click opens the menu")
-            )
-            paste_on_right_click_active = bool(self.config.get_setting('terminal.paste_on_right_click', False))
-            self.paste_on_right_click_switch.set_active(paste_on_right_click_active)
-            self.paste_on_right_click_switch.connect(
-                'notify::active', self.on_paste_on_right_click_toggled
-            )
-            mouse_group.add(self.paste_on_right_click_switch)
-
-            terminal_page.add(mouse_group)
-
-            # Preferred Terminal group (shown when external terminals are available)
-            if not should_hide_external_terminal_options():
-                terminal_choice_group = Adw.PreferencesGroup(title=_("Preferred Terminal"))
-                
-                # Radio buttons for terminal choice
-                self.builtin_terminal_radio = Gtk.CheckButton(label=_("Use built-in terminal"))
-                self.builtin_terminal_radio.set_can_focus(True)
-                self.external_terminal_radio = Gtk.CheckButton(label=_("Use other terminal"))
-                self.external_terminal_radio.set_can_focus(True)
-                
-                # Make them behave like radio buttons
-                self.external_terminal_radio.set_group(self.builtin_terminal_radio)
-                
-                # Set current preference
-                use_external = self.config.get_setting('use-external-terminal', False)
-                if use_external:
-                    self.external_terminal_radio.set_active(True)
-                else:
-                    self.builtin_terminal_radio.set_active(True)
-                
-                # Connect radio button changes
-                self.builtin_terminal_radio.connect('toggled', self.on_terminal_choice_changed)
-                self.external_terminal_radio.connect('toggled', self.on_terminal_choice_changed)
-                
-                # Add radio buttons to group
-                terminal_choice_group.add(self.builtin_terminal_radio)
-                terminal_choice_group.add(self.external_terminal_radio)
-                
-                # External terminal dropdown and custom path
-                self.external_terminal_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
-                self.external_terminal_box.set_margin_start(24)
-                self.external_terminal_box.set_margin_top(6)
-                self.external_terminal_box.set_margin_bottom(6)
-                
-                # Terminal dropdown
-                self.terminal_dropdown = Gtk.DropDown()
-                self.terminal_dropdown.set_can_focus(True)
-                
-                # Populate dropdown with available terminals
-                self._populate_terminal_dropdown()
-                
-                # Set current selection
-                current_terminal = self.config.get_setting('external-terminal', 'gnome-terminal')
-                
-                # Connect dropdown changes
-                self.terminal_dropdown.connect('notify::selected', self.on_terminal_dropdown_changed)
-                
-                # Custom path entry (initially hidden)
-                self.custom_terminal_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-                self.custom_terminal_entry = Gtk.Entry()
-                self.custom_terminal_entry.set_placeholder_text("/usr/bin/gnome-terminal")
-                self.custom_terminal_entry.set_can_focus(True)
-                
-                # Set current custom path if any
-                custom_path = self.config.get_setting('custom-terminal-path', '')
-                if custom_path:
-                    self.custom_terminal_entry.set_text(custom_path)
-                
-                # Connect custom path changes
-                self.custom_terminal_entry.connect('changed', self.on_custom_terminal_path_changed)
-                
-                self.custom_terminal_box.append(self.custom_terminal_entry)
-                
-                # Add dropdown and custom path to box
-                self.external_terminal_box.append(self.terminal_dropdown)
-                self.external_terminal_box.append(self.custom_terminal_box)
-                
-                # Now set the dropdown selection and show/hide custom path entry
-                self._set_terminal_dropdown_selection(current_terminal)
-                
-                # Initial sensitivity will be set by radio button state
-                
-                # Add to group
-                terminal_choice_group.add(self.external_terminal_box)
-                
-                # Set initial sensitivity based on radio button state
-                self.external_terminal_box.set_sensitive(self.external_terminal_radio.get_active())
-                
-                terminal_page.add(terminal_choice_group)
-            
-            # Create Groups preferences page
-            groups_page = Adw.PreferencesPage()
-            groups_page.set_title(_("Groups"))
-            groups_page.set_icon_name("folder-open-symbolic")
-
-            group_appearance_group = Adw.PreferencesGroup(title=_("Group Appearance"))
-
-            # Sidebar group color display mode
-            self._group_color_display_values = ['fill', 'badge', 'bar', 'dot']
-            self.group_color_display_row = Adw.ComboRow()
-            self.group_color_display_row.set_title(_("Sidebar Group Colors"))
-            self.group_color_display_row.set_subtitle(
-                _("Choose how group colors are shown in the sidebar")
-            )
-
-            color_display_options = Gtk.StringList()
-            color_display_options.append("Colored Rows")
-            color_display_options.append("Color Badges")
-            color_display_options.append("Accent Bars")
-            color_display_options.append("Color Dots")
-            self.group_color_display_row.set_model(color_display_options)
-
-            current_mode = 'fill'
-            try:
-                current_mode = str(
-                    self.config.get_setting('ui.group_color_display', 'fill')
-                ).lower()
-            except Exception:
-                current_mode = 'fill'
-            if current_mode not in self._group_color_display_values:
-                current_mode = 'fill'
-
-            self._group_display_sync = True
-            try:
-                self.group_color_display_row.set_selected(
-                    self._group_color_display_values.index(current_mode)
-                )
-            finally:
-                self._group_display_sync = False
-
-            self.group_color_display_row.connect(
-                'notify::selected', self.on_group_color_display_changed
-            )
-
-            group_appearance_group.add(self.group_color_display_row)
-
-            # Toggle for extending group colors to member connection rows
-            self.child_rows_color_row = Adw.SwitchRow()
-            self.child_rows_color_row.set_title(_("Use Group Color for Child Rows"))
-            self.child_rows_color_row.set_subtitle(
-                _("Apply the group's color to its connection rows as well")
-            )
-            try:
-                child_rows_pref = bool(
-                    self.config.get_setting('ui.group_color_child_rows', False)
-                )
-            except Exception:
-                child_rows_pref = False
-            self.child_rows_color_row.set_active(child_rows_pref)
-            self.child_rows_color_row.connect(
-                'notify::active', self.on_group_color_child_rows_toggled
-            )
-            group_appearance_group.add(self.child_rows_color_row)
-
-            # Toggle for coloring tabs using group colors
-            self.tab_group_color_row = Adw.SwitchRow()
-            self.tab_group_color_row.set_title(_("Show Group Color in Tabs"))
-            self.tab_group_color_row.set_subtitle(
-                _("Show the selected group's color badge in the terminal tabs")
-            )
-            try:
-                tab_pref = bool(
-                    self.config.get_setting('ui.use_group_color_in_tab', False)
-                )
-            except Exception:
-                tab_pref = False
-            self.tab_group_color_row.set_active(tab_pref)
-            self.tab_group_color_row.connect(
-                'notify::active', self.on_use_group_color_in_tab_toggled
-            )
-            group_appearance_group.add(self.tab_group_color_row)
-
-            # Toggle for applying group colors inside terminals
-            self.terminal_group_color_row = Adw.SwitchRow()
-            self.terminal_group_color_row.set_title(_("Use Group Color in Terminals"))
-            self.terminal_group_color_row.set_subtitle(
-                _("Use parent group's color as terminal background")
-            )
-            try:
-                terminal_pref = bool(
-                    self.config.get_setting('ui.use_group_color_in_terminal', False)
-                )
-            except Exception:
-                terminal_pref = False
-            self.terminal_group_color_row.set_active(terminal_pref)
-            self.terminal_group_color_row.connect(
-                'notify::active', self.on_use_group_color_in_terminal_toggled
-            )
-            group_appearance_group.add(self.terminal_group_color_row)
-
-
-            groups_page.add(group_appearance_group)
-
-            # Group display layout section (shown after appearance options)
-            group_layout_group = Adw.PreferencesGroup(title=_("Group Layout"))
-
-            self._group_display_preview_rows = {}
-            _install_group_display_preview_css()
-
-            self._group_display_modes = ['fullwidth', 'nested']
-            self.group_display_toggle_row = Adw.ActionRow()
-            self.group_display_toggle_row.set_title(_("Group Display"))
-            self.group_display_toggle_row.set_subtitle(
-                _("Choose how grouped connections appear in the sidebar")
-            )
-            self.group_display_toggle_row.set_activatable(False)
-            try:
-                self.group_display_toggle_row.set_focusable(False)
-            except Exception:
-                pass
-
-            self.group_display_toggle_group = None
-            self._group_display_toggle_controller = None
-
-            if hasattr(Adw, 'ToggleGroup') and hasattr(Adw.ToggleGroup, 'new'):
-                toggle_group = Adw.ToggleGroup.new()
-                toggle_group.set_orientation(Gtk.Orientation.HORIZONTAL)
-                toggle_group.add_css_class('linked')
-                toggle_group.set_hexpand(True)
-                try:
-                    toggle_group.set_homogeneous(True)
-                except Exception:
-                    pass
-
-                self.group_display_toggle_fullwidth = Adw.Toggle.new()
-                self.group_display_toggle_fullwidth.props.name = 'fullwidth'
-                self.group_display_toggle_fullwidth.set_label(_('Fullwidth'))
-
-                self.group_display_toggle_nested = Adw.Toggle.new()
-                self.group_display_toggle_nested.props.name = 'nested'
-                self.group_display_toggle_nested.set_label(_('Nested'))
-
-                toggle_group.add(self.group_display_toggle_fullwidth)
-                toggle_group.add(self.group_display_toggle_nested)
-                self.group_display_toggle_row.set_child(toggle_group)
-
-                self.group_display_toggle_group = toggle_group
-                self._group_display_toggle_controller = toggle_group
-            else:
-                fallback_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
-                fallback_box.add_css_class('linked')
-                fallback_box.set_hexpand(True)
-
-                self.group_display_toggle_fullwidth = Gtk.ToggleButton(label=_('Fullwidth'))
-                self.group_display_toggle_fullwidth.props.name = 'fullwidth'
-                self.group_display_toggle_fullwidth.set_hexpand(True)
-
-                self.group_display_toggle_nested = Gtk.ToggleButton(label=_('Nested'))
-                self.group_display_toggle_nested.props.name = 'nested'
-                self.group_display_toggle_nested.set_hexpand(True)
-
-                fallback_box.append(self.group_display_toggle_fullwidth)
-                fallback_box.append(self.group_display_toggle_nested)
-                self.group_display_toggle_row.set_child(fallback_box)
-
-                buttons = {
-                    'fullwidth': self.group_display_toggle_fullwidth,
-                    'nested': self.group_display_toggle_nested,
-                }
-                self._group_display_toggle_controller = _GroupDisplayToggleFallback(buttons)
-
-            current_display_mode = 'nested'
-            try:
-                current_display_mode = str(
-                    self.config.get_setting('ui.group_row_display', 'nested')
-                ).lower()
-            except Exception:
-                current_display_mode = 'nested'
-            if current_display_mode not in self._group_display_modes:
-                current_display_mode = 'nested'
-
-            self._group_display_toggle_sync = True
-            try:
-                if self._group_display_toggle_controller:
-                    self._group_display_toggle_controller.set_active_name(current_display_mode)
-            finally:
-                self._group_display_toggle_sync = False
-
-            if isinstance(self._group_display_toggle_controller, _GroupDisplayToggleFallback):
-                self._group_display_toggle_controller.connect(
-                    self.on_group_row_display_changed
-                )
-            elif self.group_display_toggle_group is not None:
-                self.group_display_toggle_group.connect(
-                    'notify::active-name', self.on_group_row_display_changed
-                )
-
-            group_layout_group.add(self.group_display_toggle_row)
-
-            # Preview showing both layout styles
-            self.group_display_preview_row = Adw.ActionRow()
-            self.group_display_preview_row.set_title(_("Layout Preview"))
-            self.group_display_preview_row.set_activatable(False)
-            try:
-                self.group_display_preview_row.set_focusable(False)
-            except Exception:
-                pass
-
-            preview_stack = Gtk.Stack()
-            preview_stack.set_transition_type(Gtk.StackTransitionType.CROSSFADE)
-            preview_stack.set_transition_duration(150)
-
-            preview_stack.set_margin_top(4)
-            preview_stack.set_margin_bottom(4)
-
-            preview_fullwidth_wrapper, preview_fullwidth_row = self._create_group_display_preview(
-                'fullwidth', 'Fullwidth'
-            )
-            preview_nested_wrapper, preview_nested_row = self._create_group_display_preview(
-                'nested', 'Nested'
-            )
-
-            preview_stack.add_named(preview_fullwidth_wrapper, 'fullwidth')
-            preview_stack.add_named(preview_nested_wrapper, 'nested')
-
-            self.group_display_preview_row.set_child(preview_stack)
-            self._group_display_preview_rows = {
-                'fullwidth': preview_fullwidth_row,
-                'nested': preview_nested_row,
-            }
-            self._group_display_preview_stack = preview_stack
-
-            self._update_group_display_preview(current_display_mode)
-
-            group_layout_group.add(self.group_display_preview_row)
-            groups_page.add(group_layout_group)
-
-            # Create Interface preferences page
-            interface_page = Adw.PreferencesPage()
-            interface_page.set_title(_("Interface"))
-            interface_page.set_icon_name("applications-graphics-symbolic")
-
-            # Language — first group on the page. Always shown: "System Default"
-            # plus every catalogue that can actually be loaded (English included,
-            # it being the source language and the way back from a translation).
-            language_group = Adw.PreferencesGroup(title=_("Language"))
-
-            self.language_row = Adw.ComboRow()
-            self.language_row.set_title(_("Interface Language"))
-            self.language_row.set_subtitle(_("Takes effect after restarting SSH Pilot"))
-
-            language_names = Gtk.StringList()
-            language_names.append(_("System Default"))
-            self._language_codes = ['']
-            for code, display_name in available_languages():
-                language_names.append(display_name)
-                self._language_codes.append(code)
-            self.language_row.set_model(language_names)
-
-            saved_language = self.config.get_setting('ui.language', '')
-            if saved_language and saved_language not in self._language_codes:
-                # The catalogue went away (uninstalled, or the setting came from
-                # another machine). Showing "System Default" while the config
-                # still names the missing language would keep applying it at
-                # every start, so clear it to match what the row now says.
-                logger.info("Interface language %r is no longer installed; "
-                            "falling back to the system default", saved_language)
-                self.config.set_setting('ui.language', '')
-                saved_language = ''
-            self.language_row.set_selected(
-                self._language_codes.index(saved_language)
-                if saved_language in self._language_codes else 0)
-
-            self.language_row.connect('notify::selected', self.on_language_changed)
-            language_group.add(self.language_row)
-            interface_page.add(language_group)
-
-            # App startup behavior
-            startup_group = Adw.PreferencesGroup(title=_("App Startup"))
-
-            # Radio buttons for startup behavior
-            self.terminal_startup_radio = Gtk.CheckButton(label=_("Show Terminal"))
-            self.terminal_startup_radio.set_can_focus(True)
-            self.welcome_startup_radio = Gtk.CheckButton(label=_("Show Start Page"))
-            self.welcome_startup_radio.set_can_focus(True)
-            self.previous_session_startup_radio = Gtk.CheckButton(label=_("Restore previous session"))
-            self.previous_session_startup_radio.set_can_focus(True)
-            self.saved_session_startup_radio = Gtk.CheckButton(label=_("Open a saved session"))
-            self.saved_session_startup_radio.set_can_focus(True)
-
-            # Make them behave like radio buttons
-            self.welcome_startup_radio.set_group(self.terminal_startup_radio)
-            self.previous_session_startup_radio.set_group(self.terminal_startup_radio)
-            self.saved_session_startup_radio.set_group(self.terminal_startup_radio)
-
-            # Set current preference (default to welcome/start page)
-            startup_behavior = self.config.get_setting('app-startup-behavior', 'welcome')
-            if startup_behavior == 'terminal':
-                self.terminal_startup_radio.set_active(True)
-            elif startup_behavior == 'previous-session':
-                self.previous_session_startup_radio.set_active(True)
-            elif startup_behavior == 'saved-session':
-                self.saved_session_startup_radio.set_active(True)
-            else:
-                self.welcome_startup_radio.set_active(True)
-
-            # Selector for which saved session to open on startup. This is built
-            # as a plain (non-row) widget so it stacks directly below the
-            # "Open a saved session" radio rather than being hoisted into the
-            # group's internal list box above the bare check buttons.
-            self._startup_session_names = []
-            try:
-                session_manager = getattr(self.parent_window, 'session_manager', None)
-                if session_manager is not None:
-                    self._startup_session_names = list(session_manager.list_session_names())
-            except Exception:
-                self._startup_session_names = []
-
-            session_model = Gtk.StringList()
-            if self._startup_session_names:
-                for name in self._startup_session_names:
-                    session_model.append(name)
-            else:
-                session_model.append("(no saved sessions)")
-
-            self.startup_session_row = Gtk.DropDown()
-            self.startup_session_row.set_model(session_model)
-            self.startup_session_row.set_valign(Gtk.Align.CENTER)
-
-            self.startup_session_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-            self.startup_session_box.set_margin_start(24)
-            self.startup_session_box.set_margin_top(2)
-            session_label = Gtk.Label(label=_("Saved session"))
-            session_label.set_xalign(0)
-            session_label.set_hexpand(True)
-            self.startup_session_box.append(session_label)
-            self.startup_session_box.append(self.startup_session_row)
-
-            selected_session = self.config.get_setting('app-startup-session-name', '')
-            if selected_session in self._startup_session_names:
-                self.startup_session_row.set_selected(
-                    self._startup_session_names.index(selected_session)
-                )
-            self.startup_session_box.set_sensitive(
-                bool(self._startup_session_names)
-                and self.saved_session_startup_radio.get_active()
-            )
-
-            # Connect radio button changes
-            self.terminal_startup_radio.connect('toggled', self.on_startup_behavior_changed)
-            self.welcome_startup_radio.connect('toggled', self.on_startup_behavior_changed)
-            self.previous_session_startup_radio.connect('toggled', self.on_startup_behavior_changed)
-            self.saved_session_startup_radio.connect('toggled', self.on_startup_behavior_changed)
-            self.startup_session_row.connect('notify::selected', self.on_startup_session_changed)
-
-            # Add radio buttons to group, with the saved-session selector placed
-            # immediately below its corresponding radio option.
-            startup_group.add(self.terminal_startup_radio)
-            startup_group.add(self.welcome_startup_radio)
-            startup_group.add(self.previous_session_startup_radio)
-            startup_group.add(self.saved_session_startup_radio)
-            startup_group.add(self.startup_session_box)
-
-            interface_page.add(startup_group)
-
-            # Appearance group
-            interface_appearance_group = Adw.PreferencesGroup(title=_("Appearance"))
-
-            # Theme selection
-            self.theme_row = Adw.ComboRow()
-            self.theme_row.set_title(_("Application Theme"))
-            self.theme_row.set_subtitle(_("Choose light, dark, or follow system theme"))
-
-            themes = Gtk.StringList()
-            themes.append("Follow System")
-            themes.append("Light")
-            themes.append("Dark")
-            self.theme_row.set_model(themes)
-            
-            # Load saved theme preference
-            saved_theme = self.config.get_setting('app-theme', 'default')
-            theme_mapping = {'default': 0, 'light': 1, 'dark': 2}
-            self.theme_row.set_selected(theme_mapping.get(saved_theme, 0))
-
-            self.theme_row.connect('notify::selected', self.on_theme_changed)
-
-            interface_appearance_group.add(self.theme_row)
-
-
-            # Color overrides section
-            color_override_group = Adw.PreferencesGroup(title=_("Color Overrides"))
-            color_override_group.set_description(_("Override the accent color"))
-
-            # Accent color override
-            self.accent_color_row = Adw.ActionRow()
-            self.accent_color_row.set_title(_("Accent Color"))
-            self.accent_color_row.set_subtitle(_("Override the accent color for highlights"))
-
-            self.accent_color_button = Gtk.ColorButton()
-            self.accent_color_button.set_use_alpha(False)
-            self.accent_color_button.set_tooltip_text(_("Choose accent color"))
-            self.accent_color_button.set_valign(Gtk.Align.CENTER)
-            self.accent_color_button.set_size_request(60, 32)
-            self.accent_color_button.connect('color-set', self.on_accent_color_changed)
-            self.accent_color_row.add_suffix(self.accent_color_button)
-            color_override_group.add(self.accent_color_row)
-            
-            # Reset colors button
-            reset_colors_row = Adw.ActionRow()
-            reset_colors_row.set_title(_("Reset to Default"))
-            reset_colors_row.set_subtitle(_("Remove the accent override and use the system accent"))
-            
-            reset_button = Gtk.Button()
-            reset_button.set_label(_("Reset"))
-            reset_button.add_css_class("destructive-action")
-            reset_button.set_valign(Gtk.Align.CENTER)
-            reset_button.connect('clicked', self.on_reset_colors_clicked)
-            reset_colors_row.add_suffix(reset_button)
-            color_override_group.add(reset_colors_row)
-
-            interface_page.add(interface_appearance_group)
-            interface_page.add(color_override_group)
-
-            # Initialize color button states
-            self.refresh_color_buttons()
-            
-            # Window group
-            window_group = Adw.PreferencesGroup(title=_("Window"))
-
-            # Remember window size switch
-            remember_size_switch = Adw.SwitchRow()
-            remember_size_switch.set_title(_("Remember Window Size"))
-            remember_size_switch.set_subtitle(_("Restore window size on startup"))
-            remember_size_switch.set_active(True)
-            
-            window_group.add(remember_size_switch)
-            interface_page.add(window_group)
-
-            # Sidebar group (at bottom of Interface page)
-            sidebar_group = Adw.PreferencesGroup(title=_("Sidebar"))
-            
-            # Maximum width slider
-            max_width_row = Adw.ActionRow()
-            max_width_row.set_title(_("Maximum Width"))
-            
-            # Load saved value or use default
-            saved_max_width = self.config.get_setting('ui.max-sidebar-width', 280)
-            
-            # Create a scale/slider for max width (100-800 sp)
-            max_width_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 100, 800, 10)
-            max_width_scale.set_draw_value(True)
-            max_width_scale.set_value_pos(Gtk.PositionType.RIGHT)
-            max_width_scale.set_size_request(200, -1)
-            max_width_scale.set_valign(Gtk.Align.CENTER)
-            max_width_scale.set_value(float(saved_max_width))
-            
-            # Update subtitle with current value
-            def update_subtitle(value):
-                max_width_row.set_subtitle(
-                    _("Adjust the maximum width of the sidebar ({width} sp)").format(width=int(value)))
-            
-            update_subtitle(saved_max_width)
-            
-            # Connect change handler
-            def on_max_width_changed(scale):
-                value = int(scale.get_value())
-                update_subtitle(value)
-                self.config.set_setting('ui.max-sidebar-width', value)
-                # Update main window if available
-                if self.parent_window and hasattr(self.parent_window, 'update_sidebar_max_width'):
-                    self.parent_window.update_sidebar_max_width(value)
-            
-            max_width_scale.connect('value-changed', on_max_width_changed)
-            
-            max_width_row.add_suffix(max_width_scale)
-            sidebar_group.add(max_width_row)
-
-            flat_rows_switch = Adw.SwitchRow()
-            flat_rows_switch.set_title(_("Flat Sidebar Rows"))
-            flat_rows_switch.set_subtitle(
-                _("Use flat list rows instead of cards in the connection sidebar")
-            )
-            flat_rows_switch.set_active(
-                bool(self.config.get_setting('ui.sidebar_flat_rows', False))
-            )
-            flat_rows_switch.connect(
-                'notify::active', self.on_sidebar_flat_rows_changed
-            )
-            sidebar_group.add(flat_rows_switch)
-            
-            # Display user@hostname toggle
-            show_user_hostname_switch = Adw.SwitchRow()
-            show_user_hostname_switch.set_title(_("Display user@hostname"))
-            show_user_hostname_switch.set_subtitle(_("Show username@hostname in connection rows"))
-            show_user_hostname_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_user_hostname', True)
-            )
-            show_user_hostname_switch.connect('notify::active', self.on_sidebar_show_user_hostname_changed)
-            sidebar_group.add(show_user_hostname_switch)
-            
-            # Display connection count in groups toggle
-            show_group_count_switch = Adw.SwitchRow()
-            show_group_count_switch.set_title(_("Display Connection Count in Groups"))
-            show_group_count_switch.set_subtitle(_("Show the number of connections in each group"))
-            show_group_count_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_group_count', True)
-            )
-            show_group_count_switch.connect('notify::active', self.on_sidebar_show_group_count_changed)
-            sidebar_group.add(show_group_count_switch)
-            
-            # Display connection status toggle
-            show_status_switch = Adw.SwitchRow()
-            show_status_switch.set_title(_("Display Connection Status"))
-            show_status_switch.set_subtitle(_("Show connection status indicator in connection rows"))
-            show_status_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_connection_status', True)
-            )
-            show_status_switch.connect('notify::active', self.on_sidebar_show_connection_status_changed)
-            sidebar_group.add(show_status_switch)
-            
-            # Display port forwarding labels toggle
-            show_port_forwarding_switch = Adw.SwitchRow()
-            show_port_forwarding_switch.set_title(_("Display Port Forwarding Labels"))
-            show_port_forwarding_switch.set_subtitle(_("Show port forwarding indicators (L/R/D) in connection rows"))
-            show_port_forwarding_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_port_forwarding', True)
-            )
-            show_port_forwarding_switch.connect('notify::active', self.on_sidebar_show_port_forwarding_changed)
-            sidebar_group.add(show_port_forwarding_switch)
-            
-            # Display connection icon toggle
-            show_connection_icon_switch = Adw.SwitchRow()
-            show_connection_icon_switch.set_title(_("Display Connection Icon"))
-            show_connection_icon_switch.set_subtitle(_("Show the computer icon in connection rows"))
-            show_connection_icon_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_connection_icon', True)
-            )
-            show_connection_icon_switch.connect('notify::active', self.on_sidebar_show_connection_icon_changed)
-            sidebar_group.add(show_connection_icon_switch)
-
-            # Display group icon toggle
-            show_group_icon_switch = Adw.SwitchRow()
-            show_group_icon_switch.set_title(_("Display Group Icon"))
-            show_group_icon_switch.set_subtitle(_("Show the folder icon in group rows"))
-            show_group_icon_switch.set_active(
-                self.config.get_setting('ui.sidebar_show_group_icon', True)
-            )
-            show_group_icon_switch.connect('notify::active', self.on_sidebar_show_group_icon_changed)
-            sidebar_group.add(show_group_icon_switch)
-            
-            interface_page.add(sidebar_group)
-
-            # Sidebar behavior
-            sidebar_behavior_group = Adw.PreferencesGroup(title=_("Sidebar behavior"))
-
-            hide_on_startup_switch = Adw.SwitchRow()
-            hide_on_startup_switch.set_title(_("Hide Sidebar on Startup"))
-            hide_on_startup_switch.set_subtitle(_("Start with the sidebar collapsed"))
-            hide_on_startup_switch.set_active(
-                bool(self.config.get_setting('ui.sidebar_hide_on_startup', False))
-            )
-            hide_on_startup_switch.connect(
-                'notify::active',
-                lambda r, _p: self.config.set_setting('ui.sidebar_hide_on_startup', bool(r.get_active())),
-            )
-            sidebar_behavior_group.add(hide_on_startup_switch)
-
-            hide_on_terminal_switch = Adw.SwitchRow()
-            hide_on_terminal_switch.set_title(_("Hide When a Terminal Opens"))
-            hide_on_terminal_switch.set_subtitle(_("Collapse the sidebar when any session opens, including local terminals"))
-            hide_on_terminal_switch.set_active(
-                bool(self.config.get_setting('ui.sidebar_hide_on_terminal_open', False))
-            )
-            hide_on_terminal_switch.connect(
-                'notify::active',
-                lambda r, _p: self.config.set_setting('ui.sidebar_hide_on_terminal_open', bool(r.get_active())),
-            )
-            sidebar_behavior_group.add(hide_on_terminal_switch)
-
-            show_when_no_tabs_switch = Adw.SwitchRow()
-            show_when_no_tabs_switch.set_title(_("Show When No Tab Is Open"))
-            show_when_no_tabs_switch.set_subtitle(_("Reveal the sidebar when returning to the welcome screen"))
-            show_when_no_tabs_switch.set_active(
-                bool(self.config.get_setting('ui.sidebar_show_when_no_tabs', False))
-            )
-            show_when_no_tabs_switch.connect(
-                'notify::active',
-                lambda r, _p: self.config.set_setting('ui.sidebar_show_when_no_tabs', bool(r.get_active())),
-            )
-            sidebar_behavior_group.add(show_when_no_tabs_switch)
-
-            interface_page.add(sidebar_behavior_group)
-
-            # Header bar button visibility
-            headerbar_group = Adw.PreferencesGroup(title=_("Header Bar Buttons"))
-
-            def _add_headerbar_switch(title, subtitle, key, default=True):
-                row = Adw.SwitchRow()
-                row.set_title(title)
-                row.set_subtitle(subtitle)
-                row.set_active(bool(self.config.get_setting(key, default)))
-
-                def _on_toggled(r, _p, _k=key):
-                    self.config.set_setting(_k, bool(r.get_active()))
-                    if self.parent_window and hasattr(self.parent_window, 'update_headerbar_buttons'):
-                        self.parent_window.update_headerbar_buttons()
-
-                row.connect('notify::active', _on_toggled)
-                headerbar_group.add(row)
-
-            _add_headerbar_switch(
-                "Split View Button",
-                "Show the split-view button (the grid icon that starts a split view)",
-                'ui.headerbar_show_split_view',
-                default=False,
-            )
-            _add_headerbar_switch(
-                "Commands Button",
-                "Show the command snippets toggle button",
-                'ui.headerbar_show_commands',
-            )
-            _add_headerbar_switch(
-                "Theme Menu",
-                "Show the application theme menu beside the commands button",
-                'ui.headerbar_show_theme_toggle',
-            )
-            _add_headerbar_switch(
-                "Local Terminal Button",
-                "Show the button that opens a local terminal",
-                'ui.headerbar_show_local_terminal',
-            )
-
-            interface_page.add(headerbar_group)
-
-            # Tips group at the bottom of the Interface page. Lets users
-            # re-enable the terminal tips banner after dismissing it with
-            # "Don't show again".
-            tips_group = Adw.PreferencesGroup(title=_("Tips"))
-            show_tips_switch = Adw.SwitchRow()
-            show_tips_switch.set_title(_("Show Terminal Tips"))
-            show_tips_switch.set_subtitle(_("Show usage tips in a banner when a terminal opens"))
-            show_tips_switch.set_active(
-                bool(self.config.get_setting('terminal.show_tips', True))
-            )
-            show_tips_switch.connect('notify::active', self.on_show_tips_toggled)
-            tips_group.add(show_tips_switch)
-            interface_page.add(tips_group)
-
-            # Shortcuts page with inline editor
-            shortcuts_page = Adw.PreferencesPage()
-            shortcuts_page.set_title(_("Shortcuts"))
-            shortcuts_page.set_icon_name("preferences-desktop-keyboard-shortcuts-symbolic")
-
-            shortcuts_intro_group = Adw.PreferencesGroup(title=_("Keyboard Shortcuts"))
-
-            shortcuts_button_row = Adw.ActionRow()
-            shortcuts_button_row.set_title(_("Shortcut Overview"))
-            shortcuts_button_row.set_subtitle(_("Open the shortcuts window for a full reference"))
-
-            shortcuts_button = Gtk.Button(label=_("Open"))
-            try:
-                shortcuts_button.add_css_class("flat")
-            except Exception:
-                pass
-            shortcuts_button.set_valign(Gtk.Align.CENTER)
-            shortcuts_button.connect('clicked', self.on_view_shortcuts_clicked)
-            shortcuts_button_row.add_suffix(shortcuts_button)
-            shortcuts_button_row.set_activatable_widget(shortcuts_button)
-
-            self._shortcuts_row = shortcuts_button_row
-            self._shortcuts_button = shortcuts_button
-
-            shortcuts_intro_group.add(shortcuts_button_row)
-            shortcuts_page.add(shortcuts_intro_group)
-
-            try:
-                self.shortcuts_editor_page = ShortcutsPreferencesPage(
-                    parent_widget=self.parent_window,
-                    app=self.parent_window.get_application() if self.parent_window else None,
-                    config=self.config,
-                    owner_window=self.parent_window,
-                )
-
-                groups_added = len(list(self.shortcuts_editor_page.iter_groups()))
-                self.shortcuts_editor_page.create_editor_widget()
-
-                notice_widget = getattr(
-                    self.shortcuts_editor_page, 'get_pass_through_notice_widget', None
-                )
-                if callable(notice_widget):
-                    notice_widget = notice_widget()
-                if notice_widget is not None:
-                    parent = notice_widget.get_parent()
-                    if parent is not None:
-                        remove_method = getattr(parent, 'remove', None)
-                        if callable(remove_method):
-                            remove_method(notice_widget)
-                        else:
-                            remove_child = getattr(parent, 'remove_child', None)
-                            if callable(remove_child):
-                                remove_child(notice_widget)
-
-                    # Create a preferences group for the notice widget
-                    # Adw.PreferencesGroup accepts Adw.ActionRow, so we need to wrap it
-                    notice_group = Adw.PreferencesGroup()
-                    
-                    # Try to add the widget directly first (works for some widget types)
-                    try:
-                        notice_group.add(notice_widget)
-                    except (TypeError, AttributeError):
-                        # If direct add fails, wrap in an ActionRow
-                        # For Banner/Label widgets, we'll create a simple row
-                        notice_row = Adw.ActionRow()
-                        notice_row.set_activatable(False)
-                        notice_row.set_selectable(False)
-                        # Set the notice widget as the child of the row
-                        notice_row.set_child(notice_widget)
-                        notice_group.add(notice_row)
-                    
-                    shortcuts_page.add(notice_group)
-
-                for group in self.shortcuts_editor_page.iter_groups():
-                    parent = group.get_parent()
-                    if parent is not None:
-                        remove_method = getattr(parent, 'remove', None)
-                        if callable(remove_method):
-                            remove_method(group)
-                        else:
-                            remove_child = getattr(parent, 'remove_child', None)
-                            if callable(remove_child):
-                                remove_child(group)
-                    shortcuts_page.add(group)
-                logger.debug(
-                    "Added shortcut editor widget with %d groups", groups_added
-                )
-
-                try:
-                    self.shortcuts_editor_page.set_pass_through_enabled(
-                        getattr(self, '_pass_through_enabled', False)
-                    )
-                except Exception:
-                    pass
-
-                logger.info(f"Shortcut editor successfully added to preferences with {groups_added} groups")
-            except Exception as e:
-                logger.error(f"Failed to create shortcut editor: {e}", exc_info=True)
-                # Add a fallback message to the shortcuts page
-                fallback_group = Adw.PreferencesGroup(title=_("Shortcut Editor"))
-                fallback_row = Adw.ActionRow()
-                fallback_row.set_title(_("Shortcut Editor Unavailable"))
-                fallback_row.set_subtitle(_("The shortcut editor could not be loaded. Please check the logs for details."))
-                fallback_group.add(fallback_row)
-                shortcuts_page.add(fallback_group)
-
-            # Advanced SSH settings
-            advanced_page = Adw.PreferencesPage()
-            advanced_page.set_title(_("Advanced"))
-            advanced_page.set_icon_name("applications-system-symbolic")
-
-            # Security & Credentials page — secret storage + identity provider live here
-            # (built below alongside the Advanced page, then registered as its own page).
-            security_page = Adw.PreferencesPage()
-            security_page.set_title(_("Security & Credentials"))
-            security_page.set_icon_name("dialog-password-symbolic")
-
-            # Operation mode selection
-            operation_group = Adw.PreferencesGroup(title=_("Operation Mode"))
-
-
-            # Default mode row
-            self.default_mode_row = Adw.ActionRow()
-            self.default_mode_row.set_title(_("Default Mode"))
-            self.default_mode_row.set_subtitle(_("SSH Pilot loads and modifies ~/.ssh/config"))
-            self.default_mode_radio = Gtk.CheckButton()
-
-
-            # Isolated mode row
-            self.isolated_mode_row = Adw.ActionRow()
-            self.isolated_mode_row.set_title(_("Isolated Mode"))
-            config_path = get_config_dir()
-            self.isolated_mode_row.set_subtitle(
-                _("SSH Pilot stores its configuration file in {path}/").format(path=config_path)
-            )
-            self.isolated_mode_radio = Gtk.CheckButton()
-
-            # Group the radios for exclusive selection
-            self.isolated_mode_radio.set_group(self.default_mode_radio)
-
-            self.default_mode_row.add_prefix(self.default_mode_radio)
-            self.default_mode_row.set_activatable_widget(self.default_mode_radio)
-
-            operation_group.add(self.default_mode_row)
-
-            self.isolated_mode_row.add_prefix(self.isolated_mode_radio)
-            self.isolated_mode_row.set_activatable_widget(self.isolated_mode_radio)
-            operation_group.add(self.isolated_mode_row)
-
-            use_isolated = bool(self.config.get_setting('ssh.use_isolated_config', False))
-            self.isolated_mode_radio.set_active(use_isolated)
-            self.default_mode_radio.set_active(not use_isolated)
-
-            self.default_mode_radio.connect('toggled', self.on_operation_mode_toggled)
-            self.isolated_mode_radio.connect('toggled', self.on_operation_mode_toggled)
-
-            self._update_operation_mode_styles()
-
-            advanced_page.add(operation_group)
-
-            # Secret storage backend selection
-            secrets_group = Adw.PreferencesGroup(
-                title=_("Secret Storage"),
-                description=_(
-                    "Where sshPilot stores passwords and key passphrases. "
-                    "Switching does not migrate existing secrets.\n"
-                    "Note: Bitwarden/Vaultwarden keep the unlocked session token in the "
-                    "environment while sshPilot runs, so other programs running as your "
-                    "user can read the vault until you quit."
-                ),
-            )
-            self.secret_backend_row = Adw.ComboRow()
-            self.secret_backend_row.set_title(_("Secret storage backend"))
-            try:
-                from .secret_storage import get_secret_manager
-                self._secret_backend_mgr = get_secret_manager()
-                registered = self._secret_backend_mgr.registered_backends()
-            except Exception:
-                self._secret_backend_mgr = None
-                registered = []
-            current_backend = str(self.config.get_setting('secrets.backend', 'auto'))
-            if current_backend.strip().lower() == 'vaultwarden':
-                current_backend = 'bitwarden'   # merged into one bw backend
-            self._secret_backend_labels = {
-                'libsecret': _("System keyring (libsecret)"),
-                'keyring': _("System keyring"),
-                'pass': _("pass (password store)"),
-                'bitwarden': _("Bitwarden / Vaultwarden (bw CLI)"),
-                'rbw': _("Bitwarden via rbw (agent)"),
-                'keepassxc': _("KeePass database (.kdbx)"),
-                'agent': _("SSH Agent Only"),
-            }
-            # Offer EVERY registered backend (not just the available ones). Unavailable
-            # ones are labelled so the choice is honest.
-            preferred_order = ['libsecret', 'keyring', 'pass', 'bitwarden', 'rbw', 'keepassxc', 'agent']
-            ordered_names = [n for n in preferred_order if n in registered]
-            ordered_names += [n for n in registered if n not in preferred_order]
-            self._secret_backend_ids = ['auto'] + ordered_names
-            self._secret_backend_ordered = ordered_names
-            # Keep an unknown saved backend visible so the UI matches the config.
-            if current_backend not in self._secret_backend_ids:
-                self._secret_backend_ids.append(current_backend)
-                self._secret_backend_ordered = ordered_names + [current_backend]
-            # Probing availability (keyring/keepassxc is_available) costs ~400ms on
-            # the main thread, so show every backend without the "(unavailable)"
-            # suffix now and refine off-thread once the window is up.
-            self._set_secret_backend_model(set(self._secret_backend_ids))
-            try:
-                current_index = self._secret_backend_ids.index(current_backend)
-            except ValueError:
-                current_index = 0
-            self.secret_backend_row.set_selected(current_index)
-            self.secret_backend_row.connect('notify::selected', self.on_secret_backend_changed)
-            secrets_group.add(self.secret_backend_row)
-
-            self.bw_status_row = Adw.ActionRow()
-            self.bw_status_row.set_title(_("Bitwarden status"))
-            self.bw_status_row.set_subtitle(_("Checking…"))
-            self._bw_status_btn = Gtk.Button(label=_("Set up…"))
-            self._bw_status_btn.set_valign(Gtk.Align.CENTER)
-            self._bw_status_btn.connect('clicked', self.on_bw_setup_clicked)
-            self.bw_status_row.add_suffix(self._bw_status_btn)
-            self._bw_logout_btn = Gtk.Button(label=_("Log out"))
-            self._bw_logout_btn.set_valign(Gtk.Align.CENTER)
-            self._bw_logout_btn.add_css_class('destructive-action')
-            self._bw_logout_btn.connect('clicked', self.on_bw_logout_clicked)
-            self.bw_status_row.add_suffix(self._bw_logout_btn)
-            secrets_group.add(self.bw_status_row)
-
-            # rbw (github.com/doy/rbw) status + setup — only shown for the rbw backend.
-            self.rbw_status_row = Adw.ActionRow()
-            self.rbw_status_row.set_title(_("rbw status"))
-            self.rbw_status_row.set_subtitle(_("Checking…"))
-            self._rbw_status_btn = Gtk.Button(label=_("Set up…"))
-            self._rbw_status_btn.set_valign(Gtk.Align.CENTER)
-            self._rbw_status_btn.connect('clicked', self.on_rbw_setup_clicked)
-            self.rbw_status_row.add_suffix(self._rbw_status_btn)
-            self._rbw_lock_btn = Gtk.Button(label=_("Lock"))
-            self._rbw_lock_btn.set_valign(Gtk.Align.CENTER)
-            self._rbw_lock_btn.connect('clicked', self.on_rbw_lock_clicked)
-            self.rbw_status_row.add_suffix(self._rbw_lock_btn)
-            secrets_group.add(self.rbw_status_row)
-
-            # Bitwarden CLI account/profile (BITWARDENCLI_APPDATA_DIR) — a data dir for a
-            # specific account (incl. a self-hosted Vaultwarden). Empty = default account.
-            # Only shown when the Bitwarden backend is selected.
-            self.bw_profile_row = Adw.EntryRow(title=_("bw data directory (account/profile)"))
-            self.bw_profile_row.set_text(
-                str(self.config.get_setting('secrets.bitwarden.profile', '') or '')
-            )
-            try:
-                from .platform_utils import is_flatpak
-                flatpak_note = _(
-                    " Under Flatpak, use the host path (e.g. /home/you/.config/Bitwarden CLI) "
-                    "or leave empty for the host default — the app runs `bw` on the host."
-                ) if is_flatpak() else ""
-                self.bw_profile_row.set_tooltip_text(_(
-                    "Optional. Path to a `bw` data directory (BITWARDENCLI_APPDATA_DIR) for "
-                    "a specific account. Empty = the default account. Leave empty for a "
-                    "single Bitwarden account.{flatpak_note}"
-                ).format(flatpak_note=flatpak_note))
-            except Exception:
-                pass
-            browse_btn = Gtk.Button(icon_name='folder-open-symbolic')
-            browse_btn.set_valign(Gtk.Align.CENTER)
-            browse_btn.add_css_class('flat')
-            browse_btn.set_tooltip_text(_("Choose data directory"))
-            browse_btn.connect('clicked', self.on_bw_profile_browse)
-            self.bw_profile_row.add_suffix(browse_btn)
-            self.bw_profile_row.connect('changed', self.on_bw_profile_changed)
-            secrets_group.add(self.bw_profile_row)
-
-            # KeePass (.kdbx) database + optional key file — only shown for the KeePassXC
-            # backend. The master password is typed per launch (not stored here).
-            self.kdbx_db_row = Adw.EntryRow(title=_("KeePass database (.kdbx)"))
-            self.kdbx_db_row.set_text(
-                str(self.config.get_setting('secrets.keepassxc.database', '') or ''))
-            kdbx_new_btn = Gtk.Button(icon_name='document-new-symbolic')
-            kdbx_new_btn.set_valign(Gtk.Align.CENTER)
-            kdbx_new_btn.add_css_class('flat')
-            kdbx_new_btn.set_tooltip_text(_("Create new database"))
-            kdbx_new_btn.connect('clicked', self.on_kdbx_create_database)
-            self.kdbx_db_row.add_suffix(kdbx_new_btn)
-            kdbx_db_btn = Gtk.Button(icon_name='document-open-symbolic')
-            kdbx_db_btn.set_valign(Gtk.Align.CENTER)
-            kdbx_db_btn.add_css_class('flat')
-            kdbx_db_btn.set_tooltip_text(_("Choose database file"))
-            kdbx_db_btn.connect('clicked', self.on_kdbx_database_browse)
-            self.kdbx_db_row.add_suffix(kdbx_db_btn)
-            self.kdbx_db_row.connect('changed', self.on_kdbx_database_changed)
-            secrets_group.add(self.kdbx_db_row)
-
-            self.kdbx_keyfile_row = Adw.EntryRow(title=_("Key file (optional)"))
-            self.kdbx_keyfile_row.set_text(
-                str(self.config.get_setting('secrets.keepassxc.keyfile', '') or ''))
-            kdbx_kf_btn = Gtk.Button(icon_name='document-open-symbolic')
-            kdbx_kf_btn.set_valign(Gtk.Align.CENTER)
-            kdbx_kf_btn.add_css_class('flat')
-            kdbx_kf_btn.set_tooltip_text(_("Choose key file"))
-            kdbx_kf_btn.connect('clicked', self.on_kdbx_keyfile_browse)
-            self.kdbx_keyfile_row.add_suffix(kdbx_kf_btn)
-            self.kdbx_keyfile_row.connect('changed', self.on_kdbx_keyfile_changed)
-            secrets_group.add(self.kdbx_keyfile_row)
-
-            # Idle minutes before a session-backed vault (Bitwarden/Vaultwarden)
-            # re-asks for the master password. 0 = keep unlocked until app exit.
-            self.secret_session_timeout_row = Adw.SpinRow.new_with_range(0, 1440, 5)
-            self.secret_session_timeout_row.set_title(_("Vault lock timeout (minutes)"))
-            self.secret_session_timeout_row.set_subtitle(
-                _("Re-ask for the master password after this idle time. 0 = until app exits.")
-            )
-            self.secret_session_timeout_row.set_value(
-                int(self.config.get_setting('secrets.session_timeout', 0) or 0)
-            )
-            self.secret_session_timeout_row.connect(
-                'notify::value', self.on_secret_session_timeout_changed
-            )
-            secrets_group.add(self.secret_session_timeout_row)
-
-            # Forget a remembered master password (saved in the OS keyring via the unlock
-            # dialog's "Remember" option). This is the only way to clear it once saved,
-            # since auto-unlock then skips the dialog. Shown for session-backed backends.
-            self.forget_master_row = Adw.ActionRow(title=_("Saved master password"))
-            forget_btn = Gtk.Button(label=_("Forget"))
-            forget_btn.set_valign(Gtk.Align.CENTER)
-            forget_btn.add_css_class('destructive-action')
-            forget_btn.connect('clicked', self.on_forget_master_password)
-            self.forget_master_row.add_suffix(forget_btn)
-            self._forget_master_btn = forget_btn
-            secrets_group.add(self.forget_master_row)
-
-            self.agent_no_store_row = Adw.ActionRow()
-            self.agent_no_store_row.set_title(_("No secret storage"))
-            self.agent_no_store_row.set_subtitle(_(
-                "Passwords and passphrases are not saved by sshPilot. Use ssh-agent "
-                "and SSH's own prompts instead."
-            ))
-            secrets_group.add(self.agent_no_store_row)
-
-            # Show the bw/timeout/forget rows only when they apply to the
-            # currently-selected backend. Backend probes (``bw status``, rbw, …)
-            # run only when the user opens this page — not on every Settings open.
-            self._update_secret_rows_visibility(current_backend, defer_status_probe=True)
-
-            security_page.add(secrets_group)
-            self._secrets_page_id = self._page_id("Security & Credentials")
-
-            # --- SSH identity provider (parallel to Secret Storage) ---
-            identity_group = Adw.PreferencesGroup(
-                title=_("SSH Identity"),
-                description=_(
-                    "Default identity provider whose agent/keys are offered to "
-                    "connections. The per-connection key is set on each connection "
-                    "(IdentityFile); this is the global default."
-                ),
-            )
-            self.identity_provider_row = Adw.ComboRow()
-            self.identity_provider_row.set_title(_("Default SSH agent"))
-            try:
-                from .identity import get_identity_manager
-                _imgr = get_identity_manager()
-                id_registered = _imgr.registered_providers()
-                id_available = {p.name for p in _imgr.available_providers()}
-            except Exception:
-                id_registered = ['system-agent']
-                id_available = set()
-            id_labels = {'onepassword': _("1Password")}
-            current_provider = str(
-                self.config.get_setting('identity.provider', 'auto')
-            ).strip().lower()
-            # 'auto' already means the system ssh-agent, so it is not listed twice;
-            # 'file-key' is per-key, not a global default. 'custom' is a free-form socket.
-            id_order = [n for n in id_registered
-                        if n not in ('system-agent', 'file-key')]
-            self._identity_provider_ids = ['auto'] + id_order + ['custom']
-            id_model = Gtk.StringList()
-            id_model.append(_("Automatic (system ssh-agent)"))
-            for name in id_order:
-                label = id_labels.get(name, name)
-                if name not in id_available:
-                    label = _("{provider} (unavailable)").format(provider=label)
-                id_model.append(label)
-            id_model.append(_("Custom socket…"))
-            if current_provider not in self._identity_provider_ids:
-                self._identity_provider_ids.append(current_provider)
-                id_model.append(_("{provider} (unavailable)").format(
-                    provider=id_labels.get(current_provider, current_provider)))
-            self.identity_provider_row.set_model(id_model)
-            try:
-                id_index = self._identity_provider_ids.index(current_provider)
-            except ValueError:
-                id_index = 0
-            self.identity_provider_row.set_selected(id_index)
-            self.identity_provider_row.connect(
-                'notify::selected', self.on_identity_provider_changed)
-            identity_group.add(self.identity_provider_row)
-
-            # Custom agent socket — only shown when "Custom socket…" is selected. Written
-            # as a global `Host *` IdentityAgent directive to ~/.ssh/config.
-            self.identity_agent_socket_row = Adw.EntryRow(
-                title=_("Custom agent socket (IdentityAgent)"))
-            self.identity_agent_socket_row.set_text(
-                str(self.config.get_setting('identity.agent_socket', '') or ''))
-            self.identity_agent_socket_row.connect(
-                'changed', self.on_identity_agent_socket_changed)
-            identity_group.add(self.identity_agent_socket_row)
-            self._update_identity_rows_visibility(current_provider)
-
-            security_page.add(identity_group)
-
-            # Application behavior group
-            behavior_group = Adw.PreferencesGroup(title=_("Application Behavior"))
-            
-            # Confirm before disconnecting
-            self.confirm_disconnect_switch = Adw.SwitchRow()
-            self.confirm_disconnect_switch.set_title(_("Confirm before disconnecting"))
-            self.confirm_disconnect_switch.set_subtitle(_("Show a confirmation dialog when disconnecting from a host"))
-            self.confirm_disconnect_switch.set_active(
-                self.config.get_setting('confirm-disconnect', True)
-            )
-            self.confirm_disconnect_switch.connect('notify::active', self.on_confirm_disconnect_changed)
-            behavior_group.add(self.confirm_disconnect_switch)
-
-            # ssh.agent_preload_keys stays on by default (no Preferences toggle):
-            # the terminal worker force-unlocks configured identities into the
-            # agent so locked gcr keys cannot fall through to the system askpass.
-
-            advanced_page.add(behavior_group)
-
-            # Logging group ------------------------------------------------
-            logging_group = Adw.PreferencesGroup(title=_("Logging"))
-            logging_group.set_description(
-                _("Controls how verbose sshPilot is in the console and the rotated log file. "
-                "The command-line flags --verbose / --quiet always override this.")
-            )
-
-            self.logging_level_row = Adw.ComboRow()
-            self.logging_level_row.set_title(_("Log Level"))
-            self.logging_level_row.set_subtitle(
-                _("Default is concise; switch to Debug if you're filing a bug or chasing an issue")
-            )
-            log_levels_model = Gtk.StringList()
-            log_levels_model.append("Info — concise (recommended)")
-            log_levels_model.append("Debug — verbose")
-            self.logging_level_row.set_model(log_levels_model)
-            saved_level = str(
-                self.config.get_setting('logging.level', 'info') or 'info'
-            ).lower()
-            self.logging_level_row.set_selected(1 if saved_level == 'debug' else 0)
-            self.logging_level_row.connect(
-                'notify::selected', self.on_logging_level_changed
-            )
-            logging_group.add(self.logging_level_row)
-            advanced_page.add(logging_group)
-
-            # File management preferences moved to dedicated page
-
-            ssh_settings_page = Adw.PreferencesPage()
-            ssh_settings_page.set_title("SSH")
-            ssh_settings_page.set_icon_name("network-workgroup-symbolic")
-
-            help_group = Adw.PreferencesGroup()
-            help_row = Adw.ActionRow()
-            help_row.set_title(_("Custom SSH Options"))
-            help_row.set_subtitle(
-                _("These settings override values from your ~/.ssh/config.")
-            )
-            if hasattr(help_row, "set_activatable"):
-                help_row.set_activatable(False)
-            if hasattr(help_row, "set_selectable"):
-                help_row.set_selectable(False)
-            help_group.add(help_row)
-
-            advanced_group = Adw.PreferencesGroup(title=_("SSH Settings"))
-
-            # Connect timeout
-            self.connect_timeout_row = Adw.SpinRow.new_with_range(0, 120, 1)
-            self.connect_timeout_row.set_title(_("Connect Timeout (s)"))
-            connect_timeout_value = self.config.get_setting('ssh.connection_timeout', None)
-            try:
-                connect_timeout_value = int(connect_timeout_value)
-            except (TypeError, ValueError):
-                connect_timeout_value = 0
-            if connect_timeout_value < 0:
-                connect_timeout_value = 0
-            self.connect_timeout_row.set_value(connect_timeout_value)
-            advanced_group.add(self.connect_timeout_row)
-
-            # Connection attempts
-            self.connection_attempts_row = Adw.SpinRow.new_with_range(0, 10, 1)
-            self.connection_attempts_row.set_title(_("Connection Attempts"))
-            connection_attempts_value = self.config.get_setting('ssh.connection_attempts', None)
-            try:
-                connection_attempts_value = int(connection_attempts_value)
-            except (TypeError, ValueError):
-                connection_attempts_value = 0
-            if connection_attempts_value < 0:
-                connection_attempts_value = 0
-            self.connection_attempts_row.set_value(connection_attempts_value)
-            advanced_group.add(self.connection_attempts_row)
-
-            # Default keepalive opt-out. When on (default) and the user hasn't
-            # set an explicit ServerAlive interval below or in ~/.ssh/config,
-            # SSH Pilot applies a sane default so dropped links are detected.
-            self.apply_default_keepalive_row = Adw.SwitchRow()
-            self.apply_default_keepalive_row.set_title(_("Apply default keepalive"))
-            self.apply_default_keepalive_row.set_subtitle(
-                _("Detect dropped connections automatically when no ServerAlive "
-                "value is set here or in ~/.ssh/config. Explicit values always win.")
-            )
-            self.apply_default_keepalive_row.set_active(
-                bool(self.config.get_setting('ssh.apply_default_keepalive', True))
-            )
-            advanced_group.add(self.apply_default_keepalive_row)
-
-            # Keepalive interval
-            self.keepalive_interval_row = Adw.SpinRow.new_with_range(0, 300, 5)
-            self.keepalive_interval_row.set_title(_("ServerAlive Interval (s)"))
-            keepalive_interval_value = self.config.get_setting('ssh.keepalive_interval', None)
-            try:
-                keepalive_interval_value = int(keepalive_interval_value)
-            except (TypeError, ValueError):
-                keepalive_interval_value = 0
-            if keepalive_interval_value < 0:
-                keepalive_interval_value = 0
-            self.keepalive_interval_row.set_value(keepalive_interval_value)
-            advanced_group.add(self.keepalive_interval_row)
-
-            # Keepalive count max
-            self.keepalive_count_row = Adw.SpinRow.new_with_range(0, 10, 1)
-            self.keepalive_count_row.set_title(_("ServerAlive CountMax"))
-            keepalive_count_value = self.config.get_setting('ssh.keepalive_count_max', None)
-            try:
-                keepalive_count_value = int(keepalive_count_value)
-            except (TypeError, ValueError):
-                keepalive_count_value = 0
-            if keepalive_count_value < 0:
-                keepalive_count_value = 0
-            self.keepalive_count_row.set_value(keepalive_count_value)
-            advanced_group.add(self.keepalive_count_row)
-
-            # Strict host key checking
-            self.strict_host_row = Adw.ComboRow()
-            self.strict_host_row.set_title(_("StrictHostKeyChecking"))
-            strict_model = Gtk.StringList()
-            for item in ["accept-new", "yes", "no", "ask"]:
-                strict_model.append(item)
-            self.strict_host_row.set_model(strict_model)
-            # Map current value
-            current_strict = str(self.config.get_setting('ssh.strict_host_key_checking', 'accept-new'))
-            try:
-                idx = ["accept-new", "yes", "no", "ask"].index(current_strict)
-            except ValueError:
-                idx = 0
-            self.strict_host_row.set_selected(idx)
-            advanced_group.add(self.strict_host_row)
-
-            # BatchMode (non-interactive)
-            self.batch_mode_row = Adw.SwitchRow()
-            self.batch_mode_row.set_title(_("BatchMode (disable prompts)"))
-            self.batch_mode_row.set_active(bool(self.config.get_setting('ssh.batch_mode', False)))
-            advanced_group.add(self.batch_mode_row)
-
-            # Compression
-            self.compression_row = Adw.SwitchRow()
-            self.compression_row.set_title(_("Enable Compression (-C)"))
-            self.compression_row.set_active(bool(self.config.get_setting('ssh.compression', False)))
-            advanced_group.add(self.compression_row)
-
-            # Connection multiplexing (ControlMaster). When on, the first
-            # connection to a host opens a master socket that later connections
-            # reuse (no re-handshake) — faster reconnects and chatty operations.
-            self.controlmaster_row = Adw.SwitchRow()
-            self.controlmaster_row.set_title(_("Enable SSH connection multiplexing"))
-            self.controlmaster_row.set_subtitle(
-                _("Reuse one connection per host (ControlMaster) for faster reconnects")
-            )
-            self.controlmaster_row.set_active(bool(self.config.get_setting('ssh.controlmaster', False)))
-            advanced_group.add(self.controlmaster_row)
-
-            # SSH verbosity (-v levels)
-            self.verbosity_row = Adw.SpinRow.new_with_range(0, 3, 1)
-            self.verbosity_row.set_title(_("SSH Verbosity (-v)"))
-            self.verbosity_row.set_value(int(self.config.get_setting('ssh.verbosity', 0)))
-            advanced_group.add(self.verbosity_row)
-
-            # Debug logging toggle
-            self.debug_enabled_row = Adw.SwitchRow()
-            self.debug_enabled_row.set_title(_("Enable SSH Debug Logging"))
-            self.debug_enabled_row.set_active(bool(self.config.get_setting('ssh.debug_enabled', False)))
-            advanced_group.add(self.debug_enabled_row)
-
-
-            # Reset button
-            # Add spacing before reset button
-            advanced_group.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
-            
-            # Use Adw.ActionRow for proper spacing and layout
-            reset_row = Adw.ActionRow()
-            reset_row.set_title(_("Reset Advanced SSH Settings"))
-            reset_row.set_subtitle(_("Restore all advanced SSH settings to their default values"))
-            
-            reset_btn = Gtk.Button.new_with_label("Reset")
-            reset_btn.add_css_class('destructive-action')
-            reset_btn.set_valign(Gtk.Align.CENTER)
-            reset_btn.connect('clicked', self.on_reset_advanced_ssh)
-            reset_row.add_suffix(reset_btn)
-            
-            advanced_group.add(reset_row)
-
-            ssh_settings_page.add(help_group)
-            ssh_settings_page.add(advanced_group)
-
-            # Ensure shortcut overview controls reflect current state
-            self._set_shortcut_controls_enabled(not self._pass_through_enabled)
-
-            # Create File Management preferences page
-            file_management_page = Adw.PreferencesPage()
-            file_management_page.set_title(_("File Management"))
-            file_management_page.set_icon_name("folder-symbolic")
-            
-            # File Management group
-            if has_internal_file_manager():
-                file_manager_group = Adw.PreferencesGroup(title=_("File Manager Options"))
-                file_manager_group.set_description(
-                    _("These preferences only affect sshPilot's built-in SFTP file manager.")
-                )
-
-                self.force_internal_file_manager_row = None
-                if should_show_force_internal_file_manager_toggle():
-                    self.force_internal_file_manager_row = Adw.SwitchRow()
-                    self.force_internal_file_manager_row.set_title(_("Always Use Built-in File Manager"))
-                    self.force_internal_file_manager_row.set_subtitle(
-                        _("Use the in-app file manager even when system integrations are available")
-                    )
-                    self.force_internal_file_manager_row.set_active(
-                        bool(self.config.get_setting('file_manager.force_internal', False))
-                    )
-                    self.force_internal_file_manager_row.connect(
-                        'notify::active', self.on_force_internal_file_manager_changed
-                    )
-
-                    file_manager_group.add(self.force_internal_file_manager_row)
-
-                self.open_file_manager_externally_row = Adw.SwitchRow()
-                self.open_file_manager_externally_row.set_title(_("Open File Manager in Separate Window"))
-                self.open_file_manager_externally_row.set_subtitle(
-                    _("Show the built-in file manager in its own window instead of a tab")
-                )
-                self.open_file_manager_externally_row.set_active(
-                    bool(self.config.get_setting('file_manager.open_externally', False))
-                )
-                self.open_file_manager_externally_row.connect(
-                    'notify::active', self.on_open_file_manager_externally_changed
-                )
-
-                file_manager_group.add(self.open_file_manager_externally_row)
-
-                file_manager_defaults = {}
-                try:
-                    defaults = self.config.get_default_config()
-                    file_manager_defaults = defaults.get('file_manager', {}) if isinstance(defaults, dict) else {}
-                except Exception:
-                    file_manager_defaults = {}
-
-                file_manager_config: Dict[str, Any] = {}
-                if hasattr(self.config, 'get_file_manager_config'):
-                    try:
-                        file_manager_config = self.config.get_file_manager_config() or {}
-                    except Exception as exc:
-                        logger.debug("Failed to read file manager configuration: %s", exc)
-                        file_manager_config = {}
-
-                def _fm_default_int(key: str, fallback: int = 0) -> int:
-                    value = 0
-                    if isinstance(file_manager_defaults, dict):
-                        try:
-                            value = int(file_manager_defaults.get(key, fallback))
-                        except (TypeError, ValueError):
-                            value = fallback
-                    else:
-                        value = fallback
-                    return value if value >= 0 else fallback
-
-                def _fm_config_int(key: str, fallback: int) -> int:
-                    if isinstance(file_manager_config, dict):
-                        try:
-                            value = int(file_manager_config.get(key, fallback))
-                        except (TypeError, ValueError):
-                            value = fallback
-                        if value < 0:
-                            return fallback
-                        return value
-                    return fallback
-
-                keepalive_interval_default = _fm_default_int('sftp_keepalive_interval', 0)
-                keepalive_interval_value = _fm_config_int('sftp_keepalive_interval', keepalive_interval_default)
-                keepalive_interval_value = max(0, min(keepalive_interval_value, 3600))
-
-                sftp_advanced_group = Adw.PreferencesGroup(title=_("Advanced SFTP Settings"))
-                sftp_advanced_group.set_description(
-                    _("Fine-tune options that only apply to sshPilot's built-in SFTP file manager.")
-                )
-
-
-                self.sftp_keepalive_interval_row = Adw.SpinRow.new_with_range(0, 3600, 5)
-                self.sftp_keepalive_interval_row.set_title(_("SFTP Keepalive Interval (seconds)"))
-                self.sftp_keepalive_interval_row.set_subtitle(
-                    _("How often the built-in file manager sends keepalives. "
-                    "Set to 0 to disable.")
-                )
-                self.sftp_keepalive_interval_row.set_value(keepalive_interval_value)
-                sftp_advanced_group.add(self.sftp_keepalive_interval_row)
-
-
-                keepalive_count_default = _fm_default_int('sftp_keepalive_count_max', 0)
-                keepalive_count_value = _fm_config_int('sftp_keepalive_count_max', keepalive_count_default)
-                keepalive_count_value = max(0, min(keepalive_count_value, 10))
-
-                self.sftp_keepalive_count_row = Adw.SpinRow.new_with_range(0, 10, 1)
-                self.sftp_keepalive_count_row.set_title(_("SFTP Keepalive Retry Limit"))
-                self.sftp_keepalive_count_row.set_subtitle(
-                    _("Number of failed keepalives tolerated by the built-in file "
-                    "manager before raising an error.")
-                )
-                self.sftp_keepalive_count_row.set_value(keepalive_count_value)
-                sftp_advanced_group.add(self.sftp_keepalive_count_row)
-
-
-                connect_timeout_default = _fm_default_int('sftp_connect_timeout', 0)
-                connect_timeout_value = _fm_config_int('sftp_connect_timeout', connect_timeout_default)
-                connect_timeout_value = max(0, min(connect_timeout_value, 600))
-
-                self.sftp_connect_timeout_row = Adw.SpinRow.new_with_range(0, 600, 1)
-                self.sftp_connect_timeout_row.set_title(_("SFTP Connection Timeout (seconds)"))
-                self.sftp_connect_timeout_row.set_subtitle(
-                    _("Time allowed for the built-in file manager to establish a "
-                    "session; 0 uses the default.")
-                )
-                self.sftp_connect_timeout_row.set_value(connect_timeout_value)
-                sftp_advanced_group.add(self.sftp_connect_timeout_row)
-
-
-                self._update_external_file_manager_row()
-                file_management_page.add(file_manager_group)
-                file_management_page.add(sftp_advanced_group)
-            else:
-                # If no internal file manager, create empty page with message
-                no_file_manager_group = Adw.PreferencesGroup(title=_("File Manager"))
-                no_file_manager_row = Adw.ActionRow()
-                no_file_manager_row.set_title(_("File Manager Not Available"))
-                no_file_manager_row.set_subtitle(_("Built-in file manager is not available on this system"))
-                no_file_manager_group.add(no_file_manager_row)
-                file_management_page.add(no_file_manager_group)
-
-            # Updates page
-            updates_page = Adw.PreferencesPage()
-            updates_page.set_title(_("Updates"))
-            updates_page.set_icon_name("software-update-available-symbolic")
-            
-            updates_group = Adw.PreferencesGroup(title=_("Update Notifications"))
-            updates_group.set_description(_("Configure how SSH Pilot checks for updates"))
-            
-            # Check for updates on startup switch
-            self.check_updates_switch = Adw.SwitchRow()
-            self.check_updates_switch.set_title(_("Check for updates on startup"))
-            self.check_updates_switch.set_subtitle(_("Automatically check for new versions when the application starts"))
-            self.check_updates_switch.set_active(
-                self.config.get_setting('updates.check_on_startup', True)
-            )
-            self.check_updates_switch.connect('notify::active', self.on_check_updates_changed)
-            updates_group.add(self.check_updates_switch)
-            
-            updates_page.add(updates_group)
+            terminal_page = self._build_terminal_preferences_page()
+            groups_page = self._build_groups_preferences_page()
+            interface_page = self._build_interface_preferences_page()
+            shortcuts_page = self._build_shortcuts_preferences_page()
+            advanced_page, security_page = self._build_advanced_and_security_pages()
+            ssh_settings_page = self._build_ssh_settings_preferences_page()
+            file_management_page = self._build_file_management_preferences_page()
+            updates_page = self._build_updates_preferences_page()
 
             # Add pages to the custom layout
             self.add_page_to_layout(N_("Interface"), "applications-graphics-symbolic", interface_page)
@@ -2105,7 +2143,7 @@ class PreferencesWindow(Adw.Dialog):
             command_blocks_page = self._create_command_blocks_page()
             self.add_page_to_layout(N_("Command Blocks"), "view-list-symbolic", command_blocks_page)
             self.add_page_to_layout(N_("Advanced"), "applications-system-symbolic", advanced_page)
-            
+
             logger.info("Preferences window initialized")
         except Exception as e:
             logger.error(f"Failed to setup preferences: {e}")

--- a/src/sshpilot/scp_window.py
+++ b/src/sshpilot/scp_window.py
@@ -434,6 +434,82 @@ class ScpWindowController:
             identity_agent_disabled=identity_agent_disabled,
         )
 
+    def _scp_download_default_dir(self) -> str:
+        """Return a sensible default local Downloads path for SCP downloads."""
+        try:
+            default_download_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD)
+        except Exception:
+            default_download_dir = None
+        if not default_download_dir:
+            try:
+                default_download_dir = str(Path.home() / 'Downloads')
+            except Exception:
+                default_download_dir = GLib.get_home_dir() or os.path.expanduser('~')
+        return default_download_dir
+
+    @staticmethod
+    def _scp_transfer_copy(direction: str, target: str, destination: str) -> dict:
+        """UI copy strings for an SCP upload/download transfer dialog."""
+        if direction == 'upload':
+            return {
+                'title_text': _('Upload files (scp)'),
+                'running_text': _('Uploading to {target}:{path}').format(
+                    target=target, path=destination,
+                ),
+                'success_text': _('Uploaded to {target}:{path}').format(
+                    target=target, path=destination,
+                ),
+                'failure_text': _('Failed to upload to {target}:{path}').format(
+                    target=target, path=destination,
+                ),
+                'start_message': _('Starting upload…'),
+                'success_message': _('Upload finished successfully.'),
+                'failure_message': _('Upload failed. See output above.'),
+                'result_heading_fail': _('Upload failed'),
+            }
+        if direction == 'download':
+            return {
+                'title_text': _('Download files (scp)'),
+                'running_text': _('Downloading from {target}').format(target=target),
+                'success_text': _('Downloaded to {dest}').format(dest=destination),
+                'failure_text': _('Failed to download from {target}').format(
+                    target=target,
+                ),
+                'start_message': _('Starting download…'),
+                'success_message': _('Download finished successfully.'),
+                'failure_message': _('Download failed. See output above.'),
+                'result_heading_fail': _('Download failed'),
+            }
+        raise ValueError(f'Unsupported scp direction: {direction}')
+
+    def _prepare_scp_spawn_env(self) -> dict:
+        """Build the environment for spawning scp in the transfer terminal."""
+        env = os.environ.copy()
+        # Apply the auth env from resolve_native_auth (askpass for passphrases
+        # and stored login passwords; MFA stays on this VTE via prefer).
+        from .scp_utils import _apply_native_auth_env
+        _scp_auth = getattr(self, '_scp_auth', None)
+        if _scp_auth is not None:
+            _apply_native_auth_env(env, _scp_auth)
+            self._scp_auth = None
+            logger.debug(
+                "SCP: applied resolved auth env (askpass=%s)",
+                _scp_auth.use_askpass,
+            )
+
+        if os.path.exists('/app/bin'):
+            current_path = env.get('PATH', '')
+            if '/app/bin' not in current_path:
+                env['PATH'] = f"/app/bin:{current_path}"
+
+        logger.debug(
+            "SCP: Final environment variables: SSH_ASKPASS=%s, "
+            "SSH_ASKPASS_REQUIRE=%s",
+            env.get('SSH_ASKPASS', 'NOT_SET'),
+            env.get('SSH_ASKPASS_REQUIRE', 'NOT_SET'),
+        )
+        return env
+
     def _prompt_scp_download(self, connection):
         """Show a simple file picker that downloads selected remote files via scp."""
         from .window import _show_password_passphrase_dialog
@@ -485,15 +561,7 @@ class ScpWindowController:
             # Get display name for password prompts
             display_name = profile.alias or f"{username}@{host_value}"
 
-            try:
-                default_download_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD)
-            except Exception:
-                default_download_dir = None
-            if not default_download_dir:
-                try:
-                    default_download_dir = str(Path.home() / 'Downloads')
-                except Exception:
-                    default_download_dir = GLib.get_home_dir() or os.path.expanduser('~')
+            default_download_dir = self._scp_download_default_dir()
 
             dialog = ScpDownloadWindow(self.window, subtitle=display_name)
             # Register with the app so routed askpass prompts can find this
@@ -1117,34 +1185,15 @@ class ScpWindowController:
                 else host_value
             )
 
-            if direction == 'upload':
-                title_text = _('Upload files (scp)')
-                running_text = _('Uploading to {target}:{path}').format(
-                    target=target, path=destination,
-                )
-                success_text = _('Uploaded to {target}:{path}').format(
-                    target=target, path=destination,
-                )
-                failure_text = _('Failed to upload to {target}:{path}').format(
-                    target=target, path=destination,
-                )
-                start_message = _('Starting upload…')
-                success_message = _('Upload finished successfully.')
-                failure_message = _('Upload failed. See output above.')
-                result_heading_fail = _('Upload failed')
-            elif direction == 'download':
-                title_text = _('Download files (scp)')
-                running_text = _('Downloading from {target}').format(target=target)
-                success_text = _('Downloaded to {dest}').format(dest=destination)
-                failure_text = _('Failed to download from {target}').format(
-                    target=target,
-                )
-                start_message = _('Starting download…')
-                success_message = _('Download finished successfully.')
-                failure_message = _('Download failed. See output above.')
-                result_heading_fail = _('Download failed')
-            else:
-                raise ValueError(f'Unsupported scp direction: {direction}')
+            copy = self._scp_transfer_copy(direction, target, destination)
+            title_text = copy['title_text']
+            running_text = copy['running_text']
+            success_text = copy['success_text']
+            failure_text = copy['failure_text']
+            start_message = copy['start_message']
+            success_message = copy['success_message']
+            failure_message = copy['failure_message']
+            result_heading_fail = copy['result_heading_fail']
 
             dlg = ScpTransferDialog(title_text)
 
@@ -1249,31 +1298,7 @@ class ScpWindowController:
                 known_hosts_path=self.window.connection_manager.known_hosts_path,
             )
 
-            env = os.environ.copy()
-            # Apply the auth env from resolve_native_auth (askpass for passphrases
-            # and stored login passwords; MFA stays on this VTE via prefer).
-            from .scp_utils import _apply_native_auth_env
-            _scp_auth = getattr(self, '_scp_auth', None)
-            if _scp_auth is not None:
-                _apply_native_auth_env(env, _scp_auth)
-                self._scp_auth = None
-                logger.debug(
-                    "SCP: applied resolved auth env (askpass=%s)",
-                    _scp_auth.use_askpass,
-                )
-
-            if os.path.exists('/app/bin'):
-                current_path = env.get('PATH', '')
-                if '/app/bin' not in current_path:
-                    env['PATH'] = f"/app/bin:{current_path}"
-
-            logger.debug(
-                "SCP: Final environment variables: SSH_ASKPASS=%s, "
-                "SSH_ASKPASS_REQUIRE=%s",
-                env.get('SSH_ASKPASS', 'NOT_SET'),
-                env.get('SSH_ASKPASS_REQUIRE', 'NOT_SET'),
-            )
-            env_dict = dict(env)
+            env_dict = self._prepare_scp_spawn_env()
 
             def _feed_colored_line(text: str, color: str):
                 colors = {

--- a/src/sshpilot/sidebar.py
+++ b/src/sshpilot/sidebar.py
@@ -3428,13 +3428,8 @@ def _expand_toolbar_button(button: Gtk.Widget) -> Gtk.Widget:
     return button
 
 
-def build_sidebar(window):
-    """Set up the sidebar with connection list"""
-    sidebar_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-    # Ensure sidebar box expands to use full allocated width from NavigationSplitView
-    sidebar_box.set_hexpand(True)
-    sidebar_box.set_vexpand(True)
-    
+def _build_sidebar_header(window, sidebar_box):
+    """Build the sidebar action header (add/search/filter/sort/menu)."""
     # Sidebar header
     header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
     header.set_hexpand(True)
@@ -3601,6 +3596,8 @@ def build_sidebar(window):
     header_handle.set_child(header)
     sidebar_box.append(header_handle)
 
+def _build_sidebar_search(window, sidebar_box):
+    """Build the collapsible connection search entry."""
     # Search container
     search_container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
     search_container.add_css_class('search-container')
@@ -3633,6 +3630,8 @@ def build_sidebar(window):
     
     sidebar_box.append(search_container)
 
+def _create_sidebar_connection_list(window, sidebar_box):
+    """Create the connection ListBox and wire selection/DnD."""
     # Connection list
     window.connection_scrolled = Gtk.ScrolledWindow()
     window.connection_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -3684,6 +3683,8 @@ def build_sidebar(window):
     # Set up drag and drop for reordering
     setup_connection_list_dnd(window)
 
+def _attach_connection_list_context_menu(window):
+    """Attach right-click context menu and middle-click open handlers."""
     # Right-click context menu using simple gesture without coordinate detection
     try:
         # Use a simple gesture but avoid all coordinate-based operations
@@ -4049,7 +4050,9 @@ def build_sidebar(window):
         window.connection_list.add_controller(middle_click)
     except Exception:
         pass
-    
+
+def _attach_connection_list_shortcuts(window):
+    """Attach Ctrl/Cmd+Enter shortcut to open selected connections."""
     # Add keyboard controller for Ctrl/⌘+Enter to open new connection
     try:
         key_controller = Gtk.ShortcutController()
@@ -4080,10 +4083,9 @@ def build_sidebar(window):
         logger.debug(
             f"Failed to add {get_primary_modifier_label()}+Enter shortcut: {e}"
         )
-    
-    window.connection_scrolled.set_child(window.connection_list)
-    sidebar_box.append(window.connection_scrolled)
-    
+
+def _build_sidebar_toolbar(window, sidebar_box):
+    """Build connection and group toolbars at the bottom of the sidebar."""
     # Sidebar toolbar
     toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
     toolbar.set_hexpand(True)
@@ -4206,6 +4208,8 @@ def build_sidebar(window):
     
     sidebar_box.append(toolbar)
 
+def _assemble_sidebar_shell(window, sidebar_box):
+    """Wrap the sidebar content in HeaderBar + ToolbarView and attach it."""
     # Sidebar header: title + window controls (GNOME split-view pattern)
     window.sidebar_header_bar = Adw.HeaderBar()
     window.sidebar_header_bar.add_css_class('flat')
@@ -4225,6 +4229,25 @@ def build_sidebar(window):
 
     window._set_sidebar_widget(sidebar_toolbar_view)
     logger.debug("Set sidebar widget")
+
+def build_sidebar(window):
+    """Set up the sidebar with connection list"""
+    sidebar_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+    # Ensure sidebar box expands to use full allocated width from NavigationSplitView
+    sidebar_box.set_hexpand(True)
+    sidebar_box.set_vexpand(True)
+
+    _build_sidebar_header(window, sidebar_box)
+    _build_sidebar_search(window, sidebar_box)
+    _create_sidebar_connection_list(window, sidebar_box)
+    _attach_connection_list_context_menu(window)
+    _attach_connection_list_shortcuts(window)
+
+    window.connection_scrolled.set_child(window.connection_list)
+    sidebar_box.append(window.connection_scrolled)
+
+    _build_sidebar_toolbar(window, sidebar_box)
+    _assemble_sidebar_shell(window, sidebar_box)
 
 
 __all__ = ["ConnectionRow", "GroupRow", "build_sidebar"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1081: split the remaining oversized UI and askpass dispatchers without changing behavior.

### Changes
- **`askpass_utils.handle_askpass_cli`** (~215 → ~96 lines): shared `_prompt_via_main_or_dialog` plus presence/confirm/challenge/password/passphrase handlers; deduped login-password detection.
- **`preferences.setup_preferences`** (~1700 → ~30 lines): delegates to `_build_*_preferences_page` builders (terminal, groups, interface, shortcuts, advanced+security, SSH, file management, updates).
- **`sidebar.build_sidebar`** (~800 → ~18 lines): header/search/list/context-menu/shortcuts/toolbar/shell helpers.
- **`file_manager_window._on_request_operation`** (~634 → ~17 lines): thin dispatcher with per-action `_op_*` handlers (copy/cut, paste, mkdir, newfile, rename, delete, upload, download).
- **`scp_window`**: extracted `_scp_download_default_dir`, `_scp_transfer_copy`, and `_prepare_scp_spawn_env` (download/transfer dialog bodies remain large due to tightly coupled closures).

### Testing
- Askpass, prefs, sidebar, FM, SCP, and related unit tests: **277 passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7aec06-e0bc-43c3-b7f8-d447bdc8276f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7aec06-e0bc-43c3-b7f8-d447bdc8276f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

