### PR TITLE
Stop storing vault master passwords in Keychain

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,9 +137,11 @@ Backend specifics:
   saves it to the **platform keyring** (libsecret/keyring) — never the vault it unlocks —
   via `SecretManager.store_in_keyring`/`lookup_in_keyring`/`delete_in_keyring` and
   `master_password_spec` (keyed by backend + `BITWARDENCLI_APPDATA_DIR` profile,
-  selection-independent). When a saved password exists, `prompt_unlock` auto-unlocks with
-  it but still shows the "Unlocking…" spinner; a stale saved password is dropped and the
-  manual prompt shown.
+  selection-independent). Keyring access is gated by
+  `secrets.remember_master_password` so a session vault (including `keepassxc` on
+  macOS) does not probe Keychain until the user opts in. When that flag is set and a
+  saved password exists, `prompt_unlock` auto-unlocks with it but still shows the
+  "Unlocking…" spinner; a stale saved password is dropped and the manual prompt shown.
 - **`agent`** means *don't store secrets at all*: a null backend. When explicitly
   selected, `SecretManager` consults only it (no fallback/fallthrough) so nothing
   is written to or read from other stores; the user relies on ssh-agent (the existing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,15 +133,12 @@ Backend specifics:
   never prompts); it is driven from Preferences and lazily from
   `terminal_manager.connect_to_host`. Signing in (`bw login`, and `bw config server <url>`
   first for a self-hosted Vaultwarden) is a one-time user step in a terminal — the app
-  only runs `bw unlock`. The prompt has an opt-in **"Remember master password"** that
-  saves it to the **platform keyring** (libsecret/keyring) — never the vault it unlocks —
-  via `SecretManager.store_in_keyring`/`lookup_in_keyring`/`delete_in_keyring` and
-  `master_password_spec` (keyed by backend + `BITWARDENCLI_APPDATA_DIR` profile,
-  selection-independent). Keyring access is gated by
-  `secrets.remember_master_password` so a session vault (including `keepassxc` on
-  macOS) does not probe Keychain until the user opts in. When that flag is set and a
-  saved password exists, `prompt_unlock` auto-unlocks with it but still shows the
-  "Unlocking…" spinner; a stale saved password is dropped and the manual prompt shown.
+  only runs `bw unlock`. The master password is typed at unlock and is **not**
+  stored in the OS keyring / Keychain (alternative backends exist to avoid that).
+  After unlock, only the in-process session token (`BW_SESSION`) is kept until
+  idle timeout or exit. For KeePass, prefer an optional **key file**
+  (`secrets.keepassxc.keyfile`) as the KeePass-native way to strengthen unlock
+  without involving Keychain.
 - **`agent`** means *don't store secrets at all*: a null backend. When explicitly
   selected, `SecretManager` consults only it (no fallback/fallthrough) so nothing
   is written to or read from other stores; the user relies on ssh-agent (the existing

--- a/src/sshpilot/config.py
+++ b/src/sshpilot/config.py
@@ -155,11 +155,17 @@ class Config(GObject.Object):
                     'profile': '',
                 },
                 # KeePass (.kdbx) backend: path to the database file and an optional key
-                # file. The master password is typed per launch (kept in memory).
+                # file. The master password is typed per launch (kept in memory) unless
+                # the user opts into "Remember master password" (see below).
                 'keepassxc': {
                     'database': '',
                     'keyfile': '',
                 },
+                # When True, the unlock dialog may auto-read / write the vault master
+                # password via the OS keyring (Keychain on macOS). Default False so a
+                # session vault (keepassxc/bitwarden) does not touch Keychain until the
+                # user explicitly checks "Remember master password".
+                'remember_master_password': False,
             },
             'identity': {
                 # Default SSH agent offered to connections. 'auto' = the OS/desktop

--- a/src/sshpilot/config.py
+++ b/src/sshpilot/config.py
@@ -155,17 +155,13 @@ class Config(GObject.Object):
                     'profile': '',
                 },
                 # KeePass (.kdbx) backend: path to the database file and an optional key
-                # file. The master password is typed per launch (kept in memory) unless
-                # the user opts into "Remember master password" (see below).
+                # file. The master password is typed per launch and kept only in memory
+                # for the session (never in the OS keyring / Keychain). Use a key file
+                # if you want a second factor or less password typing.
                 'keepassxc': {
                     'database': '',
                     'keyfile': '',
                 },
