### PR TITLE
Welcome page empty-state hints for Recent

### DIFF
--- a/src/sshpilot/terminal_manager.py
+++ b/src/sshpilot/terminal_manager.py
@@ -887,6 +887,9 @@ class TerminalManager:
                 meta = self.window.config.get_connection_meta(nickname)
                 meta['last_used'] = time.time()
                 self.window.config.set_connection_meta(nickname, meta)
+                welcome = getattr(self.window, 'welcome_view', None)
+                if welcome is not None and hasattr(welcome, 'refresh_recent'):
+                    welcome.refresh_recent()
         except Exception:
             logger.debug("Failed to record last-used time", exc_info=True)
         for row in self.window._rows_for_connection(terminal.connection):

--- a/src/sshpilot/welcome_page.py
+++ b/src/sshpilot/welcome_page.py
@@ -37,7 +37,9 @@ class WelcomePage(Gtk.Overlay):
         self.set_can_focus(False)
 
         self._pinned_box = None
+        self._recent_box = None
 
+        self.connection_manager.connect_after('connection-added', self._on_connection_added)
         self.connection_manager.connect_after('connection-removed', self._on_connection_removed)
 
         current_shortcuts = self._get_safe_current_shortcuts()
@@ -124,8 +126,6 @@ class WelcomePage(Gtk.Overlay):
         scrolled.set_hexpand(True)
         scrolled.set_can_focus(False)
 
-        connections = list(getattr(self.connection_manager, 'connections', []) or [])
-
         inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         inner.set_halign(Gtk.Align.FILL)
         inner.set_hexpand(True)
@@ -145,7 +145,7 @@ class WelcomePage(Gtk.Overlay):
 
         lists = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=24)
         lists.set_hexpand(True)
-        lists.append(self._build_min_connection_list(connections))
+        lists.append(self._build_min_connection_list())
         self._pinned_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         self._pinned_box.set_hexpand(True)
         lists.append(self._pinned_box)
@@ -260,20 +260,24 @@ class WelcomePage(Gtk.Overlay):
         user = getattr(conn, 'username', '')
         return f"{user}@{host}" if user and host else host
 
-    def _build_min_connection_list(self, connections):
-        if not connections:
-            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
-            box.set_hexpand(True)
-            heading = Gtk.Label(label=_('Recent'), xalign=0)
-            heading.set_hexpand(True)
-            heading.add_css_class('startpage-recent-head')
-            heading.set_margin_bottom(4)
-            box.append(heading)
-            empty = Gtk.Label(label=_('No connections yet'), xalign=0)
-            empty.add_css_class('dim-label')
-            empty.set_margin_top(8)
-            box.append(empty)
-            return box
+    def _build_min_connection_list(self):
+        self._recent_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self._recent_box.set_hexpand(True)
+        self._populate_recent_box()
+        return self._recent_box
+
+    def _populate_recent_box(self):
+        """Fill Recent rows, or a subtle empty-state hint when there are none."""
+        box = getattr(self, '_recent_box', None)
+        if box is None:
+            return
+        child = box.get_first_child()
+        while child:
+            nxt = child.get_next_sibling()
+            box.remove(child)
+            child = nxt
+
+        connections = list(getattr(self.connection_manager, 'connections', []) or [])
 
         def _last_used(conn):
             try:
@@ -281,14 +285,39 @@ class WelcomePage(Gtk.Overlay):
             except Exception:
                 return 0
 
-        recent = sorted(connections, key=_last_used, reverse=True)[:4]
+        # Only hosts that have been connected to belong under Recent.
+        recent = [
+            c for c in sorted(connections, key=_last_used, reverse=True)
+            if _last_used(c) > 0
+        ][:4]
+
+        if not recent:
+            empty = Gtk.Label(label=self._empty_recent_message(bool(connections)))
+            empty.add_css_class('dim-label')
+            empty.set_wrap(True)
+            empty.set_justify(Gtk.Justification.CENTER)
+            empty.set_halign(Gtk.Align.CENTER)
+            empty.set_hexpand(True)
+            empty.set_margin_top(8)
+            box.append(empty)
+            return
+
         rows = [
             self._min_row(
                 getattr(conn, 'nickname', ''), self._conn_target(conn),
                 lambda _b, c=conn: self.window.terminal_manager.connect_to_host(c))
             for conn in recent
         ]
-        return self._min_section(_('Recent'), rows)
+        box.append(self._min_section(_('Recent'), rows))
+
+    @staticmethod
+    def _empty_recent_message(has_connection_rows: bool) -> str:
+        """Subtle hint when Recent is empty; copy depends on sidebar hosts."""
+        if has_connection_rows:
+            return _(
+                'Double click a host to connect or press + to create a new connection'
+            )
+        return _('Press + to create a new connection')
 
     def _populate_pinned_box(self):
         """Fill the Pinned section (rows, styled like Recent) below the list."""
@@ -458,6 +487,14 @@ class WelcomePage(Gtk.Overlay):
         """Rebuild the pinned section after a pin/unpin action."""
         self._populate_pinned_box()
 
+    def refresh_recent(self):
+        """Rebuild the Recent section after connections or last-used change."""
+        self._populate_recent_box()
+
+    def _on_connection_added(self, _manager, _connection):
+        """Refresh empty-state / Recent when a host is added to the inventory."""
+        self.refresh_recent()
+
     def _on_connection_removed(self, _manager, connection):
         """Auto-unpin a connection when it is deleted from the inventory."""
         try:
@@ -467,6 +504,7 @@ class WelcomePage(Gtk.Overlay):
                 self.refresh_pinned()
         except Exception:
             pass
+        self.refresh_recent()
 
     def show_sidebar_hint(self):
         """Show a hint about using the sidebar to manage connections"""

--- a/tests/test_welcome_empty_state.py
+++ b/tests/test_welcome_empty_state.py
@@ -1,0 +1,15 @@
+"""Welcome page empty-state copy for Recent."""
+
+from sshpilot.welcome_page import WelcomePage
+
+
+def test_empty_recent_message_no_connection_rows():
+    assert WelcomePage._empty_recent_message(False) == (
+        'Press + to create a new connection'
+    )
+
+
+def test_empty_recent_message_with_connection_rows():
+    assert WelcomePage._empty_recent_message(True) == (
+        'Double click a host to connect or press + to create a new connection'
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When the Start/welcome page has no recent connections, show subtle normal-size dim text instead of the previous “No connections yet” empty state:

- **No sidebar hosts:** `Press + to create a new connection`
- **Hosts exist but none used yet:** `Double click a host to connect or press + to create a new connection`

Recent only lists hosts that have been connected to (`last_used > 0`). The empty hint has no bold/heading; the Recent section appears only when there are recent hosts. The list refreshes when connections are added, removed, or used.

## Test plan
- [ ] Fresh install / empty sidebar: welcome shows “Press + to create a new connection”
- [ ] Add hosts but do not connect: welcome shows the double-click / + hint
- [ ] Connect to a host: Recent list appears with that host
- [ ] Delete all hosts: empty hint returns to the press-+ message
- [ ] Confirm text is dim, normal weight/size, and the page stays minimal
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44bbbf93-35f2-4f71-b391-7854916b7fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44bbbf93-35f2-4f71-b391-7854916b7fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

