### PR TITLE
Show group avatars in minimal sidebar

### DIFF
--- a/src/sshpilot/sidebar.py
+++ b/src/sshpilot/sidebar.py
@@ -278,8 +278,22 @@ def install_sidebar_css():
           }
         }
 
-        /* Minimal (icon-only) sidebar: ring around a connected connection's
-           avatar. box-shadow follows the avatar's circle so it reads as a ring. */
+        /* Minimal (icon-only) sidebar: keep initials avatars neutral.
+           Adw.Avatar normally assigns deterministic accent colors from the
+           label text; in the minimized sidebar those colored circles can be
+           mistaken for configured group colors. */
+        avatar.sidebar-avatar {
+          background-color: alpha(@window_fg_color, 0.12);
+          color: @window_fg_color;
+        }
+
+        image.sidebar-avatar-icon {
+          color: @window_fg_color;
+        }
+
+        /* Ring around a connected connection's avatar. box-shadow follows the
+           avatar's circle so it reads as a status ring without changing the
+           neutral avatar fill. */
         avatar.sidebar-avatar-online {
           box-shadow: 0 0 0 2px @success_color;
         }
@@ -723,6 +737,9 @@ class GroupRow(Gtk.ListBoxRow):
         self._color_badge_provider = None
         self._member_rows = []
         self._child_group_rows = []
+        self._compact_avatar = None
+        self._compact_avatar_icon = None
+        self._compact_avatar_overlay = None
 
         # Main container with drop indicators
         main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -748,7 +765,8 @@ class GroupRow(Gtk.ListBoxRow):
         self.color_dot = _create_color_dot("big-dot-symbolic")
         content.append(self.color_dot)
 
-        icon = icon_utils.new_image_from_icon_name("folder-symbolic")
+        self._group_icon_name = "folder-symbolic"
+        icon = icon_utils.new_image_from_icon_name(self._group_icon_name)
         icon.set_icon_size(Gtk.IconSize.NORMAL)
         icon.set_valign(Gtk.Align.CENTER)  # Center vertically relative to text
         config = getattr(self.group_manager, 'config', None)
@@ -1162,11 +1180,13 @@ class GroupRow(Gtk.ListBoxRow):
         _apply_sidebar_row_style(self, config, flat=flat)
 
     def set_compact(self, compact: bool) -> None:
-        """Collapse the group header to just its folder icon, or restore it."""
+        """Collapse the group header to a folder avatar, or restore it."""
         compact = bool(compact)
         self._compact = compact
         content = self._content
         if compact:
+            from sshpilot import icon_utils
+
             content.set_halign(Gtk.Align.CENTER)
             content.set_margin_start(0)
             self.set_margin_start(0)  # flatten nested-group indentation in the strip
@@ -1176,10 +1196,27 @@ class GroupRow(Gtk.ListBoxRow):
             self.split_view_button.set_visible(False)
             self.edit_button.set_visible(False)
             self.expand_button.set_visible(False)
-            self.icon.set_visible(True)
+            self.icon.set_visible(False)
+
+            if self._compact_avatar_overlay is None:
+                self._compact_avatar = Adw.Avatar(size=28, show_initials=False)
+                self._compact_avatar.add_css_class('sidebar-avatar')
+                self._compact_avatar_icon = icon_utils.new_image_from_icon_name(
+                    getattr(self, '_group_icon_name', 'folder-symbolic')
+                )
+                self._compact_avatar_icon.set_icon_size(Gtk.IconSize.NORMAL)
+                self._compact_avatar_icon.add_css_class('sidebar-avatar-icon')
+                self._compact_avatar_overlay = Gtk.Overlay()
+                self._compact_avatar_overlay.set_child(self._compact_avatar)
+                self._compact_avatar_overlay.add_overlay(self._compact_avatar_icon)
+                content.prepend(self._compact_avatar_overlay)
+
+            self._compact_avatar_overlay.set_visible(True)
             self.set_tooltip_text(str(self.group_info.get('name', '')))
         else:
             content.set_halign(Gtk.Align.FILL)
+            if self._compact_avatar_overlay is not None:
+                self._compact_avatar_overlay.set_visible(False)
             self._info_box.set_visible(True)
             self.split_view_button.set_visible(True)
             self.edit_button.set_visible(True)
@@ -1208,7 +1245,8 @@ class TagGroupRow(GroupRow):
         self.remove_css_class("card")
         self.remove_css_class("navigation-sidebar")
         self.add_css_class("osd")
-        self.icon.set_from_icon_name("tag-symbolic")
+        self._group_icon_name = "tag-symbolic"
+        self.icon.set_from_icon_name(self._group_icon_name)
         # The edit button renames the tag (across all tagged connections);
         # the split-view button works as inherited — the action only reads
         # group_info['connections'] / ['name'], so a synthetic group is fine.

