### PR TITLE
Make daemon connection saves secret-safe and resumable

### DIFF
--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -1370,7 +1370,14 @@ class ConnectionDialog(
     __gtype_name__ = 'ConnectionDialog'
 
     __gsignals__ = {
-        'connection-saved': (GObject.SignalFlags.RUN_FIRST, None, (object,)),
+        # Config, metadata, secrets and completion deliberately travel as
+        # separate objects.  In particular, secret values must never be added
+        # to the dictionary that is accepted by ConnectionManager or encoded
+        # into a daemon mutation DTO.
+        'connection-saved': (
+            GObject.SignalFlags.RUN_FIRST, None,
+            (object, object, object, object),
+        ),
     }
 
     content_mount = Gtk.Template.Child()
@@ -3148,7 +3155,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # The live object is only mutated by the manager after a successful
         # persist; metadata rides the payload and the dialog closes only once
         # the window reports the save outcome.
-        data['__meta'] = self._collect_connection_meta()
+        metadata = self._collect_connection_meta()
         completion_called = [False]
 
         def _after_saved(ok):
@@ -3158,14 +3165,11 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             else:
                 self.show_error(_("The connection settings could not be saved."))
 
-        data['__save_completion'] = _after_saved
-        self.emit('connection-saved', data)
+        self.emit('connection-saved', data, metadata, {}, _after_saved)
         if not completion_called[0]:
-            if '__save_completion' in data:
-                # No consumer popped the marker (standalone dialog, e.g. in
-                # tests): keep the legacy emit-then-close behavior.
-                data.pop('__save_completion', None)
-                self.close()
+            # No consumer (standalone dialog, e.g. in tests): keep the legacy
+            # emit-then-close behavior.
+            self.close()
             # else: consumer popped the marker and is handling the
             # completion asynchronously (e.g. daemon bridge).  Do NOT
             # assume failure here — the async callback will invoke
@@ -3312,7 +3316,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         except Exception:
             logger.debug("Failed to collect key passphrase changes", exc_info=True)
 
-        connection_data['__secret_plan'] = {
+        secret_plan = {
             'password_changed': bool(password_changed),
             'password': self.password_row.get_text(),
             'passphrase_operations': passphrase_ops,
@@ -3335,18 +3339,15 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
 
         # Wake-on-LAN and tags metadata ride the payload; the window persists
         # them only after the config write succeeds.
-        connection_data['__meta'] = self._collect_connection_meta()
+        metadata = self._collect_connection_meta()
 
         if self.is_editing and self.connection:
-            connection_data['__previous_secret_identity'] = {
+            secret_plan['previous_identity'] = {
                 'nickname': getattr(self.connection, 'nickname', ''),
                 'hostname': getattr(self.connection, 'hostname', ''),
                 'host': getattr(self.connection, 'host', ''),
                 'username': getattr(self.connection, 'username', ''),
             }
-            # Provide connection ID for daemon secret RPCs
-            from .api.in_process_client import InProcessClient
-            connection_data['__connection_id'] = InProcessClient.connection_id_for(self.connection)
 
         # Editing rewrites the block as `Host <nickname>` (multi-host blocks go
         # through the split path), so aliases are cleared via the payload. The
@@ -3371,13 +3372,13 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # Unlock first when needed, then persist all changed secrets in one worker. Secret
         # backends may invoke external tools (notably ``bw``), so none of this I/O may run
         # in the GTK signal handler.
-        if self._needs_secret_unlock_before_save(connection_data):
+        if self._needs_secret_unlock_before_save(secret_plan):
             try:
                 from .secret_unlock_dialog import prompt_unlock
 
                 def _after_unlock(ok):
                     if ok:
-                        self._store_secrets_then_save(connection_data)
+                        self._store_secrets_then_save(connection_data, metadata, secret_plan)
                     else:
                         self._set_secret_save_busy(False)
 
@@ -3389,17 +3390,18 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 self._set_secret_save_busy(False)
                 self.show_error(_("The secure storage backend could not be unlocked."))
                 return
-        self._store_secrets_then_save(connection_data)
+        self._store_secrets_then_save(connection_data, metadata, secret_plan)
 
     def _set_secret_save_busy(self, busy):
         self._secret_save_in_progress = bool(busy)
         self._refresh_save_sensitivity()
 
-    def _store_secrets_then_save(self, connection_data):
+    def _store_secrets_then_save(self, connection_data, metadata=None, secret_plan=None):
         """Persist changed secrets off-thread, then emit the normal save signal."""
+        metadata = metadata or {}
+        secret_plan = secret_plan or {}
         operations = []
-        previous_identity = connection_data.pop('__previous_secret_identity', None)
-        secret_plan = connection_data.get('__secret_plan', {})
+        previous_identity = secret_plan.get('previous_identity')
         manager = getattr(self, 'connection_manager', None)
         if manager is None:
             manager = getattr(getattr(self, 'parent_window', None),
@@ -3428,19 +3430,17 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                     if meta_error:
                         self.show_error(meta_error)
                     else:
+                        self._clear_save_checkpoint()
                         self.close()
                 else:
                     self.show_error(_("The connection settings could not be saved."))
 
-            connection_data['__save_completion'] = _after_plain_save
-            self.emit('connection-saved', connection_data)
+            self.emit('connection-saved', connection_data, metadata, secret_plan,
+                      _after_plain_save)
             if not plain_completion_called[0]:
-                if '__save_completion' in connection_data:
-                    # No consumer popped the marker (standalone dialog, e.g. in
-                    # tests): keep the legacy emit-then-close behavior.
-                    connection_data.pop('__save_completion', None)
-                    self._set_secret_save_busy(False)
-                    self.close()
+                # No consumer (standalone dialog, e.g. in tests).
+                self._set_secret_save_busy(False)
+                self.close()
                 # else: consumer popped the marker and is handling the
                 # completion asynchronously (e.g. daemon bridge).  Do NOT
                 # assume failure here — the async callback will invoke
@@ -3487,7 +3487,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                                 DeleteConnectionPasswordRequest,
                             )
                             # Use the real connection_id returned by the mutation
-                            mutation_result = connection_data.get('__mutation_result')
+                            mutation_result = getattr(self, '_save_mutation_result', None)
                             conn_id = getattr(mutation_result, 'connection_id', None) or connection_data.get('nickname', '').strip()
                             if conn_id and action == 'store':
                                 req = StoreConnectionPasswordRequest(
@@ -3554,7 +3554,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             except Exception:
                 logger.exception("Failed to save connection secrets")
                 ok = False
-            GLib.idle_add(self._finish_secret_save, connection_data, ok,
+            GLib.idle_add(self._finish_secret_save, ok,
                           close_spinner, spinner, True)
 
         completion_called = [False]
@@ -3563,19 +3563,18 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             completion_called[0] = True
             if ok:
                 if mutation_result:
-                    connection_data['__mutation_result'] = mutation_result
-                if meta_error:
-                    connection_data['__meta_error'] = meta_error
+                    self._save_mutation_result = mutation_result
+                self._save_meta_error = meta_error
                 threading.Thread(target=_worker, daemon=True).start()
             else:
                 self._finish_secret_save(
-                    connection_data, False, close_spinner, spinner, False)
+                    False, close_spinner, spinner, False)
 
         # Preserve the established save order: persist connection/config data first, then
         # its credentials. The private marker keeps update_connection from performing the
         # same secret I/O synchronously inside this signal emission.
-        connection_data['__save_completion'] = _after_config_saved
-        self.emit('connection-saved', connection_data)
+        self.emit('connection-saved', connection_data, metadata, secret_plan,
+                  _after_config_saved)
         if not completion_called[0]:
             # Consumer popped the marker and is handling the completion
             # asynchronously (e.g. daemon bridge).  Do NOT assume failure
@@ -3583,16 +3582,17 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             # with the real result.
             pass
 
-    def _finish_secret_save(self, connection_data, ok, close_spinner, spinner,
+    def _finish_secret_save(self, ok, close_spinner, spinner,
                             settings_saved):
         """Finish an asynchronous secret save on the GTK main thread."""
         def _after_closed(*_args):
             self._set_secret_save_busy(False)
             if ok:
-                meta_error = connection_data.get('__meta_error')
+                meta_error = getattr(self, '_save_meta_error', None)
                 if meta_error:
                     self.show_error(meta_error)
                 else:
+                    self._clear_save_checkpoint()
                     self.close()
             elif not settings_saved:
                 self.show_error(_("The connection settings could not be saved."))
@@ -3613,7 +3613,17 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             _after_closed()
         return False
 
-    def _needs_secret_unlock_before_save(self, connection_data) -> bool:
+    def _clear_save_checkpoint(self):
+        """Forget resumable daemon stages after the entire save succeeds."""
+        for name in ('_save_mutation_result', '_save_meta_error',
+                     '_daemon_save_checkpoint', '_daemon_metadata_saved',
+                     '_resumable_save_active'):
+            try:
+                delattr(self, name)
+            except AttributeError:
+                pass
+
+    def _needs_secret_unlock_before_save(self, secret_plan) -> bool:
         """True when saving would store or delete a secret — a host password or a key
         passphrase — and the selected session backend (Bitwarden/Vaultwarden) is locked
         or not signed in, so it should be unlocked before the secret I/O runs."""
@@ -3621,7 +3631,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             from .secret_storage import get_secret_manager
             if not get_secret_manager().selected_needs_unlock():
                 return False
-            secret_plan = connection_data.get('__secret_plan', {})
             pw = secret_plan.get('password')
             if pw and str(pw).strip():
                 return True

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -6633,6 +6633,13 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             complete_save(False)
             return
 
+        # A later metadata/secret stage may be retried after the config
+        # mutation has committed.  Keep the authoritative mutation result on
+        # the dialog so retry never repeats create/update/rename/split.
+        resumable = bool(getattr(dialog, '_resumable_save_active', False))
+        checkpoint = (getattr(dialog, '_daemon_save_checkpoint', None)
+                      if resumable else None)
+
         # Daemon edits may never save against a pending/failed snapshot: the
         # dialog disables Save in that state, but the signal path (accelerator,
         # programmatic) is gated here too.
@@ -6794,8 +6801,12 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     )
 
             pending_meta_local = pending_meta or {}
+            if getattr(dialog, '_daemon_metadata_saved', False):
+                _finish_save_flow()
+                return
             if pending_meta_local and new_conn_id:
                 def _meta_success(_):
+                    dialog._daemon_metadata_saved = True
                     _finish_save_flow()
                 def _meta_failure(error):
                     logger.debug("Metadata update via daemon RPC failed: %s", error)
@@ -6827,21 +6838,40 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                 )
             complete_save(False)
 
+        if checkpoint is not None:
+            _success(checkpoint)
+            return
+
+        def _checkpoint_success(details):
+            if resumable:
+                dialog._daemon_save_checkpoint = details
+            _success(details)
+
         try:
             bridge.submit(
                 operation,
-                on_success=_success,
+                on_success=_checkpoint_success,
                 on_error=_failure,
             )
         except RuntimeError:
             complete_save(False)
 
-    def on_connection_saved(self, dialog, connection_data):
+    def on_connection_saved(self, dialog, connection_data, pending_meta=None,
+                            secret_plan=None, save_completion=None):
         """Handle connection saved from dialog"""
-        save_completion = connection_data.pop('__save_completion', None)
-        pending_meta = connection_data.pop('__meta', None)
-        # Prevent secret plan from entering process memory outside of dedicated ops
-        secret_plan = connection_data.pop('__secret_plan', None)
+        # Compatibility for third-party/plugin emitters using the pre-v2
+        # one-object signal.  Values are removed before any persistence call.
+        if save_completion is None:
+            save_completion = connection_data.pop('__save_completion', None)
+        if pending_meta is None:
+            pending_meta = connection_data.pop('__meta', None)
+        # The signal contract keeps these objects separate by construction.
+        # Assert at the persistence boundary as defence in depth.
+        if '__secret_plan' in connection_data:
+            logger.error("Rejected connection payload containing a secret plan")
+            if callable(save_completion):
+                save_completion(False)
+            return
 
         def _complete_save(ok, result=None, meta_error=None):
             if callable(save_completion):
@@ -6856,6 +6886,19 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                         save_completion(bool(ok))
                 except Exception:
                     save_completion(bool(ok))
+            has_secret_work = bool(
+                secret_plan and (
+                    secret_plan.get('password_changed')
+                    or secret_plan.get('passphrase_operations')
+                )
+            )
+            if ok and not meta_error and not has_secret_work:
+                for name in ('_daemon_save_checkpoint', '_daemon_metadata_saved',
+                             '_resumable_save_active'):
+                    try:
+                        delattr(dialog, name)
+                    except AttributeError:
+                        pass
 
         try:
             if connection_data.get('protocol', 'ssh') != 'ssh':
@@ -6863,6 +6906,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     dialog, connection_data, _complete_save, pending_meta)
                 return
             if self._daemon_mode_active():
+                dialog._resumable_save_active = True
                 self._save_connection_via_client(
                     dialog,
                     connection_data,

--- a/tests/test_connection_dialog_passphrase.py
+++ b/tests/test_connection_dialog_passphrase.py
@@ -305,9 +305,9 @@ def test_connection_secret_save_runs_backend_io_in_worker(monkeypatch):
     emitted = []
     closed = []
 
-    def emit(signal, data):
-        emitted.append((signal, dict(data)))
-        data.pop('__save_completion')(True)
+    def emit(signal, data, metadata, secret_plan, completion):
+        emitted.append((signal, dict(data), dict(metadata), dict(secret_plan)))
+        completion(True)
 
     dialog.emit = emit
     dialog.close = lambda: closed.append(True)
@@ -323,13 +323,16 @@ def test_connection_secret_save_runs_backend_io_in_worker(monkeypatch):
             'passphrase_operations': [('store', '/key', 'key-secret')],
         }
     }
-    dialog._store_secrets_then_save(data)
+    secret_plan = data.pop('__secret_plan')
+    dialog._store_secrets_then_save(data, {}, secret_plan)
 
     assert len(pending_threads) == 1
     assert pending_threads[0].daemon is True
     assert calls == []
     assert emitted[0][0] == 'connection-saved'
     assert emitted[0][1]['__secret_storage_done'] is True
+    assert '__secret_plan' not in emitted[0][1]
+    assert emitted[0][3]['password'] == 'host-secret'
     assert closed == []
 
     pending_threads[0].target()
@@ -389,7 +392,7 @@ def test_deleting_unstored_password_is_not_an_error(monkeypatch):
     closed = []
     errors = []
 
-    dialog.emit = lambda signal, data: data.pop('__save_completion')(True)
+    dialog.emit = lambda signal, data, metadata, secrets, completion: completion(True)
     dialog.close = lambda: closed.append(True)
     dialog.show_error = lambda message: errors.append(message)
 
@@ -397,9 +400,7 @@ def test_deleting_unstored_password_is_not_an_error(monkeypatch):
         'hostname': 'example.com',
         'nickname': 'example',
         'username': 'demo',
-        '__password': '',
-        'password_changed': True,
-    })
+    }, {}, {'password': '', 'password_changed': True})
 
     assert errors == []
     assert closed == [True]
