### PR TITLE
Do not inject broker SSH option defaults into prepared ssh argv

### DIFF
--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -273,39 +273,12 @@ class InteractionBroker:
             port = int(effective.get("port", spec.port))
         except (TypeError, ValueError):
             port = spec.port
-        # Prefer the app/CLI StrictHostKeyChecking already on argv (Preferences
-        # default is accept-new). Only fall back to ssh -G / accept-new.
-        strict_mode = self._strict_host_key_mode(argv, effective)
         user_paths = self._known_hosts_paths(effective)
-        session_known = self._private_dir / f"h-{spec.session_id[-12:]}"
-        self._atomic_write(session_known, b"")
-        # ask: session-first known_hosts so ACCEPT_ONCE stays session-scoped and
-        # ACCEPT_AND_STORE can merge into the user file. accept-new/yes/no: leave
-        # UserKnownHostsFile alone so OpenSSH writes where Preferences expect.
-        host_key_options: tuple[str, ...] = ()
-        if strict_mode == "ask":
-            known_hosts_value = " ".join(
-                (str(session_known), *(str(path) for path in user_paths))
-            )
-            host_key_options = (
-                "-o",
-                f"UserKnownHostsFile={known_hosts_value}",
-            )
         token = secrets.token_urlsafe(32)
-        options = (
-            "-o",
-            "BatchMode=no",
-            "-o",
-            "KbdInteractiveAuthentication=no",
-            "-o",
-            "NumberOfPasswordPrompts=3",
-            *host_key_options,
-        )
-        # OpenSSH keeps the first obtained value for each option. Insert broker
-        # controls before preference overrides and strip conflicting earlier
-        # copies of options we set — never strip StrictHostKeyChecking so the
-        # Preferences/default accept-new (or ask/yes/no) reaches ssh.
-        argv = self._with_broker_options(argv, options)
+        # Keep the canonical builder argv unchanged. In particular, the daemon
+        # must not impose BatchMode, KbdInteractiveAuthentication,
+        # NumberOfPasswordPrompts, or UserKnownHostsFile defaults that the
+        # in-process terminal path does not impose.
         context = _AskpassContext(
             token=token,
             session_id=spec.session_id,
@@ -319,7 +292,7 @@ class InteractionBroker:
             attempts={},
             stored_attempted=set(),
             pending_remember=[],
-            session_known_hosts=str(session_known),
+            session_known_hosts="",
             user_known_hosts_paths=tuple(str(path) for path in user_paths),
             hash_known_hosts=effective.get("hashknownhosts", "no") == "yes",
         )

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -602,7 +602,7 @@ def test_persistent_host_key_rejects_symlink(
     assert target.read_text() == ""
 
 
-def test_broker_options_win_over_conflicting_preference_overrides(
+def test_prepare_launch_preserves_canonical_ssh_options(
     broker: InteractionBroker,
     monkeypatch,
 ) -> None:
@@ -634,25 +634,23 @@ def test_broker_options_win_over_conflicting_preference_overrides(
             {"PATH": os.environ.get("PATH", "")},
         ),
     )
-    assert argv[:5] == (
+    assert argv == (
         "/usr/bin/ssh",
         "-F",
         "/tmp/config",
         "-o",
-        "BatchMode=no",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "UserKnownHostsFile=/tmp/user-known-hosts",
+        "-o",
+        "ConnectTimeout=5",
+        "example",
     )
-    text = " ".join(argv)
-    assert text.index("BatchMode=no") < text.index("ConnectTimeout=5")
-    assert "BatchMode=yes" not in argv
-    # Preferences / argv StrictHostKeyChecking must survive (default accept-new).
-    assert "StrictHostKeyChecking=accept-new" in argv
-    assert "StrictHostKeyChecking=ask" not in argv
-    # UserKnownHostsFile from argv is left alone unless mode is ask.
-    assert "UserKnownHostsFile=/tmp/user-known-hosts" in argv
-    assert argv[-1] == "example"
 
 
-def test_prepare_launch_does_not_force_connection_multiplexing(
+def test_prepare_launch_does_not_add_ssh_option_defaults(
     broker: InteractionBroker,
     monkeypatch,
 ) -> None:
@@ -673,9 +671,7 @@ def test_prepare_launch_does_not_force_connection_multiplexing(
         ),
     )
 
-    assert not any("ControlMaster=" in item for item in argv)
-    assert not any("ControlPersist=" in item for item in argv)
-    assert not any("ControlPath=" in item for item in argv)
+    assert argv == ("/usr/bin/ssh", "example")
 
 
 def test_strict_host_key_mode_selects_first_occurrence() -> None:
@@ -714,7 +710,7 @@ def test_strict_host_key_mode_selects_first_occurrence() -> None:
     ) == "yes"
 
 
-def test_prepare_launch_ask_uses_session_known_hosts(
+def test_prepare_launch_ask_preserves_user_known_hosts(
     broker: InteractionBroker,
     monkeypatch,
 ) -> None:
@@ -741,12 +737,7 @@ def test_prepare_launch_ask_uses_session_known_hosts(
         ),
     )
     assert "StrictHostKeyChecking=ask" in argv
-    known_opt = next(
-        item for item in argv if item.startswith("UserKnownHostsFile=")
-    )
-    assert known_opt.startswith("UserKnownHostsFile=")
-    assert "/tmp/user-known-hosts" not in known_opt
-    assert "known_hosts" in known_opt or "/h-" in known_opt or "h-" in known_opt
+    assert "UserKnownHostsFile=/tmp/user-known-hosts" in argv
 
 
 def test_parse_openssh_host_key_askpass_prompt(broker: InteractionBroker) -> None:


### PR DESCRIPTION
### Motivation

- The daemon broker must not impose SSH option defaults (like `BatchMode`, `KbdInteractiveAuthentication`, `NumberOfPasswordPrompts`, or `UserKnownHostsFile`) that differ from the canonical builder argv or the in-process terminal path.

### Description

- Stop computing and applying `strict_mode`, `host_key_options`, session-scoped `known_hosts` files, and the `options` tuple into the builder `argv` inside `prepare_launch` so the canonical builder argv is preserved. 
- Keep the `control_path` and `control_argv` empty and set `session_known_hosts` to an empty string in the `_AskpassContext` to avoid daemon-enforced multiplexing or session-scoped host file behavior. 
- Preserve the original builder `argv` returned by `prepare_launch` and retain the environment askpass setup (`SSH_ASKPASS`, `SSH_ASKPASS_REQUIRE`, `DISPLAY`, `SSHPILOT_DAEMON_ASKPASS_*`, and `PYTHONPATH`).
- Update tests in `tests/daemon/test_interaction_broker.py` to reflect the new behavior and rename/adjust assertions to expect the canonical `argv` to be unchanged.

### Testing

- Ran the updated unit tests for the interaction broker with `pytest tests/daemon/test_interaction_broker.py`, and the modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc243da0083288d8f6130662e2a62)