--- a/tests/test_sidebar_minimal_rows.py
+++ b/tests/test_sidebar_minimal_rows.py
@@ -95,3 +95,68 @@ def test_restore_noop_when_never_compact():
     # Nothing to restore: update_status not called, still not compact.
     row.update_status.assert_not_called()
     assert row._compact is False
+
+
+class _GroupCfg:
+    def get_setting(self, key, default=None):
+        if key == 'ui.sidebar_show_group_icon':
+            return True
+        return default
+
+
+def _make_group_row():
+    mod = importlib.import_module('sshpilot.sidebar')
+    row = mod.GroupRow.__new__(mod.GroupRow)
+    row.group_info = {'id': 'g1', 'name': 'Production'}
+    row.group_manager = type('GM', (), {'config': _GroupCfg()})()
+    row._compact = False
+    row._compact_avatar = None
+    row._compact_avatar_icon = None
+    row._compact_avatar_overlay = None
+    row._group_icon_name = 'folder-symbolic'
+    for name in ('_content', '_info_box', 'color_dot', 'color_badge',
+                 'split_view_button', 'edit_button', 'expand_button', 'icon'):
+        setattr(row, name, MagicMock())
+    row.set_tooltip_text = MagicMock()
+    row.set_margin_start = MagicMock()
+    row._apply_group_display_mode = MagicMock()
+    row._update_display = MagicMock()
+    return row, mod
+
+
+def test_group_compact_uses_folder_avatar(monkeypatch):
+    row, mod = _make_group_row()
+    fake_avatar = MagicMock()
+    fake_icon = MagicMock()
+    fake_overlay = MagicMock()
+    monkeypatch.setattr(mod.Adw, 'Avatar', lambda **kw: fake_avatar)
+    monkeypatch.setattr(mod.Gtk, 'Overlay', lambda: fake_overlay)
+    icon_utils = importlib.import_module('sshpilot.icon_utils')
+    new_icon = MagicMock(return_value=fake_icon)
+    monkeypatch.setattr(icon_utils, 'new_image_from_icon_name', new_icon)
+
+    row.set_compact(True)
+
+    assert row._compact is True
+    assert row._compact_avatar is fake_avatar
+    fake_avatar.add_css_class.assert_called_with('sidebar-avatar')
+    new_icon.assert_called_with('folder-symbolic')
+    fake_icon.add_css_class.assert_called_with('sidebar-avatar-icon')
+    fake_overlay.set_child.assert_called_with(fake_avatar)
+    fake_overlay.add_overlay.assert_called_with(fake_icon)
+    row._content.prepend.assert_called_with(fake_overlay)
+    fake_overlay.set_visible.assert_called_with(True)
+    row.icon.set_visible.assert_called_with(False)
+    row.set_tooltip_text.assert_called_with('Production')
+
+
+def test_group_restore_hides_compact_avatar_and_restores_icon():
+    row, _ = _make_group_row()
+    row._compact_avatar_overlay = MagicMock()
+
+    row.set_compact(False)
+
+    row._compact_avatar_overlay.set_visible.assert_called_with(False)
+    row.icon.set_visible.assert_called_with(True)
+    row._apply_group_display_mode.assert_called_once()
+    row._update_display.assert_called_once()


### PR DESCRIPTION
### Motivation
- The minimized (icon-only) sidebar used neutral `Adw.Avatar` circles for connection rows but left group rows as standalone folder icons, producing an inconsistent strip and not matching the request to show groups as avatars with a folder icon.
- Groups should appear as neutral avatars with their folder/tag symbol overlaid so the strip is visually consistent and group colors are not confused with avatar fills.

### Description
- Render compact group rows as a neutral `Adw.Avatar` circle with the group icon overlaid using a `Gtk.Overlay`, storing per-row `_group_icon_name` and keeping the original `icon` hidden while compact. (changes in `src/sshpilot/sidebar.py`)
- Add/adjust CSS: preserve the neutral avatar fill (`avatar.sidebar-avatar`) and add `image.sidebar-avatar-icon` so overlaid folder/tag icons use the avatar foreground treatment. (CSS in `install_sidebar_css()`)
- Ensure tag groups continue to use the `tag-symbolic` icon and set `_group_icon_name` for tag rows. (TagGroupRow changes)
- Add unit tests for compact group avatar creation and restore behavior in `tests/test_sidebar_minimal_rows.py`.

### Testing
- Ran `python -m py_compile src/sshpilot/sidebar.py`, which succeeded.
- Ran `pytest -q tests/test_sidebar_minimal_rows.py`, which succeeded (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60cd3f5dcc83289aaa54b1ad7b8fbd)