@@ -429,21 +430,21 @@ def test_save_gate_detects_pending_passphrase_when_locked(monkeypatch):
     sm = ss.get_secret_manager()
 
     monkeypatch.setattr(sm, 'selected_needs_unlock', lambda: True)
-    assert dialog._needs_secret_unlock_before_save({'__secret_plan': {'password': ''}}) is True   # passphrase
-    assert dialog._needs_secret_unlock_before_save({'__secret_plan': {'password': 'p'}}) is True  # password
+    assert dialog._needs_secret_unlock_before_save({'password': ''}) is True   # passphrase
+    assert dialog._needs_secret_unlock_before_save({'password': 'p'}) is True  # password
 
     # No pending passphrase and no password -> no prompt even when locked.
     dialog.key_editor = types.SimpleNamespace(has_pending_passphrases=lambda: False)
-    assert dialog._needs_secret_unlock_before_save({'__secret_plan': {'password': ''}}) is False
+    assert dialog._needs_secret_unlock_before_save({'password': ''}) is False
 
     # Clearing a stored password is a vault delete -> must unlock first.
     assert dialog._needs_secret_unlock_before_save(
-        {'__secret_plan': {'password': '', 'password_changed': True}}) is True
+        {'password': '', 'password_changed': True}) is True
 
     # Unlocked -> never needs a prompt.
     monkeypatch.setattr(sm, 'selected_needs_unlock', lambda: False)
     dialog.key_editor = types.SimpleNamespace(has_pending_passphrases=lambda: True)
