### PR TITLE
Preserve LocalCommand for daemon launches and stop forcing ControlMaster multiplexing

### DIFF
--- a/src/sshpilot/api/in_process_client.py
+++ b/src/sshpilot/api/in_process_client.py
@@ -280,6 +280,30 @@ class InProcessClient:
                 "The SSH session requires unsupported interaction",
                 connection_id=connection_id,
             )
+        # Keep daemon launches on the canonical ``ssh Host`` path, but carry the
+        # parsed LocalCommand explicitly.  Unlike the in-process terminal, the
+        # daemon owns a separately prepared process and must not depend on a
+        # frontend-side Connection object retaining this directive indirectly.
+        # Command-line options precede ssh_config, so PermitLocalCommand cannot
+        # be lost to a differing daemon-side config/default during launch.
+        connection_data = getattr(connection, "data", None)
+        data_local_command = (
+            connection_data.get("local_command", "")
+            if isinstance(connection_data, dict)
+            else ""
+        )
+        local_command = str(
+            getattr(connection, "local_command", "") or data_local_command or ""
+        ).strip()
+        if local_command:
+            argv = (
+                *argv[:-1],
+                "-o",
+                "PermitLocalCommand=yes",
+                "-o",
+                f"LocalCommand={local_command}",
+                argv[-1],
+            )
         executable = shutil.which(argv[0], path=environment.get("PATH"))
         if executable is None:
             raise SshPilotError(

--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -248,8 +248,8 @@ class InteractionBroker:
 
         ``trailing_args`` are appended after the target host once broker
         options have been inserted (e.g. ``("sftp",)`` for the SFTP subsystem
-        request) — the host must stay ``argv[-1]`` while ControlMaster options
-        are computed.
+        request) — the host must stay ``argv[-1]`` while broker options are
+        inserted.
         """
 
         argv_value, environment_value = launch_builder(
@@ -292,7 +292,6 @@ class InteractionBroker:
                 f"UserKnownHostsFile={known_hosts_value}",
             )
         token = secrets.token_urlsafe(32)
-        control_path = str(self._private_dir / f"c-{spec.session_id[-12:]}")
         options = (
             "-o",
             "BatchMode=no",
@@ -301,26 +300,12 @@ class InteractionBroker:
             "-o",
             "NumberOfPasswordPrompts=3",
             *host_key_options,
-            "-o",
-            "ControlMaster=yes",
-            "-o",
-            "ControlPersist=no",
-            "-o",
-            f"ControlPath={control_path}",
         )
         # OpenSSH keeps the first obtained value for each option. Insert broker
         # controls before preference overrides and strip conflicting earlier
         # copies of options we set — never strip StrictHostKeyChecking so the
         # Preferences/default accept-new (or ask/yes/no) reaches ssh.
         argv = self._with_broker_options(argv, options)
-        control_argv = (
-            argv[0],
-            "-S",
-            control_path,
-            "-O",
-            "check",
-            target,
-        )
         context = _AskpassContext(
             token=token,
             session_id=spec.session_id,
@@ -328,9 +313,9 @@ class InteractionBroker:
             hostname=hostname,
             username=username,
             port=port,
-            control_path=control_path,
+            control_path="",
             control_target=target,
-            control_argv=control_argv,
+            control_argv=(),
             attempts={},
             stored_attempted=set(),
             pending_remember=[],

--- a/src/sshpilot/daemon/server.py
+++ b/src/sshpilot/daemon/server.py
@@ -588,21 +588,6 @@ class DaemonServer:
                     ),
                 )
             )
-            # RUNNING means authenticated: wait for ControlMaster before the
-            # session leaves STARTING. Cancelled askpass maps to OPERATION_CANCELLED.
-            if (
-                hasattr(self._session_runtime, "set_auth_gate")
-                and hasattr(self._interaction_broker, "wait_for_control_master")
-            ):
-                broker = self._interaction_broker
-
-                def _auth_failure_classifier(session_id: SessionId) -> ErrorCode:
-                    if hasattr(broker, "classify_startup_failure"):
-                        return broker.classify_startup_failure(session_id)
-                    return ErrorCode.SESSION_STARTUP_FAILED
-
-                self._session_runtime._auth_failure_classifier = _auth_failure_classifier
-                self._session_runtime.set_auth_gate(broker.wait_for_control_master)
             self._dispatcher = RequestDispatcher(
                 self._core_client,
                 self._session_runtime,

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -486,6 +486,51 @@ def test_prepare_daemon_terminal_launch_preloads_keys(monkeypatch) -> None:
     assert preloads == [True]
 
 
+def test_prepare_daemon_terminal_launch_carries_local_command(monkeypatch) -> None:
+    """Daemon SSH argv must preserve the host's parsed LocalCommand."""
+    from sshpilot.api.in_process_client import InProcessClient
+    from tests.daemon.conftest import TestConnection, TestConnectionManager
+
+    class LocalCommandConnection(TestConnection):
+        def __init__(self):
+            super().__init__(nickname="local-command", hostname="h", username="u")
+            self.id = "local-command"
+            self.uuid = "local-command"
+            self.local_command = 'notify-send "connected"'
+            self.data.update({
+                "id": "local-command",
+                "local_command": self.local_command,
+            })
+
+        async def native_connect(self, **kwargs):
+            from types import SimpleNamespace
+
+            self.ssh_connection_cmd = SimpleNamespace(
+                command=("ssh", "local-command"),
+                env={"PATH": "/usr/bin", "HOME": "/tmp", "TERM": "xterm"},
+                use_askpass=False,
+            )
+            return True
+
+    manager = TestConnectionManager()
+    manager.connections = [LocalCommandConnection()]
+    client = InProcessClient(manager, allow_cross_thread_commands=True)
+    monkeypatch.setattr("shutil.which", lambda name, path=None: "/usr/bin/ssh")
+
+    argv, _env = client.prepare_daemon_terminal_launch(
+        ConnectionId("local-command"), interaction_policy="broker"
+    )
+
+    assert argv == (
+        "/usr/bin/ssh",
+        "-o",
+        "PermitLocalCommand=yes",
+        "-o",
+        'LocalCommand=notify-send "connected"',
+        "local-command",
+    )
+
+
 def test_remembered_password_is_stored_only_after_authenticated_status(
     monkeypatch,
 ) -> None:
@@ -650,6 +695,32 @@ def test_broker_options_win_over_conflicting_preference_overrides(
     # UserKnownHostsFile from argv is left alone unless mode is ask.
     assert "UserKnownHostsFile=/tmp/user-known-hosts" in argv
     assert argv[-1] == "example"
+
+
+def test_prepare_launch_does_not_force_connection_multiplexing(
+    broker: InteractionBroker,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(broker, "_effective_ssh_config", lambda _argv: {})
+
+    argv, _environment = broker.prepare_launch(
+        SessionLaunchSpec(
+            session_id=SESSION_ID,
+            connection_id=CONNECTION_ID,
+            protocol="ssh",
+            hostname="example.test",
+            username="alice",
+            port=22,
+        ),
+        lambda _connection_id, **_kwargs: (
+            ("/usr/bin/ssh", "example"),
+            {"PATH": os.environ.get("PATH", "")},
+        ),
+    )
+
+    assert not any("ControlMaster=" in item for item in argv)
+    assert not any("ControlPersist=" in item for item in argv)
+    assert not any("ControlPath=" in item for item in argv)
 
 
 def test_strict_host_key_mode_selects_first_occurrence() -> None:


### PR DESCRIPTION
### Motivation

- Ensure daemon-launched SSH processes receive any parsed `LocalCommand` from the connection so daemon-side ssh invocations behave like in-process terminals.
- Avoid having the daemon unilaterally force OpenSSH connection multiplexing (`ControlMaster`/`ControlPersist`/`ControlPath`) so multiplexing remains a client-side decision.
- Remove daemon-side coupling that waited for a ControlMaster before marking sessions as authenticated since multiplexing is no longer forced.

### Description

- In `InProcessClient` added logic to read `connection.local_command` (falling back to `connection.data["local_command"]`) and, when present, inject `-o PermitLocalCommand=yes` and `-o LocalCommand=...` into the daemon `ssh` `argv` prior to the target host.
- In `InteractionBroker.prepare_launch` removed insertion of broker `ControlMaster` options (`ControlMaster=yes`, `ControlPersist=no`, `ControlPath=...`) and stopped building a `control_argv`; the `_AskpassContext` now records an empty `control_path` and empty `control_argv` instead.
- In the daemon server initialization removed the block that set an authentication gate to wait for ControlMaster and the `_auth_failure_classifier` glue, decoupling session auth from control master checks.
- Added unit tests `test_prepare_daemon_terminal_launch_carries_local_command` and `test_prepare_launch_does_not_force_connection_multiplexing` to validate the new behavior and updated related test expectations.

### Testing

- Ran the `tests/daemon/test_interaction_broker.py` unit tests including the newly added tests `test_prepare_daemon_terminal_launch_carries_local_command` and `test_prepare_launch_does_not_force_connection_multiplexing`, and they passed.
- Existing broker-related tests that verify option ordering and host-key handling were executed and remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb9cd0fa88328a3f4998d5ea5bc81)