### PR TITLE
Fix asynchronous connection save lifecycle and retry semantics

### DIFF
--- a/src/sshpilot/api/in_process_client.py
+++ b/src/sshpilot/api/in_process_client.py
@@ -539,7 +539,7 @@ class InProcessClient:
     ) -> bool:
         connection = self._find_connection(connection_id)
         if connection is None:
-            return False
+            return True
         previous_connection = None
         if previous_hostname or previous_host or previous_username:
             previous_connection = {
@@ -578,7 +578,9 @@ class InProcessClient:
                 previous_connection, username=username,
             )
             removed = removed or removed_prev
-        return removed
+        # Deletion is idempotent: an already absent credential satisfies the
+        # requested final state. Backend exceptions still propagate as errors.
+        return True
 
     def store_connection_password_rpc(
         self, request: StoreConnectionPasswordRequest
@@ -614,7 +616,10 @@ class InProcessClient:
         )
 
     def delete_daemon_passphrase(self, key_path: str) -> bool:
-        return bool(self._connection_manager.delete_key_passphrase(key_path))
+        # Secret-manager deletion reports False when the item was already
+        # absent; that is still a successful idempotent delete operation.
+        self._connection_manager.delete_key_passphrase(key_path)
+        return True
 
     def store_key_passphrase_rpc(
         self, request: StoreKeyPassphraseRequest

--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -1380,6 +1380,23 @@ class ConnectionDialog(
         ),
     }
 
+    class SaveRequest:
+        """Completion callback with an explicit signal-consumer handshake."""
+
+        def __init__(self, callback):
+            self.claimed = False
+            self._callback = callback
+
+        def claim(self):
+            self.claimed = True
+            return self
+
+        def __call__(self, *args, **kwargs):
+            # Synchronous consumers claim implicitly by completing; asynchronous
+            # consumers must call claim() before returning from signal dispatch.
+            self.claimed = True
+            return self._callback(*args, **kwargs)
+
     content_mount = Gtk.Template.Child()
     cancel_button = Gtk.Template.Child()
     save_button = Gtk.Template.Child()
@@ -3421,30 +3438,25 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         if not operations:
             # No secret I/O — but the dialog still only closes once the window
             # reports a successful config write.
-            plain_completion_called = [False]
-
             def _after_plain_save(ok, result=None, meta_error=None):
-                plain_completion_called[0] = True
                 self._set_secret_save_busy(False)
-                if ok:
-                    if meta_error:
-                        self.show_error(meta_error)
-                    else:
-                        self._clear_save_checkpoint()
-                        self.close()
+                if meta_error:
+                    self.show_error(meta_error)
+                elif ok:
+                    self._clear_save_checkpoint()
+                    self.close()
                 else:
                     self.show_error(_("The connection settings could not be saved."))
 
+            request = self.SaveRequest(_after_plain_save)
             self.emit('connection-saved', connection_data, metadata, secret_plan,
-                      _after_plain_save)
-            if not plain_completion_called[0]:
-                # No consumer (standalone dialog, e.g. in tests).
+                      request)
+            if not request.claimed:
+                # An unclaimed request means there is no persistence consumer.
+                # Never infer that from whether an asynchronous callback happened
+                # to complete while emit() was on the stack.
                 self._set_secret_save_busy(False)
                 self.close()
-                # else: consumer popped the marker and is handling the
-                # completion asynchronously (e.g. daemon bridge).  Do NOT
-                # assume failure here — the async callback will invoke
-                # _after_plain_save with the real result.
             return
         if manager is None:
             self._set_secret_save_busy(False)
@@ -3488,7 +3500,11 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                             )
                             # Use the real connection_id returned by the mutation
                             mutation_result = getattr(self, '_save_mutation_result', None)
-                            conn_id = getattr(mutation_result, 'connection_id', None) or connection_data.get('nickname', '').strip()
+                            conn_id = getattr(mutation_result, 'connection_id', None)
+                            if not conn_id:
+                                raise RuntimeError(
+                                    "Daemon secret save has no authoritative mutation result"
+                                )
                             if conn_id and action == 'store':
                                 req = StoreConnectionPasswordRequest(
                                     connection_id=conn_id,
@@ -3506,20 +3522,6 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                                     previous_username=previous_identity.get('username', '') if previous_identity else '',
                                 )
                                 ok = client.delete_connection_password(req)
-                            else:
-                                # Create case: no connection_id yet, use local manager
-                                if action == 'store':
-                                    ok = bool(manager.store_connection_password(
-                                        connection_data, value, username=username,
-                                        previous_connection=previous_identity))
-                                else:
-                                    manager.delete_connection_passwords(
-                                        connection_data, username=username)
-                                    if previous_identity:
-                                        previous_user = previous_identity.get('username') or username
-                                        manager.delete_connection_passwords(
-                                            previous_identity, username=previous_user)
-                                    ok = True
                         else:
                             # Direct local storage
                             if action == 'store':
