### PR TITLE
Fix macOS JSON text preview during connection-row DnD

### DIFF
--- a/src/sshpilot/command_blocks.py
+++ b/src/sshpilot/command_blocks.py
@@ -13,7 +13,7 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib, GObject, Gdk, Pango
 
 from .context_menu import IconContextMenu
-from .dnd_payload import content_provider_for_payload
+from .dnd_payload import content_provider_for_payload, set_internal_drag_icon
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -1225,7 +1225,12 @@ class CommandBlocksPanel(Gtk.Box):
                 'has_placeholders': _cmd.get('has_placeholders', False),
             })
 
+        def _on_begin(src, _drag):
+            # macOS string payloads render as drag text unless we set an icon.
+            set_internal_drag_icon(src, row)
+
         drag_source.connect('prepare', _on_prepare)
+        drag_source.connect('drag-begin', _on_begin)
         row.add_controller(drag_source)
 
     # ------------------------------------------------------------------

--- a/src/sshpilot/dnd_payload.py
+++ b/src/sshpilot/dnd_payload.py
@@ -14,6 +14,9 @@ command-block drags must do the same.
 Encode every in-app drag as a JSON string under ``format`` =
 ``sshpilot_internal_drag``, and receive it with ``Gtk.DropTarget`` typed as
 ``GObject.TYPE_STRING``.
+
+On macOS, AppKit previews that string beside the cursor unless a custom
+drag icon is attached via :func:`set_internal_drag_icon`.
 """
 
 from __future__ import annotations
@@ -41,6 +44,39 @@ def encode_dnd_payload(payload: dict) -> str:
 def content_provider_for_payload(payload: dict) -> Gdk.ContentProvider:
     """Return a ``TYPE_STRING`` content provider for *payload*."""
     return Gdk.ContentProvider.new_for_value(encode_dnd_payload(payload))
+
+
+def set_internal_drag_icon(
+    source: Gtk.DragSource,
+    widget: Gtk.Widget,
+    *,
+    drag: Optional[Gdk.Drag] = None,
+    icon_name: Optional[str] = None,
+) -> None:
+    """Attach a drag preview that does not expose the JSON payload string.
+
+    Internal drags advertise a pasteboard-safe JSON string. On macOS, AppKit
+    previews string content as that text beside the cursor unless a custom
+    icon is set. Prefer ``DragSource.set_icon`` over ``Gtk.DragIcon`` on
+    macOS — ``DragIcon`` has tripped AppKit during
+    ``beginDraggingSessionWithItems``.
+
+    On other platforms, keep the existing ``DragIcon`` + symbolic-icon look
+    when *drag* and *icon_name* are provided; otherwise fall back to a
+    widget paintable.
+    """
+    from .platform_utils import is_macos
+
+    try:
+        if is_macos() or drag is None or not icon_name:
+            source.set_icon(Gtk.WidgetPaintable.new(widget), 0, 0)
+            return
+        icon = Gtk.DragIcon.get_for_drag(drag)
+        image = Gtk.Image.new_from_icon_name(icon_name)
+        image.set_icon_size(Gtk.IconSize.LARGE)
+        icon.set_child(image)
+    except Exception as exc:
+        logger.debug("Could not set drag icon: %s", exc)
 
 
 def new_internal_drop_target(

--- a/src/sshpilot/file_manager/pane.py
+++ b/src/sshpilot/file_manager/pane.py
@@ -2211,13 +2211,10 @@ class FilePane(Gtk.Box):
     def _on_drag_begin(self, drag_source: Gtk.DragSource, drag: Gdk.Drag) -> None:
         """Called when drag operation begins - set drag icon."""
         logger.debug(f"Drag begin: pane={self._is_remote}")
-        if is_macos():
-            # macOS provides its own drag preview; avoid setting a custom icon.
-            return
-        # Create a simple icon for the drag operation
+        # Always set a custom icon. On macOS, string ContentProviders are
+        # otherwise previewed as the JSON payload text beside the cursor.
         widget = drag_source.get_widget()
         if widget:
-            # Create a paintable from the widget to use as drag icon
             paintable = Gtk.WidgetPaintable.new(widget)
             drag_source.set_icon(paintable, 0, 0)
 

--- a/src/sshpilot/sidebar.py
+++ b/src/sshpilot/sidebar.py
@@ -16,6 +16,7 @@ from .dnd_payload import (
     content_provider_for_payload,
     decode_dnd_payload,
     new_internal_drop_target,
+    set_internal_drag_icon,
 )
 from .platform_utils import is_macos
 from .connection_manager import Connection
@@ -900,16 +901,10 @@ class GroupRow(Gtk.ListBoxRow):
         )
 
     def _on_drag_begin(self, source, drag):
-        # macOS supplies its own drag preview; custom DragIcon can also trip
-        # AppKit during beginDraggingSessionWithItems.
-        if not is_macos():
-            try:
-                icon = Gtk.DragIcon.get_for_drag(drag)
-                image = Gtk.Image.new_from_icon_name("folder-symbolic")
-                image.set_icon_size(Gtk.IconSize.LARGE)
-                icon.set_child(image)
-            except Exception as e:
-                logger.debug(f"Could not set group drag icon: {e}")
+        # macOS string payloads render as drag text unless we set an icon.
+        set_internal_drag_icon(
+            source, self, drag=drag, icon_name="folder-symbolic"
+        )
         try:
             window = self.get_root()
             if window:
@@ -1719,14 +1714,10 @@ class ConnectionRow(Gtk.ListBoxRow):
         return content_provider_for_payload(data)
 
     def _on_drag_begin(self, source, drag):
-        if not is_macos():
-            try:
-                icon = Gtk.DragIcon.get_for_drag(drag)
-                image = Gtk.Image.new_from_icon_name("computer-symbolic")
-                image.set_icon_size(Gtk.IconSize.LARGE)
-                icon.set_child(image)
-            except Exception as e:
-                logger.debug(f"Could not set drag icon: {e}")
+        # macOS string payloads render as drag text unless we set an icon.
+        set_internal_drag_icon(
+            source, self, drag=drag, icon_name="computer-symbolic"
+        )
         try:
             window = self.get_root()
             if window:

--- a/tests/test_dnd_payload.py
+++ b/tests/test_dnd_payload.py
@@ -3,14 +3,19 @@
 macOS crashes when Gtk.DragSource advertises GObject.TYPE_PYOBJECT (see
 GitHub #704/#847/#876). These tests pin the encode/decode contract used by
 sidebar, split-view, and command-block drags.
+
+They also pin that string payloads get a custom drag icon on macOS so AppKit
+does not render the JSON beside the cursor.
 """
 
 import json
