### PR TITLE
Remove forced ControlMaster options and ControlMaster auth gating

### DIFF
--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -248,8 +248,8 @@ class InteractionBroker:
 
         ``trailing_args`` are appended after the target host once broker
         options have been inserted (e.g. ``("sftp",)`` for the SFTP subsystem
-        request) — the host must stay ``argv[-1]`` while ControlMaster options
-        are computed.
+        request) — the host must stay ``argv[-1]`` while broker options are
+        inserted.
         """
 
         argv_value, environment_value = launch_builder(
@@ -292,7 +292,6 @@ class InteractionBroker:
                 f"UserKnownHostsFile={known_hosts_value}",
             )
         token = secrets.token_urlsafe(32)
-        control_path = str(self._private_dir / f"c-{spec.session_id[-12:]}")
         options = (
             "-o",
             "BatchMode=no",
@@ -301,26 +300,12 @@ class InteractionBroker:
             "-o",
             "NumberOfPasswordPrompts=3",
             *host_key_options,
-            "-o",
-            "ControlMaster=yes",
-            "-o",
-            "ControlPersist=no",
-            "-o",
-            f"ControlPath={control_path}",
         )
         # OpenSSH keeps the first obtained value for each option. Insert broker
         # controls before preference overrides and strip conflicting earlier
         # copies of options we set — never strip StrictHostKeyChecking so the
         # Preferences/default accept-new (or ask/yes/no) reaches ssh.
         argv = self._with_broker_options(argv, options)
-        control_argv = (
-            argv[0],
-            "-S",
-            control_path,
-            "-O",
-            "check",
-            target,
-        )
         context = _AskpassContext(
             token=token,
             session_id=spec.session_id,
@@ -328,9 +313,9 @@ class InteractionBroker:
             hostname=hostname,
             username=username,
             port=port,
-            control_path=control_path,
+            control_path="",
             control_target=target,
-            control_argv=control_argv,
+            control_argv=(),
             attempts={},
             stored_attempted=set(),
             pending_remember=[],

--- a/src/sshpilot/daemon/server.py
+++ b/src/sshpilot/daemon/server.py
@@ -588,21 +588,6 @@ class DaemonServer:
                     ),
                 )
             )
-            # RUNNING means authenticated: wait for ControlMaster before the
-            # session leaves STARTING. Cancelled askpass maps to OPERATION_CANCELLED.
-            if (
-                hasattr(self._session_runtime, "set_auth_gate")
-                and hasattr(self._interaction_broker, "wait_for_control_master")
-            ):
-                broker = self._interaction_broker
-
-                def _auth_failure_classifier(session_id: SessionId) -> ErrorCode:
-                    if hasattr(broker, "classify_startup_failure"):
-                        return broker.classify_startup_failure(session_id)
-                    return ErrorCode.SESSION_STARTUP_FAILED
-
-                self._session_runtime._auth_failure_classifier = _auth_failure_classifier
-                self._session_runtime.set_auth_gate(broker.wait_for_control_master)
             self._dispatcher = RequestDispatcher(
                 self._core_client,
                 self._session_runtime,

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -652,6 +652,32 @@ def test_broker_options_win_over_conflicting_preference_overrides(
     assert argv[-1] == "example"
 
 
+def test_prepare_launch_does_not_force_connection_multiplexing(
+    broker: InteractionBroker,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(broker, "_effective_ssh_config", lambda _argv: {})
+
+    argv, _environment = broker.prepare_launch(
+        SessionLaunchSpec(
+            session_id=SESSION_ID,
+            connection_id=CONNECTION_ID,
+            protocol="ssh",
+            hostname="example.test",
+            username="alice",
+            port=22,
+        ),
+        lambda _connection_id, **_kwargs: (
+            ("/usr/bin/ssh", "example"),
+            {"PATH": os.environ.get("PATH", "")},
+        ),
+    )
+
+    assert not any("ControlMaster=" in item for item in argv)
+    assert not any("ControlPersist=" in item for item in argv)
+    assert not any("ControlPath=" in item for item in argv)
+
+
 def test_strict_host_key_mode_selects_first_occurrence() -> None:
     """Match OpenSSH: first obtained StrictHostKeyChecking wins."""
     argv = (


### PR DESCRIPTION
### Motivation

- Avoid forcing OpenSSH connection multiplexing options (`ControlMaster`, `ControlPersist`, `ControlPath`) from the daemon broker to improve compatibility and avoid creating control sockets.
- Stop blocking session startup on a ControlMaster check in the server runtime so session lifecycle is not gated on external multiplex state.

### Description

- Deleted injection of `ControlMaster=yes`, `ControlPersist=no`, and `ControlPath=...` from `InteractionBroker.prepare_launch` and removed generation of a `control_path` and corresponding `control_argv` values.
- Set `_AskpassContext.control_path` to an empty string and `control_argv` to an empty tuple instead of populating them with control socket values.
- Removed the `DaemonServer` logic that set an authentication gate using `wait_for_control_master` and the associated startup failure classifier.
- Added the unit test `test_prepare_launch_does_not_force_connection_multiplexing` to ensure the broker no longer inserts multiplexing options into the SSH argv.

### Testing

- Ran `pytest tests/daemon/test_interaction_broker.py::test_prepare_launch_does_not_force_connection_multiplexing`, which passed.
- Ran the rest of `tests/daemon/test_interaction_broker.py` to confirm no regressions, and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb9cd0fa88328a3f4998d5ea5bc81)