### PR TITLE
Fix unused prefs assignment that failed ruff F841

### DIFF
--- a/tests/test_gui_preferences_dialog.py
+++ b/tests/test_gui_preferences_dialog.py
@@ -130,7 +130,7 @@ def test_dialog_presented_on_the_window_while_in_settings(gui):
     """A dialog parented to MainWindow still works while Settings mode is open."""
     from gi.repository import Adw
 
-    prefs = _open_preferences(gui)
+    _open_preferences(gui)
     assert gui.window.is_preferences_visible()
 
     alert = Adw.AlertDialog(heading='Unlock', body='parented to the window')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The Lint workflow on `main` failed because `tests/test_gui_preferences_dialog.py` assigned the return value of `_open_preferences(gui)` to `prefs` and never used it (`F841`).

This drop the unused assignment while still opening Settings before asserting visibility.

## Test plan
- [x] `ruff check src/ tests/` passes locally
- [ ] Confirm the Lint / ruff job is green on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcb0966f-bdfc-4626-8a07-1f11ccc65d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb0966f-bdfc-4626-8a07-1f11ccc65d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