+from unittest.mock import MagicMock
 
 from sshpilot.dnd_payload import (
     DND_FORMAT,
     decode_dnd_payload,
     encode_dnd_payload,
+    set_internal_drag_icon,
 )
 from sshpilot.split_view import _connections_from_drop_payload
 
@@ -59,3 +64,60 @@ def test_connections_from_encoded_group_returns_empty():
 def test_connections_plain_string_still_empty():
     # Invalid / non-payload strings must not be treated as nicknames.
     assert _connections_from_drop_payload("nick") == []
+
+
+def test_set_internal_drag_icon_uses_widget_paintable_on_macos(monkeypatch):
+    import sshpilot.dnd_payload as dnd
+
+    source = MagicMock()
+    widget = MagicMock()
+    paintable = object()
+    monkeypatch.setattr(
+        "sshpilot.platform_utils.is_macos", lambda: True
+    )
+    monkeypatch.setattr(
+        dnd.Gtk.WidgetPaintable,
+        "new",
+        staticmethod(lambda w: paintable),
+    )
+
+    set_internal_drag_icon(source, widget, drag=object(), icon_name="computer-symbolic")
+
+    source.set_icon.assert_called_once_with(paintable, 0, 0)
+
+
+def test_set_internal_drag_icon_uses_dragicon_off_macos(monkeypatch):
+    import sshpilot.dnd_payload as dnd
+
+    source = MagicMock()
+    widget = MagicMock()
+    drag = object()
+    icon = MagicMock()
+    image = MagicMock()
+
+    monkeypatch.setattr(
+        "sshpilot.platform_utils.is_macos", lambda: False
+    )
+    monkeypatch.setattr(
+        dnd.Gtk.DragIcon,
+        "get_for_drag",
+        staticmethod(lambda d: icon),
+    )
+    monkeypatch.setattr(
+        dnd.Gtk.Image,
+        "new_from_icon_name",
+        staticmethod(lambda name: image),
+    )
+    # Avoid IconSize attribute lookup issues in environments without full GTK.
+    if not hasattr(dnd.Gtk, "IconSize"):
+        dnd.Gtk.IconSize = MagicMock(LARGE=2)
+    else:
+        monkeypatch.setattr(dnd.Gtk.IconSize, "LARGE", 2, raising=False)
+
+    set_internal_drag_icon(
+        source, widget, drag=drag, icon_name="computer-symbolic"
+    )
+
+    source.set_icon.assert_not_called()
+    icon.set_child.assert_called_once_with(image)
+    image.set_icon_size.assert_called_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On macOS, dragging connection rows showed a long JSON string beside the cursor. That came from the pasteboard-safe string payload (needed to avoid the NSPasteboard / `TYPE_PYOBJECT` crash) combined with skipping a custom drag icon on macOS.

## Fix
- Add `set_internal_drag_icon()` so macOS uses `DragSource.set_icon(WidgetPaintable)` instead of falling back to AppKit’s string preview
- Keep the existing `Gtk.DragIcon` + symbolic icon path on Linux
- Apply the same pattern to group rows, command-block drags, and file-manager drags (same root cause)

## Test plan
- [x] `pytest tests/test_dnd_payload.py`
- [ ] On macOS: drag a connection row — cursor shows a row/icon preview, not JSON text
- [ ] On macOS: drag a group row and a command block — same
- [ ] Confirm sidebar reorder / drop-to-tab still works
- [ ] On Linux: drag still shows the symbolic computer/folder icon
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-353e8e34-bed6-4dfd-a2d5-db775a794d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-353e8e34-bed6-4dfd-a2d5-db775a794d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

