### PR TITLE
fix: keep daemon RPC timeout separate from launcher probe

### DIFF
--- a/src/sshpilot/api/daemon_client.py
+++ b/src/sshpilot/api/daemon_client.py
@@ -279,6 +279,7 @@ class DaemonClient:
         *,
         socket_path: Optional[os.PathLike] = None,
         timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        connect_timeout: Optional[float] = None,
         client_name: str = "daemon-client",
         client_version: str = sshpilot_version,
         client_id: Optional[str] = None,
@@ -287,9 +288,14 @@ class DaemonClient:
     ) -> None:
         if type(timeout) not in (int, float) or timeout <= 0:
             raise ValueError("daemon request timeout must be positive")
+        if connect_timeout is None:
+            connect_timeout = timeout
+        elif type(connect_timeout) not in (int, float) or connect_timeout <= 0:
+            raise ValueError("daemon connect timeout must be positive")
         if type(event_dispatch_limit) is not int or event_dispatch_limit < 1:
             raise ValueError("event dispatch limit must be positive")
         self._timeout = float(timeout)
+        self._connect_timeout = float(connect_timeout)
         self._socket_path = (
             Path(socket_path) if socket_path is not None else self.default_socket_path()
         )
@@ -1096,7 +1102,7 @@ class DaemonClient:
 
     def _connect_and_handshake(self) -> None:
         transport = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        transport.settimeout(self._timeout)
+        transport.settimeout(self._connect_timeout)
         try:
             transport.connect(str(self._socket_path))
         except (OSError, socket.timeout):

--- a/src/sshpilot/daemon/launcher.py
+++ b/src/sshpilot/daemon/launcher.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Callable, Mapping, Optional, Sequence
 
 from sshpilot.api.capabilities import Capability
-from sshpilot.api.daemon_client import DaemonClient
+from sshpilot.api.daemon_client import DEFAULT_REQUEST_TIMEOUT, DaemonClient
 from sshpilot.api.errors import ErrorCode, SshPilotError
 
 from .lifecycle import (
@@ -177,9 +177,13 @@ class DaemonLauncher:
             return DaemonLaunchResult(client=client, process=handle)
 
     def _connect(self, timeout: float) -> DaemonClient:
+        # ``timeout`` here is the launcher probe budget for socket connect only.
+        # RPC waits must use DEFAULT_REQUEST_TIMEOUT — otherwise slow methods
+        # like sftp.list falsely trip transport_timeout (~probe 0.25s).
         client = DaemonClient(
             socket_path=self.socket_path,
-            timeout=timeout,
+            timeout=DEFAULT_REQUEST_TIMEOUT,
+            connect_timeout=timeout,
             client_name="sshpilot-gtk",
             frontend_type="gtk",
         )

--- a/tests/daemon/test_launcher.py
+++ b/tests/daemon/test_launcher.py
@@ -63,6 +63,32 @@ def test_existing_compatible_daemon_is_reused_without_launch(daemon_factory):
         result.client.close()
 
 
+def test_launcher_keeps_request_timeout_separate_from_probe(daemon_factory):
+    """Probe budget is for connect only; RPCs must keep DEFAULT_REQUEST_TIMEOUT.
+
+    Regression: wiring probe_timeout (0.25s) into DaemonClient.timeout made
+    sftp.list (and other slow methods) report false transport_timeout.
+    """
+    from sshpilot.api.daemon_client import DEFAULT_REQUEST_TIMEOUT
+
+    server, _manager = daemon_factory()
+
+    launcher = DaemonLauncher(
+        socket_path=server.socket_path,
+        probe_timeout=0.25,
+        popen=lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("must reuse existing daemon")
+        ),
+    )
+    result = launcher.connect_or_start()
+    try:
+        assert result.client._timeout == DEFAULT_REQUEST_TIMEOUT
+        assert result.client._connect_timeout == 0.25
+        assert result.client.list_connections()[0].nickname == "demo"
+    finally:
+        result.client.close()
+
+
 def test_real_on_demand_process_is_ready_via_handshake_and_owned(tmp_path):
     socket_path = tmp_path / "runtime" / "sshpilotd.sock"
     environment = dict(os.environ)


### PR DESCRIPTION
## Summary
- Separate `DaemonClient` socket connect timeout from RPC request timeout
- `DaemonLauncher` keeps using 0.25s probe for connect only; RPCs use the 5s default
- Prevents false `transport_timeout` / reconnect on slow methods like `sftp.list`

## Test plan
- [x] `pytest tests/daemon/test_launcher.py tests/daemon/test_lifecycle.py`
- [x] `pytest tests/api/test_daemon_client_protocol.py tests/api/test_client_factory.py`
- [ ] Open file manager (`daemon-sftp`) and confirm directory listing no longer times out at ~250ms


Made with [Cursor](https://cursor.com)