-    assert dialog._needs_secret_unlock_before_save({'__secret_plan': {'password': 'p'}}) is False
+    assert dialog._needs_secret_unlock_before_save({'password': 'p'}) is False
 
 
 def test_rule_editor_remote_to_local_resets_host_to_localhost():

--- a/tests/test_gtk_connection_mutations.py
+++ b/tests/test_gtk_connection_mutations.py
@@ -20,6 +20,7 @@ class _Client:
         self.deleted = []
         self.editor = None
         self.editor_calls = 0
+        self.metadata = []
 
     def create_connection(self, request):
         self.created.append(request)
@@ -38,6 +39,10 @@ class _Client:
     def delete_connection(self, request):
         self.deleted.append(request)
         return SimpleNamespace(connection_id=request.connection_id, deleted=True)
+
+    def update_connection_metadata(self, connection_id, metadata):
+        self.metadata.append((connection_id, metadata))
+        return True
 
     def get_connection_editor(self, connection_id):
         self.editor_calls += 1
@@ -184,6 +189,54 @@ def test_daemon_mutation_failure_keeps_ui_state_and_uses_safe_completion():
     assert completed == [False]
     assert window.connection_manager.reloads == 0
     assert window.rebuilds == 0
+
+
+def test_metadata_retry_resumes_without_repeating_create():
+    window = _MutationWindow()
+    completed = []
+    metadata = {"wol_port": 9, "tags": []}
+    dialog = SimpleNamespace(is_editing=False, connection=None)
+
+    window.on_connection_saved(
+        dialog, _basic_data(), metadata, {},
+        lambda ok, *args, **kwargs: completed.append(ok),
+    )
+    mutation, mutation_ok, _ = window.client_bridge.calls[0]
+    result = mutation()
+    mutation_ok(result)
+    assert len(window.client.created) == 1
+
+    # Metadata failed after create committed.  Saving again retries metadata
+    # from the checkpoint instead of submitting another create operation.
+    window.client_bridge.calls[1][2](RuntimeError("metadata unavailable"))
+    assert completed == [True]
+    window.on_connection_saved(
+        dialog, _basic_data(), metadata, {},
+        lambda ok, *args, **kwargs: completed.append(ok),
+    )
+    assert len(window.client_bridge.calls) == 3
+    metadata_retry, metadata_ok, _ = window.client_bridge.calls[2]
+    metadata_retry()
+    metadata_ok(True)
+
+    assert len(window.client.created) == 1
+    assert completed == [True, True]
+
+
+def test_secret_plan_is_rejected_at_config_persistence_boundary():
+    window = _MutationWindow()
+    completed = []
+    data = _basic_data()
+    data["__secret_plan"] = {"password": "must-not-persist"}
+
+    window.on_connection_saved(
+        SimpleNamespace(is_editing=False, connection=None), data, {}, {},
+        lambda ok: completed.append(ok),
+    )
+
+    assert completed == [False]
+    assert window.client_bridge.calls == []
+    assert window.client.created == []
 
 
 def test_daemon_editor_save_path_never_sends_password():