-                # When True, the unlock dialog may auto-read / write the vault master
-                # password via the OS keyring (Keychain on macOS). Default False so a
-                # session vault (keepassxc/bitwarden) does not touch Keychain until the
-                # user explicitly checks "Remember master password".
-                'remember_master_password': False,
             },
             'identity': {
                 # Default SSH agent offered to connections. 'auto' = the OS/desktop

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -1733,18 +1733,6 @@ class PreferencesWindow(Adw.NavigationPage):
         )
         secrets_group.add(self.secret_session_timeout_row)
 
-        # Forget a remembered master password (saved in the OS keyring via the unlock
-        # dialog's "Remember" option). This is the only way to clear it once saved,
-        # since auto-unlock then skips the dialog. Shown for session-backed backends.
-        self.forget_master_row = Adw.ActionRow(title=_("Saved master password"))
-        forget_btn = Gtk.Button(label=_("Forget"))
-        forget_btn.set_valign(Gtk.Align.CENTER)
-        forget_btn.add_css_class('destructive-action')
-        forget_btn.connect('clicked', self.on_forget_master_password)
-        self.forget_master_row.add_suffix(forget_btn)
-        self._forget_master_btn = forget_btn
-        secrets_group.add(self.forget_master_row)
-
         self.agent_no_store_row = Adw.ActionRow()
         self.agent_no_store_row.set_title(_("No secret storage"))
         self.agent_no_store_row.set_subtitle(_(
@@ -1753,7 +1741,7 @@ class PreferencesWindow(Adw.NavigationPage):
         ))
         secrets_group.add(self.agent_no_store_row)
 
-        # Show the bw/timeout/forget rows only when they apply to the
+        # Show the bw/timeout rows only when they apply to the
         # currently-selected backend. Backend probes (``bw status``, rbw, …)
         # run only when the user opens this page — not on every Settings open.
         self._update_secret_rows_visibility(current_backend, defer_status_probe=True)
@@ -2581,9 +2569,6 @@ class PreferencesWindow(Adw.NavigationPage):
                     getattr(self, attr).set_visible(name == 'keepassxc')
             if hasattr(self, 'secret_session_timeout_row'):
                 self.secret_session_timeout_row.set_visible(session)
-            if hasattr(self, 'forget_master_row'):
-                self.forget_master_row.set_visible(session)
-                self._refresh_forget_master_row()
             if hasattr(self, 'agent_no_store_row'):
                 self.agent_no_store_row.set_visible(name == 'agent')
             if hasattr(self, 'secret_backend_row'):
@@ -2596,6 +2581,11 @@ class PreferencesWindow(Adw.NavigationPage):
                     hint = _("Uses the bw CLI. See bitwarden.com/help/cli.")
                 elif name == 'rbw':
                     hint = _("Uses the rbw CLI + agent. Unlock with rbw (github.com/doy/rbw).")
+                elif name == 'keepassxc':
+                    hint = _(
+                        "Master password is typed per launch (kept in memory only). "
+                        "Optional key file is the KeePass-native second factor."
+                    )
                 else:
                     hint = ""
                 try:
@@ -2604,42 +2594,6 @@ class PreferencesWindow(Adw.NavigationPage):
                     pass
         except Exception as exc:
             logger.debug("Failed to update secret rows visibility: %s", exc)
-
-    def _refresh_forget_master_row(self):
-        """Reflect whether a master password is currently saved in the keyring.
-
-        Uses the remember opt-in flag rather than probing the OS keyring, so opening
-        Preferences with a .kdbx backend does not trigger a macOS Keychain unlock.
-        """
-        if not hasattr(self, 'forget_master_row'):
-            return
-        saved = False
-        try:
-            from .secret_storage import remember_master_password_enabled
-            saved = remember_master_password_enabled()
-        except Exception:
-            saved = False
-        self.forget_master_row.set_subtitle(
-            _("Remembered in your system keyring.") if saved
-            else _("Not saved. Use “Remember master password” when unlocking.")
-        )
-        if hasattr(self, '_forget_master_btn'):
-            self._forget_master_btn.set_sensitive(saved)
-
-    def on_forget_master_password(self, _button):
-        """Delete the remembered master password from the OS keyring."""
-        try:
-            from .secret_storage import (
-                get_secret_manager,
-                selected_master_spec,
-                set_remember_master_password,
-            )
-            get_secret_manager().delete_in_keyring(selected_master_spec())
-            set_remember_master_password(False)
-            logger.info("Forgot saved vault master password")
-        except Exception:
-            logger.debug("Failed to forget master password", exc_info=True)
-        self._refresh_forget_master_row()
 
     def on_secret_backend_changed(self, combo, _pspec):
         """Persist the selected secret storage backend and apply it live."""
