### PR TITLE
Disable first-run operation mode chooser; default to accent bars

### DIFF
--- a/src/sshpilot/config.py
+++ b/src/sshpilot/config.py
@@ -183,7 +183,7 @@ class Config(GObject.Object):
                 'window_width': 1200,
                 'window_height': 800,
                 'sidebar_width': 250,
-                'group_color_display': 'dot',
+                'group_color_display': 'bar',
                 'group_color_child_rows': False,
                 'group_row_display': 'nested',
                 'use_group_color_in_tab': False,
@@ -1218,7 +1218,8 @@ class Config(GObject.Object):
             updated = True
         display_value = ui_cfg.get('group_color_display') if isinstance(ui_cfg, dict) else None
         if display_value is None:
-            ui_cfg['group_color_display'] = 'dot'
+            # Match get_default_config(): Accent Bars for installs missing the key.
+            ui_cfg['group_color_display'] = 'bar'
             updated = True
         else:
             if not isinstance(display_value, str):

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -708,7 +708,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         except Exception as e:
             logger.debug(f"Failed to check for updates on startup: {e}")
 
-        # One-time operation mode chooser
+        # One-time operation mode chooser (disabled for fresh installs —
+        # see WindowFileManagerMixin._OPERATION_MODE_FIRST_RUN_PROMPT_ENABLED).
+        # Starts in default mode; dialog code is retained but not shown.
         try:
             if self._should_prompt_operation_mode():
                 GLib.idle_add(self._show_operation_mode_dialog)

--- a/src/sshpilot/window_file_manager.py
+++ b/src/sshpilot/window_file_manager.py
@@ -187,9 +187,25 @@ class WindowFileManagerMixin:
             logger.error("Failed to persist file manager first-run choice: %s", exc)
 
     # --- Operation mode first-run dialog ---
+    # Fresh installs start in default mode with no chooser and no automatic
+    # SSH config backup. Keep the dialog helpers below so the flow can be
+    # re-enabled by flipping this flag.
+    _OPERATION_MODE_FIRST_RUN_PROMPT_ENABLED = False
 
     def _should_prompt_operation_mode(self) -> bool:
         """Return True if the operation mode dialog should be shown."""
+        if not self._OPERATION_MODE_FIRST_RUN_PROMPT_ENABLED:
+            # Mark as shown so a later re-enable does not surprise installs
+            # that never saw the dialog (they already run in default mode).
+            try:
+                if not bool(
+                    self.config.get_setting('ssh.operation_mode_prompt_shown', False)
+                ):
+                    self.config.set_setting('ssh.operation_mode_prompt_shown', True)
+            except Exception:
+                pass
+            return False
+
         try:
             already_shown = bool(
                 self.config.get_setting('ssh.operation_mode_prompt_shown', False)

--- a/tests/test_fresh_install_defaults.py
+++ b/tests/test_fresh_install_defaults.py
@@ -1,0 +1,34 @@
+"""Fresh-install defaults: default operation mode, no chooser, accent-bar groups."""
+
+from types import SimpleNamespace
+
+from sshpilot.config import Config
+from sshpilot.window_file_manager import WindowFileManagerMixin
+
+
+def test_group_color_display_defaults_to_accent_bar():
+    defaults = Config.get_default_config(Config.__new__(Config))
+    assert defaults['ui']['group_color_display'] == 'bar'
+
+
+def test_operation_mode_defaults_to_shared_ssh_config():
+    defaults = Config.get_default_config(Config.__new__(Config))
+    assert defaults['ssh']['use_isolated_config'] is False
+
+
+def test_operation_mode_first_run_prompt_disabled():
+    assert WindowFileManagerMixin._OPERATION_MODE_FIRST_RUN_PROMPT_ENABLED is False
+
+    recorded = {}
+
+    class FakeWindow(WindowFileManagerMixin):
+        def __init__(self):
+            self.config = SimpleNamespace(
+                get_setting=lambda key, default=None: recorded.get(key, default),
+                set_setting=lambda key, value: recorded.__setitem__(key, value),
+            )
+            self.isolated_mode = False
+
+    win = FakeWindow()
+    assert win._should_prompt_operation_mode() is False
+    assert recorded.get('ssh.operation_mode_prompt_shown') is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fresh installs no longer show the operation mode chooser dialog or the automatic SSH config backup prompt.
- Apps start in **default mode** (`~/.ssh/config`); dialog code is kept behind `_OPERATION_MODE_FIRST_RUN_PROMPT_ENABLED = False`.
- Fresh installs use **Accent Bars** (`ui.group_color_display = bar`) as the default sidebar group color style.

## Test plan
- [x] `pytest tests/test_fresh_install_defaults.py tests/test_window_file_manager_mixin.py tests/test_config_upgrade.py`
- [ ] Manual: wipe app config and confirm no mode chooser / backup prompt on first launch
- [ ] Manual: confirm sidebar group colors use accent bars by default
- [ ] Manual: Preferences ▸ SSH Settings can still switch operation mode
- [ ] Manual: Preferences ▸ Interface can still change group color style

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b477ee-dd0b-497c-8f8e-cb1364dc1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b477ee-dd0b-497c-8f8e-cb1364dc1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