@@ -988,7 +1041,5 @@ def test_daemon_editor_terminal_failure_offers_retry_that_works(monkeypatch):
     assert dialog._daemon_generation == 11
     assert dialog._daemon_editor_loaded is True
     assert dialog._editor_load_failed is False
-
-
 
 


### PR DESCRIPTION
### Motivation

- Prevent secret material from being embedded in the same config dictionary that is persisted or sent to the daemon by ensuring secrets are carried separately from connection config.
- Ensure daemon-mode save flows are resumable so that a successful config mutation (create/update/rename/split) is not repeated when a later metadata or secret stage fails and is retried.
- Route password/key-passphrase operations through dedicated secret RPCs or local manager calls using the authoritative mutation result instead of leaking secrets into DTOs.

### Description

- Change the `connection-saved` GTK signal to carry four arguments (`config`, `metadata`, `secret_plan`, `completion`) so config, metadata and secrets are distinct and secrets never enter persistence DTOs. (connection_dialog/window changes)
- `ConnectionDialog._store_secrets_then_save` now accepts `metadata` and `secret_plan` parameters and emits the separated signal; it routes secret operations to daemon RPCs using a saved mutation result when available. (connection_dialog changes)
- Add resumable save checkpointing on the dialog (`_daemon_save_checkpoint`, `_daemon_metadata_saved`, `_resumable_save_active`) so post-config retries reuse the authoritative mutation result and do not repeat create/update/rename/split operations; checkpoints are cleared only after the full save flow succeeds. (window changes)
- Add a defensive rejection at the persistence boundary so payloads containing legacy `__secret_plan` inside `connection_data` are refused and the save fails fast. (window changes)
- Update tests to reflect the separated payload contract, to assert `__secret_plan` is not present in persisted `connection_data`, and to add metadata-retry/resume coverage that proves retries do not repeat creates. (tests updated)

### Testing

- Ran targeted GTK and passphrase test suites with `python -m pytest -q tests/test_gtk_connection_mutations.py tests/test_connection_dialog_passphrase.py tests/test_dialog_population.py tests/test_connection_edit_host_tokens.py`, which passed (48 passed, 1 skipped). 
- Ran the full test suite with `python -m pytest -q`, which reported the repository tests as passing locally (2,826 passed, 105 skipped) while 8 failures were classified as environment- or timing-related (container runtime missing, daemon/SFTP timing, and a leaked Paramiko test stub) and are unrelated to the changes here.
- Performed a quick style/sanity check (`git diff --check`) with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb978a6a8832894b5e2eb61d14d20)