@@ -3557,14 +3559,19 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             GLib.idle_add(self._finish_secret_save, ok,
                           close_spinner, spinner, True)
 
-        completion_called = [False]
-
         def _after_config_saved(ok, mutation_result=None, meta_error=None):
-            completion_called[0] = True
-            if ok:
+            if mutation_result:
+                self._save_mutation_result = mutation_result
+            if meta_error:
+                self._save_meta_error = meta_error
+                self._finish_secret_save(False, close_spinner, spinner, True)
+            elif ok:
+                try:
+                    delattr(self, '_save_meta_error')
+                except AttributeError:
+                    pass
                 if mutation_result:
                     self._save_mutation_result = mutation_result
-                self._save_meta_error = meta_error
                 threading.Thread(target=_worker, daemon=True).start()
             else:
                 self._finish_secret_save(
@@ -3573,14 +3580,11 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         # Preserve the established save order: persist connection/config data first, then
         # its credentials. The private marker keeps update_connection from performing the
         # same secret I/O synchronously inside this signal emission.
+        request = self.SaveRequest(_after_config_saved)
         self.emit('connection-saved', connection_data, metadata, secret_plan,
-                  _after_config_saved)
-        if not completion_called[0]:
-            # Consumer popped the marker and is handling the completion
-            # asynchronously (e.g. daemon bridge).  Do NOT assume failure
-            # here — the async callback will invoke _after_config_saved
-            # with the real result.
-            pass
+                  request)
+        if not request.claimed:
+            self._finish_secret_save(False, close_spinner, spinner, False)
 
     def _finish_secret_save(self, ok, close_spinner, spinner,
                             settings_saved):
@@ -3594,6 +3598,8 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 else:
                     self._clear_save_checkpoint()
                     self.close()
+            elif getattr(self, '_save_meta_error', None):
+                self.show_error(self._save_meta_error)
             elif not settings_saved:
                 self.show_error(_("The connection settings could not be saved."))
             else:
@@ -3617,6 +3623,7 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         """Forget resumable daemon stages after the entire save succeeds."""
         for name in ('_save_mutation_result', '_save_meta_error',
                      '_daemon_save_checkpoint', '_daemon_metadata_saved',
+                     '_daemon_config_fingerprint', '_daemon_metadata_fingerprint',
                      '_resumable_save_active'):
             try:
                 delattr(self, name)

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -6639,6 +6639,21 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         resumable = bool(getattr(dialog, '_resumable_save_active', False))
         checkpoint = (getattr(dialog, '_daemon_save_checkpoint', None)
                       if resumable else None)
+        config_fingerprint = self._normalise_daemon_editor_value({
+            key: value for key, value in connection_data.items()
+            if not key.startswith('__')
+        })
+        metadata_fingerprint = self._normalise_daemon_editor_value(pending_meta or {})
+        if checkpoint is not None and getattr(
+            dialog, '_daemon_config_fingerprint', None
+        ) != config_fingerprint:
+            checkpoint = None
+            for name in ('_daemon_save_checkpoint', '_daemon_metadata_saved',
+                         '_daemon_metadata_fingerprint', '_save_mutation_result'):
+                try:
+                    delattr(dialog, name)
+                except AttributeError:
+                    pass
 
         # Daemon edits may never save against a pending/failed snapshot: the
         # dialog disables Save in that state, but the signal path (accelerator,
@@ -6801,16 +6816,28 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     )
 
             pending_meta_local = pending_meta or {}
-            if getattr(dialog, '_daemon_metadata_saved', False):
+            metadata_saved = getattr(dialog, '_daemon_metadata_saved', False)
+            if metadata_saved and getattr(
+                dialog, '_daemon_metadata_fingerprint', None
+            ) == metadata_fingerprint:
                 _finish_save_flow()
                 return
             if pending_meta_local and new_conn_id:
-                def _meta_success(_):
+                def _meta_success(result):
+                    if result is not True:
+                        _meta_failure(RuntimeError(
+                            "Metadata persistence returned false"
+                        ))
+                        return
                     dialog._daemon_metadata_saved = True
+                    dialog._daemon_metadata_fingerprint = metadata_fingerprint
                     _finish_save_flow()
                 def _meta_failure(error):
                     logger.debug("Metadata update via daemon RPC failed: %s", error)
-                    _finish_save_flow(meta_error=_("Saved, but tags/Wake-on-LAN settings could not be stored."))
+                    complete_save(
+                        False, _details,
+                        meta_error=_("Saved, but tags/Wake-on-LAN settings could not be stored."),
+                    )
                 try:
                     bridge.submit(
                         lambda: self.client.update_connection_metadata(new_conn_id, pending_meta_local),
@@ -6819,7 +6846,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     )
                     return
                 except RuntimeError:
-                    _finish_save_flow(meta_error=_("Saved, but tags/Wake-on-LAN settings could not be stored."))
+                    complete_save(False, _details, meta_error=_("Saved, but tags/Wake-on-LAN settings could not be stored."))
                     return
                     
             _finish_save_flow()
@@ -6845,6 +6872,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         def _checkpoint_success(details):
             if resumable:
                 dialog._daemon_save_checkpoint = details
+                dialog._daemon_config_fingerprint = config_fingerprint
             _success(details)
 
         try:
@@ -6859,6 +6887,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
     def on_connection_saved(self, dialog, connection_data, pending_meta=None,
                             secret_plan=None, save_completion=None):
         """Handle connection saved from dialog"""
+        claim = getattr(save_completion, 'claim', None)
+        if callable(claim):
+            claim()
         # Compatibility for third-party/plugin emitters using the pre-v2
         # one-object signal.  Values are removed before any persistence call.
         if save_completion is None:
@@ -6894,6 +6925,8 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             )
             if ok and not meta_error and not has_secret_work:
                 for name in ('_daemon_save_checkpoint', '_daemon_metadata_saved',
+                             '_daemon_config_fingerprint',
+                             '_daemon_metadata_fingerprint',
                              '_resumable_save_active'):
                     try:
                         delattr(dialog, name)

--- a/tests/test_connection_dialog_passphrase.py
+++ b/tests/test_connection_dialog_passphrase.py
@@ -406,6 +406,34 @@ def test_deleting_unstored_password_is_not_an_error(monkeypatch):
     assert closed == [True]
 
 
+def test_no_secret_daemon_save_waits_for_explicit_async_claim():
+    dialog = ConnectionDialog.__new__(ConnectionDialog)
+    dialog.connection_manager = DummyConnectionManager()
+    dialog._save_buttons = []
+    completions = []
+    closed = []
+    errors = []
+
+    def emit(_signal, _data, _metadata, _secrets, request):
+        request.claim()
+        completions.append(request)
+
+    dialog.emit = emit
+    dialog.close = lambda: closed.append(True)
+    dialog.show_error = lambda message: errors.append(message)
+
+    dialog._store_secrets_then_save(
+        {'nickname': 'demo', 'hostname': 'demo.example', 'username': 'alice'},
+        {}, {},
+    )
+
+    assert closed == []
+    assert len(completions) == 1
+    completions[0](False)
+    assert closed == []
+    assert len(errors) == 1
+
+
 def test_has_pending_passphrases_detects_cleared_entry():
     # A cleared passphrase (initial non-empty, entry now empty) is a pending
     # delete and must count as a change, so the unlock gate fires for it.

--- a/tests/test_gtk_connection_mutations.py
+++ b/tests/test_gtk_connection_mutations.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from sshpilot.api import ErrorCode, SshPilotError
 from sshpilot.window import MainWindow
+from sshpilot.api.in_process_client import InProcessClient
 
 
 class _ControlledBridge:
@@ -209,7 +210,7 @@ def test_metadata_retry_resumes_without_repeating_create():
     # Metadata failed after create committed.  Saving again retries metadata
     # from the checkpoint instead of submitting another create operation.
     window.client_bridge.calls[1][2](RuntimeError("metadata unavailable"))