@@ -2803,8 +2757,6 @@ class PreferencesWindow(Adw.NavigationPage):
                     self._update_secret_rows_visibility('bitwarden')
                 except Exception:
                     logger.debug("Failed to refresh Bitwarden rows after setup", exc_info=True)
-                if success:
-                    self._refresh_forget_master_row()
 
             run_bitwarden_setup(self, on_done=_done)
         except Exception as exc:

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -2606,13 +2606,17 @@ class PreferencesWindow(Adw.NavigationPage):
             logger.debug("Failed to update secret rows visibility: %s", exc)
 
     def _refresh_forget_master_row(self):
-        """Reflect whether a master password is currently saved in the keyring."""
+        """Reflect whether a master password is currently saved in the keyring.
+
+        Uses the remember opt-in flag rather than probing the OS keyring, so opening
+        Preferences with a .kdbx backend does not trigger a macOS Keychain unlock.
+        """
         if not hasattr(self, 'forget_master_row'):
             return
         saved = False
         try:
-            from .secret_storage import get_secret_manager, selected_master_spec
-            saved = bool(get_secret_manager().lookup_in_keyring(selected_master_spec()))
+            from .secret_storage import remember_master_password_enabled
+            saved = remember_master_password_enabled()
         except Exception:
             saved = False
         self.forget_master_row.set_subtitle(
@@ -2625,8 +2629,13 @@ class PreferencesWindow(Adw.NavigationPage):
     def on_forget_master_password(self, _button):
         """Delete the remembered master password from the OS keyring."""
         try:
-            from .secret_storage import get_secret_manager, selected_master_spec
+            from .secret_storage import (
+                get_secret_manager,
+                selected_master_spec,
+                set_remember_master_password,
+            )
             get_secret_manager().delete_in_keyring(selected_master_spec())
+            set_remember_master_password(False)
             logger.info("Forgot saved vault master password")
         except Exception:
             logger.debug("Failed to forget master password", exc_info=True)

--- a/src/sshpilot/secret_storage.py
+++ b/src/sshpilot/secret_storage.py
@@ -427,6 +427,30 @@ def selected_master_spec(manager: Optional["SecretManager"] = None) -> SecretSpe
     return master_password_spec(name, profile)
 
 
+# Config gate for OS-keyring access of the vault master password. Without this, every
+# unlock probed Keychain (lookup) and every "don't remember" unlock still called delete —
+# which on macOS surfaces a Keychain unlock prompt even when using a .kdbx backend.
+REMEMBER_MASTER_SETTING = "secrets.remember_master_password"
+
+
+def remember_master_password_enabled() -> bool:
+    """Whether the user opted to keep the vault master password in the OS keyring."""
+    try:
+        from .config import Config
+        return bool(Config().get_setting(REMEMBER_MASTER_SETTING, False))
+    except Exception:
+        return False
+
+
+def set_remember_master_password(enabled: bool) -> None:
+    """Persist the Remember-master-password opt-in (and gate future Keychain probes)."""
+    try:
+        from .config import Config
+        Config().set_setting(REMEMBER_MASTER_SETTING, bool(enabled))
+    except Exception:
+        logger.debug("Failed to persist %s", REMEMBER_MASTER_SETTING, exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Session idle timeout (shared by session-backed backends)
 # ---------------------------------------------------------------------------

--- a/src/sshpilot/secret_storage.py
+++ b/src/sshpilot/secret_storage.py
@@ -391,14 +391,11 @@ def parse_account(account: str, *, username_hint: Optional[str] = None) -> Dict[
 
 
 def master_password_spec(backend_name: str = "bitwarden", profile: str = "") -> SecretSpec:
-    """Spec for a session vault's **master password** (e.g. the Bitwarden unlock
-    password), keyed by backend and account/profile so multiple accounts don't collide.
+    """Spec historically used for a session vault's master password in the OS keyring.
 
-    This is the one secret that must NOT live in the session vault it unlocks (circular),
-    so it is always stored in the platform keyring via
-    :meth:`SecretManager.store_in_keyring`. ``type=vault_master`` keeps it distinct from
-    host passwords, and the unique account id is carried in the schema's ``key_path``
-    attribute (the libsecret schema has no ``backend``/``profile`` keys)."""
+    The unlock UI no longer persists the master password (alternative backends exist to
+    avoid Keychain). Kept for tests and any leftover keyring cleanup tooling.
+    ``type=vault_master`` keeps it distinct from host passwords."""
     account = f"{backend_name}-master:{profile or 'default'}"
     return SecretSpec(
         keyring_service=SERVICE_NAME,
@@ -414,9 +411,7 @@ def master_password_spec(backend_name: str = "bitwarden", profile: str = "") -> 
 
 
 def selected_master_spec(manager: Optional["SecretManager"] = None) -> SecretSpec:
-    """:func:`master_password_spec` for the currently-selected backend + profile —
-    the single source of truth shared by the unlock dialog and Preferences so a saved
-    password is stored, read, and forgotten under the same key."""
+    """:func:`master_password_spec` for the currently-selected backend + profile."""
     mgr = manager if manager is not None else get_secret_manager()
     backend = mgr.selected_backend()
     name = (getattr(backend, "name", "") or "session").strip().lower()
@@ -425,30 +420,6 @@ def selected_master_spec(manager: Optional["SecretManager"] = None) -> SecretSpe
     else:
         profile = os.environ.get("BITWARDENCLI_APPDATA_DIR", "")
     return master_password_spec(name, profile)
-
-
-# Config gate for OS-keyring access of the vault master password. Without this, every
-# unlock probed Keychain (lookup) and every "don't remember" unlock still called delete —
-# which on macOS surfaces a Keychain unlock prompt even when using a .kdbx backend.
-REMEMBER_MASTER_SETTING = "secrets.remember_master_password"
-
-
-def remember_master_password_enabled() -> bool:
-    """Whether the user opted to keep the vault master password in the OS keyring."""
-    try:
-        from .config import Config
-        return bool(Config().get_setting(REMEMBER_MASTER_SETTING, False))
-    except Exception:
-        return False
-
-
-def set_remember_master_password(enabled: bool) -> None:
-    """Persist the Remember-master-password opt-in (and gate future Keychain probes)."""
-    try:
-        from .config import Config
-        Config().set_setting(REMEMBER_MASTER_SETTING, bool(enabled))
-    except Exception:
-        logger.debug("Failed to persist %s", REMEMBER_MASTER_SETTING, exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -2164,9 +2135,9 @@ class SecretManager:
         return ["keyring"] if is_macos() else ["libsecret", "keyring"]
 
     # -- platform keyring (selection-independent) -------------------------
-    # Used for the session vault's master password, which must be stored in the OS
-    # keyring regardless of the selected backend (it cannot live in the vault it
-    # unlocks, nor in `pass`/`agent`).
+    # Generic helpers for callers that need the OS keyring specifically.
+    # Session-vault master passwords are NOT stored here — they are typed per
+    # unlock and held only in the in-process session (see secret_unlock_dialog).
     def _platform_keyring_backends(self) -> List[SecretBackend]:
         out: List[SecretBackend] = []
         for name in self._platform_default_order():   # libsecret then keyring (Linux)

--- a/src/sshpilot/secret_unlock_dialog.py
+++ b/src/sshpilot/secret_unlock_dialog.py
@@ -14,7 +14,6 @@ off the main thread.
 """
 
 import logging
-import os
 import threading
 from gettext import gettext as _
 
@@ -23,13 +22,7 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 
-from .secret_storage import (
-    get_secret_manager,
-    master_password_spec,
-    remember_master_password_enabled,
-    selected_master_spec,
-    set_remember_master_password,
-)
+from .secret_storage import get_secret_manager
 from .window_dialogs import parent_window
 
 logger = logging.getLogger(__name__)
@@ -325,6 +318,10 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
     unlock was needed), and ``False`` when it merely **rode** an already-open prompt. The
     connect flow uses this to avoid silently proceeding on a *ridden* prompt that resolves
     still-locked (e.g. a startup unlock the user cancelled).
+
+    The master password is never written to the OS keyring / Keychain: alternative backends
+    exist specifically to avoid that. After unlock it lives only in the in-process session
+    (KDBX ``SSHPILOT_KDBX_KEY``, Bitwarden ``BW_SESSION``) until idle timeout or exit.
     """
     global _unlock_in_progress
     manager = get_secret_manager()
@@ -343,9 +340,6 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
                 return bool(manager.selected_needs_login())
             except Exception:
                 return False
-
-        def _master_spec():
-            return selected_master_spec(manager)
     else:
         target = manager.get_backend(backend) if isinstance(backend, str) else backend
 
@@ -357,12 +351,6 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
                 return bool(target is not None and target.needs_login())
             except Exception:
                 return False
-
-        def _master_spec():
-            name = (getattr(target, "name", "") or "session").strip().lower()
-            profile = (os.environ.get("SSHPILOT_KDBX_DATABASE", "") if name == "keepassxc"
-                       else os.environ.get("BITWARDENCLI_APPDATA_DIR", ""))
-            return master_password_spec(name, profile)
 
         _needs_unlock = bool(
             target is not None and getattr(target, "session_backed", False)
@@ -412,10 +400,7 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
     _spinner = [None]
 
     # -- run the unlock (spinner + worker) for a given password -----------
-    def _run_unlock(password, *, source, remember):
-        # ``source`` is 'manual' (typed in the entry dialog, ``remember`` = checkbox) or
-        # 'saved' (a master password read from the keyring → auto-unlock). The spinner is
-        # always shown, so startup still displays the "Unlocking…" alert when auto-unlocking.
+    def _run_unlock(password):
         def _worker(set_status):
             ok = False
             needs_login = False
@@ -443,30 +428,7 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
             close, spin = _spinner[0] if _spinner[0] is not None else (lambda: None, None)
 
             if ok:
-                # Persist the "remember" choice on a manual unlock; a saved password that
-                # just worked stays as-is. Only touch the OS keyring when the user has
-                # opted in (or is clearing a previous opt-in) — otherwise macOS shows a
-                # Keychain unlock prompt even for a pure .kdbx vault.
-                if source == 'manual':
-                    try:
-                        if remember:
-                            if manager.store_in_keyring(_master_spec(), password):
-                                set_remember_master_password(True)
-                        elif remember_master_password_enabled():
-                            manager.delete_in_keyring(_master_spec())
-                            set_remember_master_password(False)
-                    except Exception:
-                        logger.debug("persisting master password failed", exc_info=True)
                 on_spinner_closed = lambda *_a: _finish(True)
-            elif source == 'saved':
-                # The saved password is stale (e.g. the master password changed). Forget it
-                # and fall back to a manual entry dialog — no error popup.
-                try:
-                    manager.delete_in_keyring(_master_spec())
-                except Exception:
-                    pass
-                set_remember_master_password(False)
-                on_spinner_closed = lambda *_a: _show_password_dialog()
             elif needs_login:
                 from .bitwarden_setup import _prompt_gui_login
 
@@ -530,22 +492,7 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
         # set_activates_default() convenience method — set it via the property so
         # Enter triggers the dialog's default response.
         entry.set_property('activates-default', True)
-        remember_check = Gtk.CheckButton(label=_("Remember master password"))
-        remember_check.set_active(remember_master_password_enabled())
-        caption = Gtk.Label(label=_("Stored in your system keyring."))
-        caption.set_xalign(0)
-        caption.set_wrap(True)
-        caption.set_margin_start(28)
-        for css in ("dim-label", "caption"):
-            try:
-                caption.add_css_class(css)
-            except Exception:
-                pass
-        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        box.append(entry)
-        box.append(remember_check)
-        box.append(caption)
-        dialog.set_extra_child(box)
+        dialog.set_extra_child(entry)
 
         dialog.add_response('cancel', _("Cancel"))
         dialog.add_response('unlock', _("Unlock"))
@@ -575,9 +522,8 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
                 _cancel_finish_if_ready()
                 return
             password = entry.get_text() or ''
-            remember = bool(remember_check.get_active())
             # _run_unlock shows the spinner once this dialog has closed.
-            _run_unlock(password, source='manual', remember=remember)
+            _run_unlock(password)
 
         def _on_pw_closed(_d):
             _pw_closed_fired[0] = True
@@ -603,17 +549,5 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
 
         GLib.idle_add(_focus_entry)
 
-    # Auto-unlock with a saved master password (still shows the spinner), else prompt.
-    # Gate the keyring probe on the remember opt-in so session vaults (esp. keepassxc
-    # on macOS) never open Keychain unless the user asked to save the master password.
-    saved = None
-    if remember_master_password_enabled():
-        try:
-            saved = manager.lookup_in_keyring(_master_spec())
-        except Exception:
-            logger.debug("saved master password lookup failed", exc_info=True)
-    if saved:
-        _run_unlock(saved, source='saved', remember=True)
-    else:
-        _show_password_dialog()
+    _show_password_dialog()
     return True   # this call owns the (newly shown) prompt

--- a/src/sshpilot/secret_unlock_dialog.py
+++ b/src/sshpilot/secret_unlock_dialog.py
@@ -23,7 +23,13 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 
-from .secret_storage import get_secret_manager, master_password_spec, selected_master_spec
+from .secret_storage import (
+    get_secret_manager,
+    master_password_spec,
+    remember_master_password_enabled,
+    selected_master_spec,
+    set_remember_master_password,
+)
 from .window_dialogs import parent_window
 
 logger = logging.getLogger(__name__)
@@ -438,13 +444,17 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
 
             if ok:
                 # Persist the "remember" choice on a manual unlock; a saved password that
-                # just worked stays as-is.
+                # just worked stays as-is. Only touch the OS keyring when the user has
+                # opted in (or is clearing a previous opt-in) — otherwise macOS shows a
+                # Keychain unlock prompt even for a pure .kdbx vault.
                 if source == 'manual':
                     try:
                         if remember:
-                            manager.store_in_keyring(_master_spec(), password)
-                        else:
+                            if manager.store_in_keyring(_master_spec(), password):
+                                set_remember_master_password(True)
+                        elif remember_master_password_enabled():
                             manager.delete_in_keyring(_master_spec())
+                            set_remember_master_password(False)
                     except Exception:
                         logger.debug("persisting master password failed", exc_info=True)
                 on_spinner_closed = lambda *_a: _finish(True)
@@ -455,6 +465,7 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
                     manager.delete_in_keyring(_master_spec())
                 except Exception:
                     pass
+                set_remember_master_password(False)
                 on_spinner_closed = lambda *_a: _show_password_dialog()
             elif needs_login:
                 from .bitwarden_setup import _prompt_gui_login
@@ -520,7 +531,7 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
         # Enter triggers the dialog's default response.
         entry.set_property('activates-default', True)
         remember_check = Gtk.CheckButton(label=_("Remember master password"))
-        remember_check.set_active(False)   # opt-in
+        remember_check.set_active(remember_master_password_enabled())
         caption = Gtk.Label(label=_("Stored in your system keyring."))
         caption.set_xalign(0)
         caption.set_wrap(True)
@@ -593,11 +604,14 @@ def prompt_unlock(parent, *, backend=None, on_done=None):
         GLib.idle_add(_focus_entry)
 
     # Auto-unlock with a saved master password (still shows the spinner), else prompt.
+    # Gate the keyring probe on the remember opt-in so session vaults (esp. keepassxc
+    # on macOS) never open Keychain unless the user asked to save the master password.
     saved = None
-    try:
-        saved = manager.lookup_in_keyring(_master_spec())
-    except Exception:
-        logger.debug("saved master password lookup failed", exc_info=True)
+    if remember_master_password_enabled():
+        try:
+            saved = manager.lookup_in_keyring(_master_spec())
+        except Exception:
+            logger.debug("saved master password lookup failed", exc_info=True)
     if saved:
         _run_unlock(saved, source='saved', remember=True)
     else:

--- a/tests/test_secret_unlock_dialog.py
+++ b/tests/test_secret_unlock_dialog.py
@@ -149,74 +149,60 @@ def test_startup_unlock_notifies_but_does_not_unlock_when_not_signed_in(monkeypa
     assert notified == [backend]
 
 
-def test_remember_master_gate_skips_keyring_probe_when_disabled(monkeypatch):
-    """Session vaults must not touch the OS keyring unless Remember is opted in.
+def test_prompt_unlock_never_touches_keyring_for_master_password(monkeypatch):
+    """Alternative backends exist to bypass Keychain — master password must stay
+    out of the OS keyring entirely (typed per unlock, held in-process only)."""
+    class FakeBackend:
+        name = "keepassxc"
+        session_backed = True
 
-    Without this gate, keepassxc on macOS still opened Keychain on every unlock
-    (lookup always, and delete on every unlock with Remember unchecked).
-    """
-    monkeypatch.setattr(d, "remember_master_password_enabled", lambda: False)
+        def is_available(self):
+            return True
 
-    class FakeManager:
-        def lookup_in_keyring(self, _spec):
-            raise AssertionError("must not probe OS keyring when remember is off")
-
-    mgr = FakeManager()
-    saved = None
-    if d.remember_master_password_enabled():
-        saved = mgr.lookup_in_keyring(object())
-    assert saved is None
-
-
-def test_remember_master_gate_probes_keyring_when_enabled(monkeypatch):
-    monkeypatch.setattr(d, "remember_master_password_enabled", lambda: True)
-    looked_up = []
+        def is_unlocked(self):
+            return False
 
     class FakeManager:
-        def lookup_in_keyring(self, spec):
-            looked_up.append(spec)
-            return "saved-pw"
+        def selected_backend(self):
+            return FakeBackend()
 
-    mgr = FakeManager()
-    saved = None
-    if d.remember_master_password_enabled():
-        saved = mgr.lookup_in_keyring("spec")
-    assert saved == "saved-pw"
-    assert looked_up == ["spec"]
+        def selected_needs_unlock(self):
+            return True
 
+        def lookup_in_keyring(self, *_a, **_k):
+            raise AssertionError("must not probe OS keyring for master password")
 
-def test_remember_master_password_helpers(monkeypatch):
-    from sshpilot import secret_storage as ss
-    import sshpilot.config as config_mod
+        def store_in_keyring(self, *_a, **_k):
+            raise AssertionError("must not store master password in OS keyring")
 
-    state = {ss.REMEMBER_MASTER_SETTING: False}
-    calls = []
+        def delete_in_keyring(self, *_a, **_k):
+            raise AssertionError("must not delete master password from OS keyring")
 
-    class StubConfig:
-        def get_setting(self, key, default=None):
-            calls.append(("get", key, default))
-            return state.get(key, default)
+        def unlock_selected(self, *_a, **_k):
+            return True
 
-        def set_setting(self, key, value):
-            calls.append(("set", key, value))
-            state[key] = value
+        def selected_needs_login(self):
+            return False
 
-    monkeypatch.setattr(config_mod, "Config", StubConfig)
+    monkeypatch.setattr(d, "get_secret_manager", lambda: FakeManager())
+    monkeypatch.setattr(d, "_unlock_in_progress", False)
+    d._pending_callbacks.clear()
 
-    assert ss.remember_master_password_enabled() is False
-    ss.set_remember_master_password(True)
-    assert state[ss.REMEMBER_MASTER_SETTING] is True
-    assert ss.remember_master_password_enabled() is True
-    ss.set_remember_master_password(False)
-    assert state[ss.REMEMBER_MASTER_SETTING] is False
-    assert ("set", ss.REMEMBER_MASTER_SETTING, True) in calls
-    assert ("set", ss.REMEMBER_MASTER_SETTING, False) in calls
+    # Stub the password dialog so we don't need a real GTK display, and assert the
+    # manager keyring APIs are never reached on the way to showing it.
+    shown = []
 
+    def fake_show():
+        shown.append(True)
 
-def test_default_config_does_not_remember_master_password():
-    from sshpilot.config import Config
-
-    cfg = Config.__new__(Config)
-    defaults = Config.get_default_config(cfg)
-    assert defaults["secrets"]["remember_master_password"] is False
+    # Call through to the real function but replace dialog construction by patching
+    # Adw.AlertDialog / MessageDialog — simpler: verify the module no longer imports
+    # remember helpers and that FakeManager keyring methods aren't referenced from
+    # prompt_unlock's source.
+    import inspect
+    src = inspect.getsource(d.prompt_unlock)
+    assert "lookup_in_keyring" not in src
+    assert "store_in_keyring" not in src
+    assert "Remember master password" not in src
+    assert shown == []  # we didn't invoke UI
 

--- a/tests/test_secret_unlock_dialog.py
+++ b/tests/test_secret_unlock_dialog.py
@@ -148,3 +148,75 @@ def test_startup_unlock_notifies_but_does_not_unlock_when_not_signed_in(monkeypa
     d._startup_unlock_after_probe("win", needs_login=True)
     assert notified == [backend]
 
+
+def test_remember_master_gate_skips_keyring_probe_when_disabled(monkeypatch):
+    """Session vaults must not touch the OS keyring unless Remember is opted in.
+
+    Without this gate, keepassxc on macOS still opened Keychain on every unlock
+    (lookup always, and delete on every unlock with Remember unchecked).
+    """
+    monkeypatch.setattr(d, "remember_master_password_enabled", lambda: False)
+
+    class FakeManager:
+        def lookup_in_keyring(self, _spec):
+            raise AssertionError("must not probe OS keyring when remember is off")
+
+    mgr = FakeManager()
+    saved = None
+    if d.remember_master_password_enabled():
+        saved = mgr.lookup_in_keyring(object())
+    assert saved is None
+
+
+def test_remember_master_gate_probes_keyring_when_enabled(monkeypatch):
+    monkeypatch.setattr(d, "remember_master_password_enabled", lambda: True)
+    looked_up = []
+
+    class FakeManager:
+        def lookup_in_keyring(self, spec):
+            looked_up.append(spec)
+            return "saved-pw"
+
+    mgr = FakeManager()
+    saved = None
+    if d.remember_master_password_enabled():
+        saved = mgr.lookup_in_keyring("spec")
+    assert saved == "saved-pw"
+    assert looked_up == ["spec"]
+
+
+def test_remember_master_password_helpers(monkeypatch):
+    from sshpilot import secret_storage as ss
+    import sshpilot.config as config_mod
+
+    state = {ss.REMEMBER_MASTER_SETTING: False}
+    calls = []
+
+    class StubConfig:
+        def get_setting(self, key, default=None):
+            calls.append(("get", key, default))
+            return state.get(key, default)
+
+        def set_setting(self, key, value):
+            calls.append(("set", key, value))
+            state[key] = value
+
+    monkeypatch.setattr(config_mod, "Config", StubConfig)
+
+    assert ss.remember_master_password_enabled() is False
+    ss.set_remember_master_password(True)
+    assert state[ss.REMEMBER_MASTER_SETTING] is True
+    assert ss.remember_master_password_enabled() is True
+    ss.set_remember_master_password(False)
+    assert state[ss.REMEMBER_MASTER_SETTING] is False
+    assert ("set", ss.REMEMBER_MASTER_SETTING, True) in calls
+    assert ("set", ss.REMEMBER_MASTER_SETTING, False) in calls
+
+
+def test_default_config_does_not_remember_master_password():
+    from sshpilot.config import Config
+
+    cfg = Config.__new__(Config)
+    defaults = Config.get_default_config(cfg)
+    assert defaults["secrets"]["remember_master_password"] is False
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Diagnosis

Selecting `keepassxc` correctly keeps SSH host secrets in the `.kdbx` file. The macOS Keychain unlock prompt came from the optional **“Remember master password”** path, which always probed (and often deleted from) the OS keyring via `keyring` — even when Remember was never checked.

## Design answer

Alternative backends exist to **bypass Keychain**. The vault master password should **not** be stored in Keychain (or any other OS keyring).

Where it lives instead:

| When | Where |
|------|--------|
| At unlock | Typed by the user |
| After unlock (same app launch) | In-process session only — KDBX `SSHPILOT_KDBX_KEY` / Bitwarden `BW_SESSION`, dropped on idle timeout or exit |
| Cross-launch convenience (KeePass) | Optional **key file** (`secrets.keepassxc.keyfile`) — KeePass-native second factor, no Keychain |

Persisting the master password anywhere durable without Keychain either reintroduces a Keychain-like store or is weak obfuscation. So we don’t persist it.

## Changes

- Remove Remember master password → OS keyring (checkbox, auto-lookup, Forget Preferences row, `secrets.remember_master_password`)
- Unlock always prompts; session stays unlocked in memory afterward
- Docs/Preferences hint: use a KDBX key file when you want less password typing without Keychain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c1132fa-278f-441c-8c8d-f4c85eaaff23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c1132fa-278f-441c-8c8d-f4c85eaaff23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

