### PR TITLE
fix(daemon): complete headless OpenSSH askpass parity

### DIFF
--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -5,6 +5,9 @@ notes remain separate.
 
 ## Unreleased
 
+- Bumped `API_IMPLEMENTATION_VERSION` to `0.13` for the expanded interaction
+  API, including typed generic confirmations.
+
 ### Daemon askpass parity (Added)
 
 - Added typed keyboard-interactive and security-key-presence prompts so daemon

--- a/docs/api/generated/model-index.md
+++ b/docs/api/generated/model-index.md
@@ -412,6 +412,28 @@ Synthetic representation:
 }
 ```
 
+<!-- api-model: ConfirmationPrompt -->
+## `ConfirmationPrompt`
+
+**Status:** Schema only
+**Introduced:** Protocol v1
+**Purpose:** ConfirmationPrompt(text: str)
+
+**Related methods:** None
+**Related events:** None
+
+| Field | Type | Required | Default | Sensitive |
+| --- | --- | ---: | --- | ---: |
+| `text` | `str` | Yes | — | No |
+
+Synthetic representation:
+
+```json
+{
+  "text": "example"
+}
+```
+
 <!-- api-model: ConnectionDetails -->
 ## `ConnectionDetails`
 
@@ -1673,7 +1695,7 @@ Synthetic representation:
 
 **Status:** Schema only
 **Introduced:** Protocol v1
-**Purpose:** InteractionSummary(id: sshpilot.api.models.common.InteractionId, session_id: sshpilot.api.models.common.SessionId, connection_id: sshpilot.api.models.common.ConnectionId, type: sshpilot.api.models.interactions.InteractionType, state: sshpilot.api.models.interactions.InteractionState, created_at: datetime.datetime, expires_at: datetime.datetime, attempt: int, prompt: sshpilot.api.models.interactions.HostKeyPrompt | sshpilot.api.models.interactions.PasswordPrompt | sshpilot.api.models.interactions.PassphrasePrompt | sshpilot.api.models.interactions.ChallengePrompt | sshpilot.api.models.interactions.PresencePrompt, responder_client_id: sshpilot.api.models.common.ClientId | None = None)
+**Purpose:** InteractionSummary(id: sshpilot.api.models.common.InteractionId, session_id: sshpilot.api.models.common.SessionId, connection_id: sshpilot.api.models.common.ConnectionId, type: sshpilot.api.models.interactions.InteractionType, state: sshpilot.api.models.interactions.InteractionState, created_at: datetime.datetime, expires_at: datetime.datetime, attempt: int, prompt: sshpilot.api.models.interactions.HostKeyPrompt | sshpilot.api.models.interactions.PasswordPrompt | sshpilot.api.models.interactions.PassphrasePrompt | sshpilot.api.models.interactions.ChallengePrompt | sshpilot.api.models.interactions.PresencePrompt | sshpilot.api.models.interactions.ConfirmationPrompt, responder_client_id: sshpilot.api.models.common.ClientId | None = None)
 
 **Related methods:** None
 **Related events:** None
@@ -1688,7 +1710,7 @@ Synthetic representation:
 | `created_at` | `datetime` | Yes | — | No |
 | `expires_at` | `datetime` | Yes | — | No |
 | `attempt` | `int` | Yes | — | No |
-| `prompt` | `HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt` | Yes | — | No |
+| `prompt` | `HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt | ConfirmationPrompt` | Yes | — | No |
 | `responder_client_id` | `ClientId | None` | No | `null` | No |
 
 Synthetic representation:

--- a/docs/api/generated/schema.json
+++ b/docs/api/generated/schema.json
@@ -1,5 +1,5 @@
 {
-  "api_implementation_version": "0.12",
+  "api_implementation_version": "0.13",
   "client_method_contract": {
     "assign_connection_to_group": {
       "capability": "connections.groups",
@@ -726,7 +726,8 @@
       "password",
       "private_key_passphrase",
       "keyboard_interactive",
-      "security_key_presence"
+      "security_key_presence",
+      "confirmation"
     ],
     "RememberPolicy": [
       "do_not_store",
@@ -1143,6 +1144,18 @@
         }
       ],
       "status": "Implemented"
+    },
+    "ConfirmationPrompt": {
+      "fields": [
+        {
+          "default": null,
+          "name": "text",
+          "required": true,
+          "sensitive": false,
+          "type": "str"
+        }
+      ],
+      "status": "Schema only"
     },
     "ConnectionDetails": {
       "fields": [
@@ -3084,7 +3097,7 @@
           "name": "prompt",
           "required": true,
           "sensitive": false,
-          "type": "HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt"
+          "type": "HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt | ConfirmationPrompt"
         },
         {
           "default": null,

--- a/src/sshpilot/api/models/__init__.py
+++ b/src/sshpilot/api/models/__init__.py
@@ -63,6 +63,7 @@ from .daemon import (
 )
 from .interactions import (
     ChallengePrompt,
+    ConfirmationPrompt,
     HostKeyDecision,
     HostKeyPrompt,
     HostKeyStatus,
@@ -162,6 +163,7 @@ __all__ = [
     "AuthenticationMethod",
     "CancelTransferRequest",
     "ChallengePrompt",
+    "ConfirmationPrompt",
     "ClaimForwardRequest",
     "ClaimTerminalInputRequest",
     "ClientId",

--- a/src/sshpilot/api/models/interactions.py
+++ b/src/sshpilot/api/models/interactions.py
@@ -22,6 +22,7 @@ class InteractionType(str, Enum):
     PRIVATE_KEY_PASSPHRASE = "private_key_passphrase"
     KEYBOARD_INTERACTIVE = "keyboard_interactive"
     SECURITY_KEY_PRESENCE = "security_key_presence"
+    CONFIRMATION = "confirmation"
 
 
 class InteractionState(str, Enum):
@@ -136,7 +137,7 @@ class ChallengePrompt:
     attempt: int
 
     def __post_init__(self) -> None:
-        _require_safe_display(self.text, "challenge prompt", 4096)
+        _require_safe_display(self.text, "challenge prompt", 4096, multiline=True)
         if type(self.attempt) is not int or self.attempt < 1:
             raise ValueError("challenge attempt must be positive")
 
@@ -149,17 +150,32 @@ class PresencePrompt:
         _require_safe_display(self.text, "presence prompt", 4096)
 
 
+@dataclass(frozen=True)
+class ConfirmationPrompt:
+    text: str
+
+    def __post_init__(self) -> None:
+        _require_safe_display(self.text, "confirmation prompt", 4096, multiline=True)
+
+
 InteractionPrompt = Union[
-    HostKeyPrompt, PasswordPrompt, PassphrasePrompt, ChallengePrompt, PresencePrompt
+    HostKeyPrompt, PasswordPrompt, PassphrasePrompt, ChallengePrompt, PresencePrompt,
+    ConfirmationPrompt,
 ]
 
 
-def _require_safe_display(value: str, name: str, maximum: int) -> None:
+def _require_safe_display(
+    value: str, name: str, maximum: int, *, multiline: bool = False
+) -> None:
     if (
         type(value) is not str
         or not value.strip()
         or len(value) > maximum
-        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+        or any(
+            (ord(character) < 32 and not (multiline and character in "\n\t"))
+            or ord(character) == 127
+            for character in value
+        )
     ):
         raise ValueError(f"{name} is invalid")
 
@@ -199,6 +215,7 @@ class InteractionSummary:
             InteractionType.PRIVATE_KEY_PASSPHRASE: PassphrasePrompt,
             InteractionType.KEYBOARD_INTERACTIVE: ChallengePrompt,
             InteractionType.SECURITY_KEY_PRESENCE: PresencePrompt,
+            InteractionType.CONFIRMATION: ConfirmationPrompt,
         }[self.type]
         if type(self.prompt) is not expected_prompt:
             raise TypeError("interaction prompt does not match its type")

--- a/src/sshpilot/api/transport/codec.py
+++ b/src/sshpilot/api/transport/codec.py
@@ -24,6 +24,7 @@ from ..models.common import (
 )
 from ..models.interactions import (
     ChallengePrompt,
+    ConfirmationPrompt,
     HostKeyDecision,
     HostKeyPrompt,
     HostKeyStatus,
@@ -2379,7 +2380,7 @@ def capabilities_from_wire(value: Any) -> Capabilities:
 
 def _interaction_prompt_to_wire(
     interaction_type: InteractionType,
-    prompt: HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt,
+    prompt: HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt | ConfirmationPrompt,
 ) -> Dict[str, Any]:
     if interaction_type is InteractionType.HOST_KEY_CONFIRMATION:
         if type(prompt) is not HostKeyPrompt:
@@ -2420,13 +2421,17 @@ def _interaction_prompt_to_wire(
         if type(prompt) is not PresencePrompt:
             raise TypeError("presence interaction requires a presence prompt")
         return {"text": prompt.text}
+    if interaction_type is InteractionType.CONFIRMATION:
+        if type(prompt) is not ConfirmationPrompt:
+            raise TypeError("confirmation interaction requires a confirmation prompt")
+        return {"text": prompt.text}
     raise TypeError("unsupported interaction type")
 
 
 def _interaction_prompt_from_wire(
     interaction_type: InteractionType,
     value: Any,
-) -> HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt:
+) -> HostKeyPrompt | PasswordPrompt | PassphrasePrompt | ChallengePrompt | PresencePrompt | ConfirmationPrompt:
     if interaction_type is InteractionType.HOST_KEY_CONFIRMATION:
         data = _strict_fields(
             value,
@@ -2498,6 +2503,9 @@ def _interaction_prompt_from_wire(
     if interaction_type is InteractionType.SECURITY_KEY_PRESENCE:
         data = _strict_fields(value, required={"text"}, context="presence prompt")
         return PresencePrompt(text=_text(data["text"], "presence prompt"))
+    if interaction_type is InteractionType.CONFIRMATION:
+        data = _strict_fields(value, required={"text"}, context="confirmation prompt")
+        return ConfirmationPrompt(text=_text(data["text"], "confirmation prompt"))
     raise ValueError("unsupported interaction type")
 
 

--- a/src/sshpilot/api/transport/secret_frames.py
+++ b/src/sshpilot/api/transport/secret_frames.py
@@ -37,7 +37,7 @@ class SecretFrame:
             raise ValueError("secret response nonce is malformed")
         if type(self.secret) is not bytearray:
             raise TypeError("secret response payload must be a bytearray")
-        if not self.secret or len(self.secret) > MAX_SECRET_PAYLOAD_SIZE:
+        if len(self.secret) > MAX_SECRET_PAYLOAD_SIZE:
             raise ValueError("secret response payload size is invalid")
         if b"\0" in self.secret:
             raise ValueError("secret response payload must not contain NUL")
@@ -72,7 +72,7 @@ def encode_secret_payload(frame: SecretFrame) -> bytes:
 
 
 def decode_secret_payload(payload: bytes) -> SecretFrame:
-    if not isinstance(payload, bytes) or len(payload) <= _HEADER.size:
+    if not isinstance(payload, bytes) or len(payload) < _HEADER.size:
         raise FramingError(
             ErrorCode.INVALID_FRAME,
             "The secret response frame is incomplete",

--- a/src/sshpilot/api/version.py
+++ b/src/sshpilot/api/version.py
@@ -1,4 +1,4 @@
 """Version identifiers for the frontend-neutral sshPilot API."""
 
 PROTOCOL_VERSION = "1.0"
-API_IMPLEMENTATION_VERSION = "0.12"
+API_IMPLEMENTATION_VERSION = "0.13"

--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -3515,6 +3515,9 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             and hasattr(client, 'store_connection_password')
         )
 
+        pipeline = self.SaveRequest(lambda *_args: None)
+        pipeline.claim()
+
         def _worker():
             ok = True
             try:
@@ -3586,15 +3589,16 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 logger.exception("Failed to save connection secrets")
                 ok = False
             GLib.idle_add(self._finish_secret_save, ok,
-                          close_spinner, spinner, True)
+                          close_spinner, spinner, True, pipeline)
 
         def _after_config_saved(ok, mutation_result=None, meta_error=None):
-            self._active_save_request = None
             if mutation_result:
                 self._save_mutation_result = mutation_result
             if meta_error:
                 self._save_meta_error = meta_error
-                self._finish_secret_save(False, close_spinner, spinner, True)
+                self._finish_secret_save(
+                    False, close_spinner, spinner, True, pipeline
+                )
             elif ok:
                 try:
                     delattr(self, '_save_meta_error')
@@ -3605,21 +3609,29 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 threading.Thread(target=_worker, daemon=True).start()
             else:
                 self._finish_secret_save(
-                    False, close_spinner, spinner, False)
+                    False, close_spinner, spinner, False, pipeline
+                )
 
         # Preserve the established save order: persist connection/config data first, then
         # its credentials. The private marker keeps update_connection from performing the
         # same secret I/O synchronously inside this signal emission.
         request = self.SaveRequest(_after_config_saved)
-        self._active_save_request = request
+        self._active_save_request = pipeline
         self.emit('connection-saved', connection_data, metadata, secret_plan,
                   request)
         if not request.claimed:
-            self._finish_secret_save(False, close_spinner, spinner, False)
+            self._finish_secret_save(
+                False, close_spinner, spinner, False, pipeline
+            )
 
     def _finish_secret_save(self, ok, close_spinner, spinner,
-                            settings_saved):
+                            settings_saved, pipeline=None):
         """Finish an asynchronous secret save on the GTK main thread."""
+        if pipeline is not None and pipeline.cancelled:
+            close_spinner()
+            return False
+        if pipeline is not None and self._active_save_request is pipeline:
+            self._active_save_request = None
         def _after_closed(*_args):
             self._set_secret_save_busy(False)
             if ok:

--- a/src/sshpilot/daemon/askpass_helper.py
+++ b/src/sshpilot/daemon/askpass_helper.py
@@ -53,7 +53,7 @@ def main() -> int:
             transport.connect(socket_path)
             transport.sendall(_LENGTH.pack(len(request)) + request)
             size = _LENGTH.unpack(_receive_exact(transport, _LENGTH.size))[0]
-            if size < 1 or size > _MAX_RESPONSE:
+            if size > _MAX_RESPONSE:
                 return 1
             secret = bytearray(_receive_exact(transport, size))
         sys.stdout.buffer.write(secret)

--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -36,6 +36,7 @@ from sshpilot.api.events import (
 from sshpilot.api.interaction_identity import new_interaction_id
 from sshpilot.api.models import (
     ChallengePrompt,
+    ConfirmationPrompt,
     ClientId,
     ConnectionId,
     HostKeyDecision,
@@ -87,7 +88,7 @@ _SECRET_TYPES = frozenset(
         InteractionType.PASSWORD,
         InteractionType.PRIVATE_KEY_PASSPHRASE,
         InteractionType.KEYBOARD_INTERACTIVE,
-        InteractionType.SECURITY_KEY_PRESENCE,
+        InteractionType.CONFIRMATION,
     }
 )
 
@@ -224,6 +225,7 @@ class InteractionBroker:
         launch_builder: Callable[..., tuple[Sequence[str], dict[str, str]]],
         *,
         trailing_args: Sequence[str] = (),
+        headless: bool = False,
     ) -> tuple[tuple[str, ...], dict[str, str]]:
         """Prepare canonical SSH argv, OpenSSH trust, and daemon askpass.
 
@@ -240,11 +242,11 @@ class InteractionBroker:
 
         argv_value, environment_value = launch_builder(
             spec.connection_id,
-            interaction_policy="broker",
+            interaction_policy="normal",
         )
         argv = tuple(argv_value)
-        # The launch builder intentionally returns an allowlisted environment.
-        # Do not reintroduce daemon credentials through wholesale inheritance.
+        # Keep the normal OpenSSH child environment.  Replace only SSH Pilot's
+        # private, process-local askpass transport below.
         environment = dict(environment_value)
         if not argv or len(argv) < 2:
             raise SshPilotError(
@@ -287,12 +289,20 @@ class InteractionBroker:
             self._require_open_locked()
             self._askpass_contexts[token] = context
             self._condition.notify_all()
-        askpass_active = environment.pop("SSHPILOT_DAEMON_ASKPASS_ACTIVE", "") == "1"
+        resolver_askpass_active = (
+            environment.pop("SSHPILOT_DAEMON_ASKPASS_ACTIVE", "") == "1"
+        )
+        for name in tuple(environment):
+            if (
+                name in {"SSH_ASKPASS", "SSH_ASKPASS_REQUIRE"}
+                or name.startswith("SSHPILOT_ASKPASS_")
+                or name.startswith("SSHPILOT_SESSION_")
+            ):
+                environment.pop(name, None)
+        askpass_active = headless or resolver_askpass_active
         if askpass_active:
             environment["SSH_ASKPASS"] = str(self._askpass_helper_path)
-            # Match the in-process resolver: askpass is preferred only when a
-            # saved password/passphrase activated it.
-            environment["SSH_ASKPASS_REQUIRE"] = "prefer"
+            environment["SSH_ASKPASS_REQUIRE"] = "force" if headless else "prefer"
             environment["DISPLAY"] = environment.get("DISPLAY") or ":sshpilot-daemon"
             environment["SSHPILOT_DAEMON_ASKPASS_SOCKET"] = str(
                 self._askpass_socket_path
@@ -1221,7 +1231,7 @@ class InteractionBroker:
                     hint=hint,
                     helper_transport=transport,
                 )
-                if secret is None or not secret or len(secret) > _MAX_SECRET_SIZE:
+                if secret is None or len(secret) > _MAX_SECRET_SIZE:
                     continue
                 transport.sendall(
                     _ASKPASS_LENGTH.pack(len(secret)) + bytes(secret)
@@ -1264,7 +1274,11 @@ class InteractionBroker:
         helper_transport: Optional[socket.socket] = None,
     ) -> Optional[bytearray]:
         normalized_hint = hint.strip().lower()
-        prompt_type = "presence" if normalized_hint == "none" else classify_prompt(raw_prompt)
+        prompt_type = (
+            "presence" if normalized_hint == "none"
+            else "confirmation" if normalized_hint == "confirm"
+            else classify_prompt(raw_prompt)
+        )
         if prompt_type == "hostkey":
             return self._resolve_host_key_askpass(
                 token,
@@ -1274,6 +1288,11 @@ class InteractionBroker:
         if prompt_type == "presence":
             return self._resolve_nonstored_askpass(
                 token, raw_prompt, presence=True, helper_transport=helper_transport
+            )
+        if prompt_type == "confirmation":
+            return self._resolve_nonstored_askpass(
+                token, raw_prompt, presence=False, confirmation=True,
+                helper_transport=helper_transport,
             )
         if prompt_type not in {"password", "passphrase"}:
             # This deliberately includes unknown prompts: the in-process helper
@@ -1439,22 +1458,34 @@ class InteractionBroker:
         raw_prompt: str,
         *,
         presence: bool,
+        confirmation: bool = False,
         helper_transport: Optional[socket.socket],
     ) -> Optional[bytearray]:
         with self._condition:
             context = self._askpass_contexts.get(token)
             if context is None or context.closed or self._closed:
                 return None
-            key = "presence" if presence else "interactive"
+            key = (
+                "presence"
+                if presence
+                else "confirmation"
+                if confirmation
+                else "interactive"
+            )
             attempt = context.attempts.get(key, 0) + 1
             context.attempts[key] = attempt
             interaction_type = (
-                InteractionType.SECURITY_KEY_PRESENCE
-                if presence else InteractionType.KEYBOARD_INTERACTIVE
+                InteractionType.SECURITY_KEY_PRESENCE if presence
+                else InteractionType.CONFIRMATION if confirmation
+                else InteractionType.KEYBOARD_INTERACTIVE
             )
             prompt: InteractionPrompt = (
                 PresencePrompt(text=raw_prompt.strip() or "Touch your security key")
                 if presence
+                else ConfirmationPrompt(
+                    text=raw_prompt.strip() or "Confirm SSH operation"
+                )
+                if confirmation
                 else ChallengePrompt(text=raw_prompt.strip() or "Authentication response", attempt=attempt)
             )
             session_id = context.session_id
@@ -1466,9 +1497,26 @@ class InteractionBroker:
             prompt=prompt,
             attempt=attempt,
         )
+        if presence:
+            # Presence is a passive notification.  OpenSSH ends its askpass
+            # helper when the hardware operation finishes; no answer frame is
+            # required (or meaningful).
+            self.wait_for_result(
+                interaction.id,
+                cancel_check=(
+                    None
+                    if helper_transport is None
+                    else lambda: self._transport_is_closed(helper_transport)
+                ),
+            )
+            return None
         result = self.wait_for_result(
             interaction.id,
-            cancel_check=(None if helper_transport is None else lambda: self._transport_is_closed(helper_transport)),
+            cancel_check=(
+                None
+                if helper_transport is None
+                else lambda: self._transport_is_closed(helper_transport)
+            ),
         )
         if result is None or result.decision is not SecretDecision.SUBMIT or result.secret is None:
             if result is not None:

--- a/src/sshpilot/daemon/server.py
+++ b/src/sshpilot/daemon/server.py
@@ -687,7 +687,9 @@ class DaemonServer:
                 connection_id=spec.connection_id,
                 session_id=spec.session_id,
             )
-        return broker.prepare_launch(spec, launch_builder, trailing_args=("sftp",))
+        return broker.prepare_launch(
+            spec, launch_builder, trailing_args=("sftp",), headless=True
+        )
 
     def _prepare_forward_launch(
         self,
@@ -723,7 +725,7 @@ class DaemonServer:
                 interaction_policy=interaction_policy,
             )
 
-        return broker.prepare_launch(spec, _wrapped_builder)
+        return broker.prepare_launch(spec, _wrapped_builder, headless=True)
 
     def _client_can_interact(self, session_id: SessionId, client_id: Any) -> bool:
         session_runtime = self._session_runtime

--- a/src/sshpilot/daemon_interaction_dialogs.py
+++ b/src/sshpilot/daemon_interaction_dialogs.py
@@ -9,6 +9,7 @@ from gi.repository import Adw, GLib, Gtk
 from .api.events import EventType
 from .api.models import (
     ChallengePrompt,
+    ConfirmationPrompt,
     HostKeyDecision,
     HostKeyPrompt,
     HostKeyStatus,
@@ -101,6 +102,7 @@ class DaemonInteractionDialogs:
             InteractionType.PRIVATE_KEY_PASSPHRASE,
             InteractionType.KEYBOARD_INTERACTIVE,
             InteractionType.SECURITY_KEY_PRESENCE,
+            InteractionType.CONFIRMATION,
         }:
             self._present_secret(summary, parent)
 
@@ -175,13 +177,31 @@ class DaemonInteractionDialogs:
             heading = "SSH authentication challenge"
         elif isinstance(prompt, PresencePrompt):
             heading = "Security key required"
+        elif isinstance(prompt, ConfirmationPrompt):
+            heading = "Confirm SSH operation"
         else:
             return
         dialog = Adw.AlertDialog(
             heading=heading,
-            body=(prompt.text if isinstance(prompt, (ChallengePrompt, PresencePrompt))
-                  else f"Authentication attempt {summary.attempt}"),
+            body=(
+                prompt.text
+                if isinstance(
+                    prompt, (ChallengePrompt, PresencePrompt, ConfirmationPrompt)
+                )
+                else f"Authentication attempt {summary.attempt}"
+            ),
         )
+        if isinstance(prompt, PresencePrompt):
+            dialog.add_response("close", "Close")
+            dialog.set_close_response("close")
+            dialog.connect(
+                "response",
+                lambda item, _response: self._presence_closed(summary, item),
+            )
+            self._dialogs[summary.id] = dialog
+            dialog.present(parent)
+            return
+
         content = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
             spacing=12,
@@ -191,13 +211,14 @@ class DaemonInteractionDialogs:
             margin_end=12,
         )
         entry = Gtk.PasswordEntry(show_peek_icon=True)
-        if isinstance(prompt, PresencePrompt):
-            entry.set_visible(False)
         entry.connect("activate", lambda _entry: dialog.response("submit"))
         content.append(entry)
         dialog.set_extra_child(content)
         dialog.add_response("cancel", "Cancel")
-        dialog.add_response("submit", "Continue")
+        dialog.add_response(
+            "submit",
+            "Yes" if isinstance(prompt, ConfirmationPrompt) else "Continue",
+        )
         dialog.set_response_appearance(
             "submit",
             Adw.ResponseAppearance.SUGGESTED,
@@ -215,6 +236,15 @@ class DaemonInteractionDialogs:
         )
         self._dialogs[summary.id] = dialog
         dialog.present(parent)
+
+    def _presence_closed(self, summary, dialog) -> None:
+        self._dialogs.pop(summary.id, None)
+        self._bridge.submit_interaction(
+            lambda: self._client.cancel_interaction(summary.id),
+            on_success=lambda _value: None,
+            on_error=lambda _error: None,
+        )
+        dialog.close()
 
     def _secret_response(
         self,
@@ -237,9 +267,8 @@ class DaemonInteractionDialogs:
             )
             dialog.close()
             return
-        secret = bytearray(
-            ("yes" if isinstance(summary.prompt, PresencePrompt) else entry.get_text()).encode("utf-8")
-        )
+        value = "yes" if isinstance(summary.prompt, ConfirmationPrompt) else entry.get_text()
+        secret = bytearray(value.encode("utf-8"))
         entry.set_text("")
         self._pending_secrets[summary.id] = secret
 

--- a/tests/api/snapshots/public_api.json
+++ b/tests/api/snapshots/public_api.json
@@ -14,7 +14,7 @@
     "Subscription",
     "TerminalSubscription"
   ],
-  "api_implementation_version": "0.12",
+  "api_implementation_version": "0.13",
   "capabilities": [
     "connections.config.read",
     "connections.config.write",
@@ -1444,6 +1444,7 @@
     "CloseSessionRequest",
     "CloseSftpRequest",
     "CompatibilityResult",
+    "ConfirmationPrompt",
     "ConnectionDetails",
     "ConnectionEditorCapabilities",
     "ConnectionEditorDetails",
@@ -1628,6 +1629,9 @@
       "compatible",
       "protocol_version",
       "message"
+    ],
+    "ConfirmationPrompt": [
+      "text"
     ],
     "ConnectionDetails": [
       "id",
@@ -2500,7 +2504,8 @@
       "password",
       "private_key_passphrase",
       "keyboard_interactive",
-      "security_key_presence"
+      "security_key_presence",
+      "confirmation"
     ],
     "RememberPolicy": [
       "do_not_store",

--- a/tests/api/test_phase8_interactions.py
+++ b/tests/api/test_phase8_interactions.py
@@ -111,14 +111,14 @@ def test_secret_binary_frame_round_trip_clear_and_multiplexing() -> None:
     assert decoded.secret == bytearray()
 
 
-def test_secret_frame_rejects_empty_nul_and_oversized_values() -> None:
+def test_secret_frame_allows_empty_but_rejects_nul_and_oversized_values() -> None:
     common = {
         "kind": SecretFrameKind.RESPONSE,
         "interaction_id": _interaction_id(),
         "nonce": bytes.fromhex("00112233445566778899aabbccddeeff"),
     }
-    with pytest.raises(ValueError):
-        SecretFrame(secret=bytearray(), **common)
+    empty = SecretFrame(secret=bytearray(), **common)
+    assert decode_secret_payload(encode_secret_payload(empty)).secret == bytearray()
     with pytest.raises(ValueError):
         SecretFrame(secret=bytearray(b"contains\0nul"), **common)
     with pytest.raises(ValueError):

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -261,12 +261,55 @@ def test_prepare_launch_leaves_askpass_disabled_without_saved_secret(
     assert "SSH_ASKPASS_REQUIRE" not in environment
 
 
+def test_headless_launch_preserves_normal_environment_and_replaces_askpass(
+    broker: InteractionBroker,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(broker, "_effective_ssh_config", lambda _argv: {})
+    policies = []
+
+    def builder(_connection_id, *, interaction_policy):
+        policies.append(interaction_policy)
+        return ("/usr/bin/ssh", "example"), {
+            "PATH": "/custom/bin",
+            "USER_DEFINED_AUTH": "preserved",
+            "SSH_ASKPASS": "/old/helper",
+            "SSH_ASKPASS_REQUIRE": "prefer",
+            "SSHPILOT_ASKPASS_SOCKET": "/old/socket",
+            "SSHPILOT_SESSION_PASSWORD": "staged-secret",
+        }
+
+    _argv, environment = broker.prepare_launch(
+        SessionLaunchSpec(
+            session_id=SESSION_ID,
+            connection_id=CONNECTION_ID,
+            protocol="ssh",
+            hostname="example.test",
+            username="alice",
+            port=22,
+        ),
+        builder,
+        headless=True,
+    )
+
+    assert policies == ["normal"]
+    assert environment["USER_DEFINED_AUTH"] == "preserved"
+    assert environment["SSH_ASKPASS_REQUIRE"] == "force"
+    assert environment["SSH_ASKPASS"] == str(broker._askpass_helper_path)
+    assert environment["SSHPILOT_DAEMON_ASKPASS_SOCKET"] == str(
+        broker._askpass_socket_path
+    )
+    assert "SSHPILOT_ASKPASS_SOCKET" not in environment
+    assert "SSHPILOT_SESSION_PASSWORD" not in environment
+
+
 @pytest.mark.parametrize(
     ("prompt", "expected_type"),
     [
         ("Enter verification code:", InteractionType.KEYBOARD_INTERACTIVE),
         ("Custom PAM response:", InteractionType.KEYBOARD_INTERACTIVE),
         ("Touch your security key", InteractionType.SECURITY_KEY_PRESENCE),
+        ("Allow signing?", InteractionType.CONFIRMATION),
     ],
 )
 def test_daemon_routes_interactive_and_presence_prompts(
@@ -292,7 +335,10 @@ def test_daemon_routes_interactive_and_presence_prompts(
     )
     token = environment["SSHPILOT_DAEMON_ASKPASS_TOKEN"]
     monkeypatch.setattr(broker, "wait_for_result", lambda *_a, **_k: None)
-    assert broker._resolve_askpass_secret(token, prompt) is None
+    hint = "none" if expected_type is InteractionType.SECURITY_KEY_PRESENCE else (
+        "confirm" if expected_type is InteractionType.CONFIRMATION else ""
+    )
+    assert broker._resolve_askpass_secret(token, prompt, hint=hint) is None
     assert broker.list(CLIENT_A)[-1].type is expected_type
 
 


### PR DESCRIPTION
### Motivation

- Ensure daemon-owned SSH children (terminal, SFTP, forwarding) use the same OpenSSH native resolver and environment as in-process launches while replacing only SSH Pilot's private askpass transport.
- Provide correct UX and protocol semantics for security-key presence, generic confirmations, keyboard-interactive (OTP/PIN/PAM) prompts, empty responses and multiline prompts.
- Keep the connection-save cancellation pipeline live through secure-storage work so dialogs closing mid-pipeline do not leave background work mutating UI state.

### Description

- Use the normal OpenSSH resolver for daemon launches by invoking the launch builder with `interaction_policy="normal"` and add a `headless: bool` flag to `prepare_launch` so headless launches (SFTP/forwards) can force daemon askpass while preserving arbitrary user environment values; remove only SSH Pilot private askpass/session variables before installing the helper. (files: `daemon/interaction_broker.py`, `daemon/server.py`)
- Force `SSH_ASKPASS_REQUIRE="force"` for headless child processes while using `prefer` for resolver-activated askpass, and install `SSHPILOT_DAEMON_ASKPASS_*` helper details when active. (files: `daemon/interaction_broker.py`, `daemon/server.py`, `daemon/askpass_helper.py`)
- Add a typed generic confirmation interaction (`ConfirmationPrompt` / `InteractionType.CONFIRMATION`) and classify `SSH_ASKPASS_PROMPT=confirm` explicitly, and make security-key presence a passive notification lifecycle that does not require a secret answer. (files: `api/models/interactions.py`, `daemon/interaction_broker.py`, `daemon_interaction_dialogs.py`, `api/transport/codec.py`)
- Allow multiline keyboard-interactive prompts and reject unsafe control characters while keeping existing length and NUL checks. (file: `api/models/interactions.py`)
- Allow submitted empty keyboard-interactive secret payloads through the secret frame transport and helpers by: permitting zero-length `SecretFrame.secret` (but still rejecting NUL and oversized payloads) and relaxing header-length checks during decode. (file: `api/transport/secret_frames.py`)
- Keep a pipeline-level `SaveRequest` token active across config mutation → metadata mutation → secret storage → final UI completion, and have final GTK callbacks respect pipeline cancellation so the dialog may close cleanly while background secret I/O runs. (file: `connection_dialog.py`)
- Bump API implementation version to `0.13` and regenerate API artifacts and public API snapshots to reflect the expanded interaction models. (files: `api/version.py`, docs and generated artifacts)
- Updated unit tests and added coverage for headless environment/askpass preservation, confirmation routing, empty secret roundtrip and related behaviors. (tests modified/added under `tests/daemon` and `tests/api`)

### Testing

- Built byte-compiled sources with `python -m compileall -q src tests` and regenerated API artifacts with `python scripts/generate_api_artifacts.py --check` (both succeeded).
- Ran focused unit test suites: `pytest -q tests/api/test_phase8_interactions.py tests/daemon/test_interaction_broker.py tests/daemon/test_interaction_openssh.py tests/api/test_daemon_client_protocol.py` and `pytest -q tests/api/test_public_api_snapshot.py tests/api/test_api_documentation.py` (passed).
- Ran the full test run in the CI-like environment: `pytest -q` produced a large green result set (most tests passed), with a small set of environment-dependent/integration failures unrelated to the functional changes (no container runtime available, a polluted Paramiko stub during the test run, and a few daemon process/timing integration flakes); these failures are environmental and not regressions in the new askpass parity logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7029dd3acc83289efee3d9a7c70bf0)