-    assert completed == [True]
+    assert completed == [False]
     window.on_connection_saved(
         dialog, _basic_data(), metadata, {},
         lambda ok, *args, **kwargs: completed.append(ok),
@@ -220,7 +221,96 @@ def test_metadata_retry_resumes_without_repeating_create():
     metadata_ok(True)
 
     assert len(window.client.created) == 1
-    assert completed == [True, True]
+    assert completed == [False, True]
+
+
+def test_metadata_false_is_failure_and_retry_does_not_repeat_create():
+    window = _MutationWindow()
+    completed = []
+    metadata = {"tags": ["ops"]}
+    dialog = SimpleNamespace(is_editing=False, connection=None)
+
+    window.on_connection_saved(
+        dialog, _basic_data(), metadata, {},
+        lambda ok, result=None, meta_error=None: completed.append(
+            (ok, result, meta_error)
+        ),
+    )
+    create, create_ok, _ = window.client_bridge.calls[0]
+    create_ok(create())
+    window.client_bridge.calls[1][1](False)
+
+    assert completed[0][0] is False
+    assert completed[0][1].connection_id == "demo"
+    assert completed[0][2]
+    assert len(window.client.created) == 1
+
+
+def test_changed_config_invalidates_partial_save_checkpoint():
+    window = _MutationWindow()
+    dialog = SimpleNamespace(is_editing=False, connection=None)
+    metadata = {"tags": ["ops"]}
+
+    window.on_connection_saved(dialog, _basic_data(), metadata, {}, lambda *_: None)
+    create, create_ok, _ = window.client_bridge.calls[0]
+    create_ok(create())
+    window.client_bridge.calls[1][2](RuntimeError("metadata unavailable"))
+
+    changed = _basic_data(hostname="corrected.example")
+    window.on_connection_saved(dialog, changed, metadata, {}, lambda *_: None)
+    second_create = window.client_bridge.calls[2][0]
+    second_create()
+
+    assert len(window.client.created) == 2
+    assert window.client.created[-1].hostname == "corrected.example"
+
+
+def test_changed_metadata_invalidates_only_metadata_checkpoint():
+    window = _MutationWindow()
+    dialog = SimpleNamespace(
+        is_editing=False,
+        connection=None,
+        _resumable_save_active=True,
+        _daemon_save_checkpoint=SimpleNamespace(connection_id="demo", generation=1),
+        _daemon_config_fingerprint=MainWindow._normalise_daemon_editor_value({
+            key: value for key, value in _basic_data().items()
+            if not key.startswith('__')
+        }),
+        _daemon_metadata_saved=True,
+        _daemon_metadata_fingerprint=MainWindow._normalise_daemon_editor_value(
+            {"tags": ["old"]}
+        ),
+    )
+
+    window.on_connection_saved(
+        dialog, _basic_data(), {"tags": ["new"]}, {}, lambda *_: None
+    )
+
+    assert len(window.client.created) == 0
+    metadata_operation = window.client_bridge.calls[0][0]
+    assert metadata_operation() is True
+    assert window.client.metadata == [("demo", {"tags": ["new"]})]
+
+
+def test_daemon_delete_absent_password_is_idempotent():
+    client = InProcessClient.__new__(InProcessClient)
+    client._find_connection = lambda _connection_id: SimpleNamespace(
+        hostname="demo.example", host="demo", username="alice"
+    )
+    client._connection_manager = SimpleNamespace(
+        delete_connection_passwords=lambda *_args, **_kwargs: False
+    )
+
+    assert client.delete_daemon_password("demo") is True
+
+
+def test_daemon_delete_absent_passphrase_is_idempotent():
+    client = InProcessClient.__new__(InProcessClient)
+    client._connection_manager = SimpleNamespace(
+        delete_key_passphrase=lambda _path: False
+    )
+
+    assert client.delete_daemon_passphrase("/tmp/missing-key") is True
 
 
 def test_secret_plan_is_rejected_at_config_persistence_boundary():
@@ -1041,5 +1131,3 @@ def test_daemon_editor_terminal_failure_offers_retry_that_works(monkeypatch):
     assert dialog._daemon_generation == 11
     assert dialog._daemon_editor_loaded is True
     assert dialog._editor_load_failed is False
-
-


### PR DESCRIPTION
### Motivation

- Prevent the dialog from closing prematurely when daemon-backed saves complete asynchronously, which leads to lost edits, spurious errors on destroyed dialogs, and broken completion semantics.  
- Treat metadata persistence returning the exact value `False` as an error and prevent secret-stage work from running when metadata fails.  
- Ensure resumable checkpoints correspond to the actual saved inputs so retries do not silently discard user edits or repeat already-completed secret operations.  

### Description

- Introduce an explicit `SaveRequest` handshake and use a `claimed` flag so signal consumers must explicitly claim asynchronous save requests instead of relying on timing-based detection.  
- Require an authoritative daemon mutation result for daemon-mode secret operations and remove the nickname-derived fallback so secret storage uses the true connection id.  
- Treat `update_connection_metadata()` returning `False` as a failure and surface a failure to callers instead of marking metadata as saved.  
- Bind resumable config and metadata checkpoints to normalized fingerprints of the dialog inputs and invalidate checkpointed stages when the corresponding inputs change, and stop secret persistence when metadata fails.  
- Make daemon password and passphrase deletion idempotent so attempts to delete already-absent credentials are considered successful.  
- Add and update regression tests covering the async claim semantics, metadata-false handling, changed-config/metadata invalidation of checkpoints, and idempotent deletion of absent secrets.  

### Testing

- Ran `pytest -q tests/test_gtk_connection_mutations.py tests/test_connection_dialog_passphrase.py` and observed all tests in those files passed (43 passed).  
- Ran `git diff --check` to ensure no whitespace/errors; clean.  
- Ran the full test-suite `pytest -q`; results were 2,832 passed and 105 skipped with 8 failures that are environment- or timing-dependent (container runtime unavailable for some integration tests, a few daemon/SFTP timing flakes, and a Paramiko test-stub leak), which are unrelated to these logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbfbf4d7c8328b36c0a21ee23e133)