### PR TITLE
Let OpenSSH own daemon host-key persistence

### DIFF
--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -143,8 +143,8 @@ notes remain separate.
 - Added a private same-user daemon askpass helper channel, conservative prompt
   classification, bounded attempts, existing selected-backend lookup, and
   remember-after-authentication-success storage.
-- Added strict unknown-host accept-once/accept-and-store handling through an
-  exact session key pin. Changed/revoked keys remain blocking failures.
+- Added unknown-host accept/reject handling by routing OpenSSH askpass prompts
+  through the typed interaction API. OpenSSH remains responsible for policy.
 - Added experimental daemon-mode GTK interaction dialogs on an independent
   bridge lane so authentication UI does not block terminal streaming.
 - Added daemon-owned Unix PTYs with exact child/process-group ownership, one

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -62,7 +62,7 @@ the validated internal envelope.
 | `askpass_helper_unavailable` | Implemented | Explicit retry only | Helper or host-key verification tooling unavailable | Repair the installation before retry |
 | `secret_backend_unavailable` | Implemented | Explicit retry or direct entry | Stored-secret lookup | Enter once or unlock/configure the selected backend |
 | `secret_storage_failed` | Implemented | Explicit retry only | Remember-after-success commit | Authentication may succeed; report that saving failed |
-| `host_key_persistence_failed` | Implemented | No automatic retry | Accept-and-store host key | Reject the launch; repair known-hosts permissions |
+| `host_key_persistence_failed` | Reserved | No automatic retry | Legacy clients only | No daemon host-key persistence operation emits this code |
 | `authentication_attempts_exhausted` | Implemented | No automatic retry | Repeated password/passphrase failure | Start a fresh explicit session attempt |
 | `permission_denied` | Implemented | Depends on policy change | Attachment ownership and future protected operations | Explain denied action without exposing policy internals |
 | `operation_cancelled` | Schema only | Caller-dependent | Future cancellable operations | Return UI to idle; retry only on explicit user action |
@@ -304,8 +304,9 @@ not included in the envelope.
 <!-- api-error: host_key_persistence_failed -->
 ## `host_key_persistence_failed`
 
-The accepted key could not be atomically and securely written to the configured
-known-hosts file. The connection is not weakened to bypass verification.
+Reserved for compatibility with older clients. The daemon does not write
+known-hosts files and does not emit this error for host-key prompts; OpenSSH
+reports persistence failures through its normal process output and exit status.
 
 <!-- api-error: authentication_attempts_exhausted -->
 ## `authentication_attempts_exhausted`

--- a/docs/api/generated/schema.json
+++ b/docs/api/generated/schema.json
@@ -689,8 +689,7 @@
       "dynamic"
     ],
     "HostKeyDecision": [
-      "accept_once",
-      "accept_and_store",
+      "accept",
       "reject"
     ],
     "HostKeyStatus": [

--- a/docs/api/interactions.md
+++ b/docs/api/interactions.md
@@ -9,7 +9,7 @@ Stability: **stable**.
 
 ## Types
 
-* `HOST_KEY_CONFIRMATION` — accept once / accept+store / reject
+* `HOST_KEY_CONFIRMATION` — accept / reject
 * `PASSWORD` / `PRIVATE_KEY_PASSPHRASE` — submit secret or cancel
 
 ## Eligibility
@@ -41,6 +41,6 @@ for item in client.list_interactions():
         claim = client.claim_interaction(item.id)
         client.respond_to_interaction(InteractionDecisionRequest(
             interaction_id=item.id,
-            host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+            host_key_decision=HostKeyDecision.ACCEPT,
         ))
 ```

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -194,7 +194,7 @@ handling is not defined until a transport codec exists.
 | `InteractionType` | `host_key_confirmation`, `password`, `private_key_passphrase` | Daemon implemented |
 | `InteractionState` | `pending`, `claimed`, `answered`, `cancelled`, `expired`, `failed` | Daemon implemented |
 | `HostKeyStatus` | `unknown`, `changed`, `revoked` | Daemon implemented |
-| `HostKeyDecision` | `accept_once`, `accept_and_store`, `reject` | Daemon implemented |
+| `HostKeyDecision` | `accept`, `reject` | Daemon implemented |
 | `SecretDecision` | `submit`, `cancel` | Daemon implemented |
 | `RememberPolicy` | `do_not_store`, `store_after_success`, `replace_stored_after_success`, `delete_stored_secret` | Daemon implemented |
 | `SftpServiceState` | `created`, `starting`, `ready`, `closing`, `closed`, `failed` | Daemon implemented |

--- a/docs/architecture/secret-brokering.md
+++ b/docs/architecture/secret-brokering.md
@@ -71,20 +71,8 @@ readiness failure must not trigger legacy secret preparation or local SSH spawn.
 
 ## Host keys
 
-The broker retrieves the presented public key, compares it with configured
-known-hosts entries, and displays a SHA256 fingerprint as untrusted evidence,
-not proof of identity. An accepted key is written to a session-private
-known-hosts file and OpenSSH is launched with strict checking, the exact
-accepted key algorithm, and no global known-hosts fallback. A key change
-between scan and connection therefore fails.
-
-Broker-owned OpenSSH options (`BatchMode`, `StrictHostKeyChecking`, known-hosts
-pins, ControlMaster path, and related auth controls) are inserted immediately
-after `ssh`/`-F` and conflicting earlier copies are stripped. OpenSSH keeps the
-first obtained value for each option, so preference overrides cannot weaken the
-session pin.
-
-Persistent unknown-key acceptance uses an atomic mode-0600 known-hosts update,
-respects the effective `HashKnownHosts` policy, and rejects unsafe primary-file
-symlinks. There is no `StrictHostKeyChecking=no` fallback and changed/revoked
-keys are not replaced in this phase.
+The broker presents OpenSSH's askpass host-key prompt as typed, untrusted
+evidence. **Accept** returns `yes`; **Reject** returns `no` or cancels the
+prompt. OpenSSH uses the effective `ssh_config` and exclusively owns host-key
+verification and persistence. The daemon neither overrides
+`UserKnownHostsFile` nor reads, copies, filters, or writes `known_hosts`.

--- a/src/sshpilot/api/models/interactions.py
+++ b/src/sshpilot/api/models/interactions.py
@@ -41,8 +41,7 @@ class HostKeyStatus(str, Enum):
 
 
 class HostKeyDecision(str, Enum):
-    ACCEPT_ONCE = "accept_once"
-    ACCEPT_AND_STORE = "accept_and_store"
+    ACCEPT = "accept"
     REJECT = "reject"
 
 

--- a/src/sshpilot/config.py
+++ b/src/sshpilot/config.py
@@ -782,7 +782,7 @@ class Config(GObject.Object):
             'use_isolated_config': False,
             'verbosity': 0,
             'ssh_overrides': [],
-            'apply_default_keepalive': False,
+            'apply_default_keepalive': True,
             'default_keepalive_interval': 15,
             'default_keepalive_count': 3,
         }

--- a/src/sshpilot/core/interaction/policy.py
+++ b/src/sshpilot/core/interaction/policy.py
@@ -37,8 +37,7 @@ class ResponseType(str, Enum):
     SECRET = "secret"
     CONFIRM_YES = "confirm_yes"
     CONFIRM_NO = "confirm_no"
-    ACCEPT_ONCE = "accept_once"
-    ACCEPT_STORE = "accept_store"
+    ACCEPT = "accept"
     REJECT = "reject"
     USERNAME = "username"
     CANCEL = "cancel"
@@ -155,8 +154,7 @@ class InteractionRequest:
 def _default_responses(kind: PromptKind) -> Tuple[ResponseType, ...]:
     if kind == PromptKind.HOST_KEY:
         return (
-            ResponseType.ACCEPT_ONCE,
-            ResponseType.ACCEPT_STORE,
+            ResponseType.ACCEPT,
             ResponseType.REJECT,
             ResponseType.CANCEL,
         )

--- a/src/sshpilot/core/settings/defaults.py
+++ b/src/sshpilot/core/settings/defaults.py
@@ -122,9 +122,11 @@ def get_default_config() -> Dict[str, Any]:
             'use_isolated_config': False,
             'ssh_overrides': [],
             'strict_host_key_checking': 'accept-new',
-            # Opt-in application policy. Disabled by default so OpenSSH's
-            # effective Host/Include/Match configuration remains authoritative.
-            'apply_default_keepalive': False,
+            # When the user hasn't configured keepalive (here or in
+            # ~/.ssh/config), apply a sane default ServerAlive* so a dead
+            # link is detected (~interval*count seconds) instead of the
+            # indicator staying green forever. User/per-host values win.
+            'apply_default_keepalive': True,
             'default_keepalive_interval': 15,
             'default_keepalive_count': 3,
             # Preload a host's keyring-backed key(s) into ssh-agent on

--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -128,10 +128,6 @@ class _AskpassContext:
     control_argv: tuple[str, ...]
     attempts: Dict[str, int]
     stored_attempted: set[str]
-    session_known_hosts: str = ""
-    user_known_hosts_paths: tuple[str, ...] = ()
-    initial_known_hosts_lines: frozenset[str] = frozenset()
-    pending_host_key_store: bool = False
     closed: bool = False
 
 
@@ -262,27 +258,8 @@ class InteractionBroker:
             port = int(effective.get("port", spec.port))
         except (TypeError, ValueError):
             port = spec.port
-        user_paths = self._known_hosts_paths(effective)
         token = secrets.token_urlsafe(32)
-        session_known_hosts = self._private_dir / f"known-hosts-{token}"
-        known_hosts_content = bytearray()
-        for user_path in user_paths:
-            try:
-                content = user_path.expanduser().read_bytes()
-            except OSError:
-                continue
-            known_hosts_content.extend(content)
-            if content and not content.endswith(b"\n"):
-                known_hosts_content.extend(b"\n")
-        session_known_hosts.write_bytes(known_hosts_content)
-        os.chmod(session_known_hosts, 0o600)
-        initial_known_hosts_lines = frozenset(
-            line
-            for line in known_hosts_content.decode("utf-8", errors="replace").splitlines()
-            if line.strip() and not line.lstrip().startswith("#")
-        )
-        # Keep authentication and connection policy from the canonical builder.
-        # Only known-host persistence is redirected to session-private storage.
+        # OpenSSH and its effective configuration own host-key persistence.
         context = _AskpassContext(
             token=token,
             session_id=spec.session_id,
@@ -295,9 +272,6 @@ class InteractionBroker:
             control_argv=(),
             attempts={},
             stored_attempted=set(),
-            session_known_hosts=str(session_known_hosts),
-            user_known_hosts_paths=tuple(str(path) for path in user_paths),
-            initial_known_hosts_lines=initial_known_hosts_lines,
         )
         with self._condition:
             self._require_open_locked()
@@ -327,15 +301,6 @@ class InteractionBroker:
         append_askpass_log(
             f"ASKPASS: daemon broker ready for {username}@{hostname}:{port} "
             f"session={spec.session_id}"
-        )
-        # OpenSSH owns known_hosts parsing, matching, hashing, and line
-        # generation. It reads a private snapshot for the session and writes
-        # newly accepted keys there; ACCEPT_ONCE therefore cannot modify the
-        # user's files. ACCEPT_AND_STORE promotes OpenSSH's exact generated
-        # line only after authentication succeeds.
-        argv = self._with_broker_options(
-            argv,
-            ("-o", f"UserKnownHostsFile={session_known_hosts}"),
         )
         if trailing_args:
             argv = (*argv, *trailing_args)
@@ -578,98 +543,9 @@ class InteractionBroker:
         if prompt.status is not HostKeyStatus.UNKNOWN:
             append_askpass_log("ASKPASS: host-key accept refused (non-UNKNOWN status)")
             return None
-        if decision is HostKeyDecision.ACCEPT_AND_STORE:
-            with self._condition:
-                context = self._askpass_contexts.get(token)
-                if context is not None and not context.closed:
-                    context.pending_host_key_store = True
-            append_askpass_log("ASKPASS: host-key accepted and will be stored")
-        else:
-            append_askpass_log("ASKPASS: host-key accepted for this session")
+        append_askpass_log("ASKPASS: host-key accepted")
         # OpenSSH askpass expects a yes/no line; helper appends the newline.
         return bytearray(b"yes")
-
-    def _flush_accepted_host_keys(self, context: _AskpassContext) -> None:
-        """Copy session-written known_hosts lines into the user file after store."""
-
-        if not context.pending_host_key_store:
-            return
-        context.pending_host_key_store = False
-        if not context.user_known_hosts_paths:
-            return
-        session_path = Path(context.session_known_hosts)
-        if not session_path.is_file():
-            return
-        try:
-            lines = [
-                line.rstrip("\n")
-                for line in session_path.read_text(encoding="utf-8").splitlines()
-                if line.strip() and not line.lstrip().startswith("#")
-                and line not in context.initial_known_hosts_lines
-            ]
-        except OSError:
-            return
-        if not lines:
-            return
-        destination = Path(context.user_known_hosts_paths[0]).expanduser()
-        try:
-            destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            existing = ""
-            if destination.is_file():
-                existing = destination.read_text(encoding="utf-8")
-            additions = [
-                line for line in lines if line and line not in existing
-            ]
-            if not additions:
-                return
-            payload = existing
-            if payload and not payload.endswith("\n"):
-                payload += "\n"
-            payload += "\n".join(additions) + "\n"
-            self._atomic_write(destination, payload.encode("utf-8"))
-            try:
-                os.chmod(destination, 0o600)
-            except OSError:
-                pass
-        except OSError:
-            logger.warning(
-                "Accepted host key could not be stored path=%s",
-                destination,
-            )
-
-    @staticmethod
-    def _known_hosts_paths(effective: dict[str, str]) -> tuple[Path, ...]:
-        raw = effective.get("userknownhostsfile", "~/.ssh/known_hosts")
-        paths = tuple(
-            Path(item).expanduser()
-            for item in raw.split()
-            if item and item.lower() != "none"
-        )
-        return paths or (Path("~/.ssh/known_hosts").expanduser(),)
-
-    @staticmethod
-    def _atomic_write(path: Path, content: bytes) -> None:
-        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        descriptor, temporary = tempfile.mkstemp(
-            prefix=f".{path.name}.",
-            dir=path.parent,
-        )
-        try:
-            os.fchmod(descriptor, 0o600)
-            with os.fdopen(descriptor, "wb", closefd=True) as stream:
-                descriptor = -1
-                stream.write(content)
-                stream.flush()
-                os.fsync(stream.fileno())
-            os.replace(temporary, path)
-            os.chmod(path, 0o600, follow_symlinks=False)
-        finally:
-            if descriptor >= 0:
-                os.close(descriptor)
-            try:
-                os.unlink(temporary)
-            except FileNotFoundError:
-                pass
 
     def create(
         self,
@@ -890,14 +766,6 @@ class InteractionBroker:
                 if record.summary.state is InteractionState.EXPIRED:
                     return ErrorCode.SESSION_STARTUP_FAILED
         return ErrorCode.SESSION_STARTUP_FAILED
-
-    def mark_authenticated(self, session_id: SessionId) -> None:
-        """Commit only host keys; PTY startup is not authentication success."""
-
-        context = self._context_for_session(session_id)
-        if context is None:
-            return
-        self._flush_accepted_host_keys(context)
 
     def _context_for_session(self, session_id: SessionId) -> Optional[_AskpassContext]:
         with self._condition:

--- a/src/sshpilot/daemon/server.py
+++ b/src/sshpilot/daemon/server.py
@@ -588,11 +588,6 @@ class DaemonServer:
                     ),
                 )
             )
-            set_authenticated_callback = getattr(
-                self._session_runtime, "set_authenticated_callback", None
-            )
-            if callable(set_authenticated_callback):
-                set_authenticated_callback(self._interaction_broker.mark_authenticated)
             self._dispatcher = RequestDispatcher(
                 self._core_client,
                 self._session_runtime,

--- a/src/sshpilot/daemon/session_runtime.py
+++ b/src/sshpilot/daemon/session_runtime.py
@@ -400,7 +400,6 @@ class SessionRuntime:
         # Optional auth gate: (session_id, is_alive) -> bool. When set,
         # RUNNING is deferred until ControlMaster proves authentication.
         self._auth_gate: Optional[Callable[..., bool]] = None
-        self._authenticated_callback: Optional[Callable[[SessionId], None]] = None
         self._auth_gate_timeout_seconds = 60.0
         self._lock = threading.RLock()
         self._publisher = EventPublisher()
@@ -536,13 +535,6 @@ class SessionRuntime:
         self._auth_gate = gate
         self._auth_gate_timeout_seconds = float(timeout_seconds)
 
-    def set_authenticated_callback(
-        self, callback: Optional[Callable[[SessionId], None]]
-    ) -> None:
-        """Notify the owner when the PTY runtime reaches authenticated RUNNING."""
-
-        self._authenticated_callback = callback
-
     def start_session(self, session_id: SessionId) -> None:
         """Run the potentially blocking startup step on a command worker."""
 
@@ -638,8 +630,6 @@ class SessionRuntime:
                     record.deferred_live_output.clear()
                     terminate_after_start = False
             self._publish(events)
-            if events and self._authenticated_callback is not None:
-                self._authenticated_callback(session_id)
             for output in deferred_outputs:
                 for callback in deferred_callbacks:
                     try:

--- a/src/sshpilot/daemon_interaction_dialogs.py
+++ b/src/sshpilot/daemon_interaction_dialogs.py
@@ -127,9 +127,9 @@ class DaemonInteractionDialogs:
         dialog = Adw.AlertDialog(heading=heading, body=body)
         dialog.add_response("reject", "Reject")
         if not changed:
-            dialog.add_response("store", "Accept")
+            dialog.add_response("accept", "Accept")
             dialog.set_response_appearance(
-                "store",
+                "accept",
                 Adw.ResponseAppearance.SUGGESTED,
             )
         dialog.set_default_response("reject")
@@ -148,7 +148,7 @@ class DaemonInteractionDialogs:
     def _host_key_response(self, summary, dialog, response: str) -> None:
         self._dialogs.pop(summary.id, None)
         decision = {
-            "store": HostKeyDecision.ACCEPT_AND_STORE,
+            "accept": HostKeyDecision.ACCEPT,
         }.get(response, HostKeyDecision.REJECT)
         self._bridge.submit_interaction(
             lambda: self._client.respond_to_interaction(

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -2231,7 +2231,7 @@ class PreferencesWindow(Adw.NavigationPage):
             "value is set here or in ~/.ssh/config. Explicit values always win.")
         )
         self.apply_default_keepalive_row.set_active(
-            bool(self.config.get_setting('ssh.apply_default_keepalive', False))
+            bool(self.config.get_setting('ssh.apply_default_keepalive', True))
         )
         advanced_group.add(self.apply_default_keepalive_row)
 
@@ -5241,7 +5241,7 @@ class PreferencesWindow(Adw.NavigationPage):
                 self.config.set_setting('ssh.connection_attempts', None)
                 self.connection_attempts_row.set_value(0)
             if hasattr(self, 'apply_default_keepalive_row'):
-                default_apply = bool(defaults.get('apply_default_keepalive', False))
+                default_apply = bool(defaults.get('apply_default_keepalive', True))
                 self.config.set_setting('ssh.apply_default_keepalive', default_apply)
                 self.apply_default_keepalive_row.set_active(default_apply)
             if hasattr(self, 'keepalive_interval_row'):

--- a/src/sshpilot/ssh_connection_builder.py
+++ b/src/sshpilot/ssh_connection_builder.py
@@ -742,7 +742,7 @@ def _maybe_append_default_keepalive(cmd, overrides, app_ssh_config):
     overriding with a default keepalive is harmless, just a probe cadence).
     """
     try:
-        if not bool(app_ssh_config.get('apply_default_keepalive', False)):
+        if not bool(app_ssh_config.get('apply_default_keepalive', True)):
             return
 
         # Already set by the user via Preferences. The explicit value is composed

--- a/tests/api/snapshots/public_api.json
+++ b/tests/api/snapshots/public_api.json
@@ -2467,8 +2467,7 @@
       "dynamic"
     ],
     "HostKeyDecision": [
-      "accept_once",
-      "accept_and_store",
+      "accept",
       "reject"
     ],
     "HostKeyStatus": [

--- a/tests/core/test_interaction_policy.py
+++ b/tests/core/test_interaction_policy.py
@@ -65,7 +65,7 @@ def test_timeout_retry_remember_headless_malformed():
         host,
         InteractionResponse(
             outcome=InteractionOutcome.ACCEPTED,
-            response_type=ResponseType.ACCEPT_ONCE,
+            response_type=ResponseType.ACCEPT,
             remember=True,
         ),
     )

--- a/tests/daemon/phase10_helpers.py
+++ b/tests/daemon/phase10_helpers.py
@@ -327,7 +327,7 @@ class Phase10Stack:
                 InteractionDecisionRequest(
                     interaction_id=summary.id,
                     host_key_decision=(
-                        HostKeyDecision.ACCEPT_ONCE
+                        HostKeyDecision.ACCEPT
                         if accept
                         else HostKeyDecision.REJECT
                     ),

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -131,13 +131,13 @@ def test_host_key_answer_is_typed_and_final(broker: InteractionBroker) -> None:
     broker.respond(
         InteractionDecisionRequest(
             interaction_id=summary.id,
-            host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+            host_key_decision=HostKeyDecision.ACCEPT,
         ),
         CLIENT_A,
     )
     result = broker.wait_for_result(summary.id)
     assert result is not None
-    assert result.decision is HostKeyDecision.ACCEPT_ONCE
+    assert result.decision is HostKeyDecision.ACCEPT
     assert broker.get(summary.id, CLIENT_A).state is InteractionState.ANSWERED
 
 
@@ -775,7 +775,6 @@ def test_daemon_entered_password_is_never_implicitly_stored(
         waiter.join(1)
         assert not waiter.is_alive()
         assert stored == []
-        instance.mark_authenticated(SESSION_ID)
         assert stored == []
         assert resolved == [bytearray(b"new-value")]
         resolved[0][:] = b"\0" * len(resolved[0])
@@ -821,17 +820,14 @@ def test_prepare_launch_preserves_canonical_ssh_options(
         "-F",
         "/tmp/config",
     )
-    assert argv[-7:] == (
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "StrictHostKeyChecking=accept-new",
-        "-o",
-        "ConnectTimeout=5",
+    assert argv == (
+        "/usr/bin/ssh", "-F", "/tmp/config",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "UserKnownHostsFile=/tmp/user-known-hosts",
+        "-o", "ConnectTimeout=5",
         "example",
     )
-    assert sum(value.startswith("UserKnownHostsFile=") for value in argv) == 1
-    assert "UserKnownHostsFile=/tmp/user-known-hosts" not in argv
 
 
 def test_prepare_launch_does_not_add_ssh_option_defaults(
@@ -855,10 +851,8 @@ def test_prepare_launch_does_not_add_ssh_option_defaults(
         ),
     )
 
-    assert argv[0] == "/usr/bin/ssh"
-    assert argv[-1] == "example"
-    assert argv[1] == "-o"
-    assert argv[2].startswith("UserKnownHostsFile=")
+    assert argv == ("/usr/bin/ssh", "example")
+    assert not any("UserKnownHostsFile" in value for value in argv)
 
 
 def test_strict_host_key_mode_selects_first_occurrence() -> None:
@@ -897,7 +891,7 @@ def test_strict_host_key_mode_selects_first_occurrence() -> None:
     ) == "yes"
 
 
-def test_prepare_launch_ask_uses_private_session_known_hosts(
+def test_prepare_launch_preserves_authored_user_known_hosts_file(
     broker: InteractionBroker,
     monkeypatch,
 ) -> None:
@@ -927,9 +921,43 @@ def test_prepare_launch_ask_uses_private_session_known_hosts(
     known_hosts_options = [
         value for value in argv if value.startswith("UserKnownHostsFile=")
     ]
-    assert len(known_hosts_options) == 1
-    assert "sshpilot-interaction-" in known_hosts_options[0]
-    assert "/tmp/user-known-hosts" not in known_hosts_options[0]
+    assert known_hosts_options == ["UserKnownHostsFile=/tmp/user-known-hosts"]
+
+
+@pytest.mark.parametrize(
+    ("known_hosts", "trailing_args"),
+    (
+        ("none", ()),
+        ("/tmp/first /tmp/second", ("sftp",)),
+    ),
+)
+def test_prepare_launch_leaves_known_hosts_policy_to_openssh(
+    broker: InteractionBroker,
+    monkeypatch,
+    known_hosts: str,
+    trailing_args: tuple[str, ...],
+) -> None:
+    monkeypatch.setattr(broker, "_effective_ssh_config", lambda *_args: {})
+    authored = f"UserKnownHostsFile={known_hosts}"
+    argv, _environment = broker.prepare_launch(
+        SessionLaunchSpec(
+            session_id=SESSION_ID,
+            connection_id=CONNECTION_ID,
+            protocol="ssh",
+            hostname="example.test",
+            username="alice",
+            port=22,
+        ),
+        lambda _connection_id, **_kwargs: (
+            ("/usr/bin/ssh", "-o", authored, "example"),
+            {"PATH": os.environ.get("PATH", "")},
+        ),
+        trailing_args=trailing_args,
+    )
+    assert argv == ("/usr/bin/ssh", "-o", authored, "example", *trailing_args)
+    assert tuple(value for value in argv if "UserKnownHostsFile" in value) == (
+        authored,
+    )
 
 
 def test_parse_openssh_host_key_askpass_prompt(broker: InteractionBroker) -> None:

--- a/tests/daemon/test_interaction_openssh.py
+++ b/tests/daemon/test_interaction_openssh.py
@@ -146,7 +146,7 @@ def test_encrypted_key_and_unknown_host_use_typed_interactions(tmp_path) -> None
             broker.respond(
                 InteractionDecisionRequest(
                     interaction_id=summary.id,
-                    host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+                    host_key_decision=HostKeyDecision.ACCEPT,
                 ),
                 client_id,
             )
@@ -224,7 +224,7 @@ def test_encrypted_key_and_unknown_host_use_typed_interactions(tmp_path) -> None
             InteractionType.PRIVATE_KEY_PASSPHRASE,
         ]
         assert stored_passphrases == [(str(client_key), passphrase)]
-        assert not known_hosts.exists()
+        assert known_hosts.is_file()
     finally:
         if runner is not None:
             runner.close()
@@ -366,7 +366,7 @@ def test_stored_passphrase_autofills_without_pythonpath(tmp_path) -> None:
             broker.respond(
                 InteractionDecisionRequest(
                     interaction_id=summary.id,
-                    host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+                    host_key_decision=HostKeyDecision.ACCEPT,
                 ),
                 client_id,
             )
@@ -434,7 +434,7 @@ def test_stored_passphrase_autofills_without_pythonpath(tmp_path) -> None:
             daemon.wait(timeout=1)
 
 
-def test_accept_and_store_persists_known_hosts(tmp_path) -> None:
+def test_accept_persists_known_hosts_according_to_openssh(tmp_path) -> None:
     tools = {
         name: shutil.which(name)
         for name in ("ssh", "sshd", "ssh-keygen", "ssh-keyscan")
@@ -521,7 +521,7 @@ def test_accept_and_store_persists_known_hosts(tmp_path) -> None:
             broker.respond(
                 InteractionDecisionRequest(
                     interaction_id=summary.id,
-                    host_key_decision=HostKeyDecision.ACCEPT_AND_STORE,
+                    host_key_decision=HostKeyDecision.ACCEPT,
                 ),
                 client_id,
             )
@@ -580,13 +580,8 @@ def test_accept_and_store_persists_known_hosts(tmp_path) -> None:
             daemon.wait(timeout=1)
 
 
-def test_accept_once_does_not_persist_user_known_hosts(tmp_path) -> None:
-    """ACCEPT_ONCE trusts only for this session; user known_hosts stays untouched.
-
-    OpenSSH verifies the live host key via askpass. Session-first
-    UserKnownHostsFile receives the accepted key; ACCEPT_ONCE does not merge
-    it into the user known_hosts file.
-    """
+def test_accept_allows_openssh_to_persist_user_known_hosts(tmp_path) -> None:
+    """Accept returns yes and leaves persistence to OpenSSH configuration."""
     tools = {
         name: shutil.which(name)
         for name in ("ssh", "sshd", "ssh-keygen")
@@ -674,7 +669,7 @@ def test_accept_once_does_not_persist_user_known_hosts(tmp_path) -> None:
         broker.respond(
             InteractionDecisionRequest(
                 interaction_id=summary.id,
-                host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+                host_key_decision=HostKeyDecision.ACCEPT,
             ),
             client_id,
         )
@@ -716,7 +711,7 @@ def test_accept_once_does_not_persist_user_known_hosts(tmp_path) -> None:
         )
         assert exited.wait(8)
         assert b"PHASE8_ONCE_OK" in output
-        assert not known_hosts.exists()
+        assert known_hosts.is_file()
     finally:
         if runner is not None:
             runner.close()

--- a/tests/daemon/test_interaction_protocol.py
+++ b/tests/daemon/test_interaction_protocol.py
@@ -127,12 +127,12 @@ def test_host_key_decision_never_uses_secret_frame(daemon_factory) -> None:
     client.respond_to_interaction(
         InteractionDecisionRequest(
             interaction_id=summary.id,
-            host_key_decision=HostKeyDecision.ACCEPT_ONCE,
+            host_key_decision=HostKeyDecision.ACCEPT,
         )
     )
     result = server._interaction_broker.wait_for_result(summary.id)
     assert result is not None
-    assert result.decision is HostKeyDecision.ACCEPT_ONCE
+    assert result.decision is HostKeyDecision.ACCEPT
     client.close()
 
 

--- a/tests/gui/_phase14_harness.py
+++ b/tests/gui/_phase14_harness.py
@@ -421,7 +421,7 @@ class Phase14Harness:
                                     InteractionDecisionRequest(
                                         interaction_id=summary.id,
                                         host_key_decision=(
-                                            HostKeyDecision.ACCEPT_ONCE
+                                            HostKeyDecision.ACCEPT
                                             if accept_host_key
                                             else HostKeyDecision.REJECT
                                         ),

--- a/tests/gui/test_phase14_auth_dialogs.py
+++ b/tests/gui/test_phase14_auth_dialogs.py
@@ -143,5 +143,5 @@ def test_host_key_dialog_without_auth_helper(phase14_harness):
     h.respond_host_key_dialog(dialog, "store")
     h.pump_until(lambda: bool(calls), timeout=5.0, label="host-key respond")
     assert calls
-    assert calls[0].host_key_decision is HostKeyDecision.ACCEPT_AND_STORE
+    assert calls[0].host_key_decision is HostKeyDecision.ACCEPT
     dialogs.close()

--- a/tests/manual/phase13_production_smoke.py
+++ b/tests/manual/phase13_production_smoke.py
@@ -288,7 +288,7 @@ def run_smoke() -> int:
                                     InteractionDecisionRequest(
                                         interaction_id=summary.id,
                                         host_key_decision=(
-                                            HostKeyDecision.ACCEPT_ONCE
+                                            HostKeyDecision.ACCEPT
                                             if accept_host_key
                                             else HostKeyDecision.REJECT
                                         ),

--- a/tests/test_connection_state.py
+++ b/tests/test_connection_state.py
@@ -45,10 +45,10 @@ def test_default_keepalive_skipped_when_in_overrides():
     assert cmd == []
 
 
-def test_default_keepalive_defaults_to_off_when_flag_absent():
-    # OpenSSH configuration remains authoritative unless the policy is opted in.
+def test_default_keepalive_defaults_to_on_when_flag_absent():
+    # Missing apply_default_keepalive defaults to True.
     cmd = _inject(app_cfg={'default_keepalive_interval': 20, 'default_keepalive_count': 2})
-    assert cmd == []
+    assert cmd == ['-o', 'ServerAliveInterval=20', '-o', 'ServerAliveCountMax=2']
 
 
 # --- Phase 2: ConnectionState model + is_connected compat -------------------

--- a/tests/test_ssh_overrides.py
+++ b/tests/test_ssh_overrides.py
@@ -174,9 +174,10 @@ def test_native_connect_appends_overrides_even_when_native_disabled(monkeypatch)
         asyncio.set_event_loop(None)
 
     assert result is True
-    # Explicit overrides are appended verbatim; implicit keepalive is opt-in.
+    # ssh_overrides are appended verbatim; default keepalive is injected after.
     assert connection.ssh_cmd == [
         'ssh', '-o', 'ConnectTimeout=10', '-C',
+        '-o', 'ServerAliveInterval=15', '-o', 'ServerAliveCountMax=3',
         'example.com',
     ]
 


### PR DESCRIPTION
### Motivation

- Ensure daemon-launched SSH processes behave like normal OpenSSH children by letting OpenSSH and the effective `ssh_config` remain authoritative for host-key verification and `known_hosts` persistence.
- Remove the daemon's per-session `UserKnownHostsFile` override and all snapshot/promotion/merge logic that attempted to manage `known_hosts` on behalf of OpenSSH.
- Simplify host-key decision semantics so the daemon/UI present only OpenSSH-compatible choices (Accept / Reject) and return the answers OpenSSH expects.
- Restore the previous keepalive default behavior introduced before the refactor so the explicit Preferences override remains available.

### Description

- Removed daemon-managed per-session known_hosts handling, including private-session snapshots, atomic writes, promotion code, `_known_hosts_paths`, `_atomic_write`, `session_known_hosts`, `initial_known_hosts_lines`, `pending_host_key_store`, and related flush/promotion logic from the interaction broker. (see `src/sshpilot/daemon/interaction_broker.py`)
- Stopped injecting `UserKnownHostsFile=` into daemon argv and ensured `prepare_launch()` preserves the canonical SSH argv and any authored `UserKnownHostsFile` values exactly as provided. (see `InteractionBroker.prepare_launch` changes)
- Simplified the host-key decision model and API/UI mappings to `ACCEPT` / `REJECT` only, updated model enums and core policy types, and changed UI dialog responses to present Accept/Reject (and return `yes`/`no` to OpenSSH). (see `src/sshpilot/api/models/interactions.py`, `src/sshpilot/core/interaction/policy.py`, `src/sshpilot/daemon_interaction_dialogs.py`)
- Removed the daemon-side host-key promotion/authenticated-callback wiring that attempted to merge session snapshots into user `known_hosts`, including removal of `mark_authenticated` wiring between session runtime and broker and its related callback registration. (see `src/sshpilot/daemon/server.py`, `src/sshpilot/daemon/session_runtime.py`)
- Preserved daemon `LocalCommand` handling and `-o PermitLocalCommand=yes` / `-o LocalCommand=<cmd>` insertion semantics and argv ordering, ensuring the exact configured command is passed before the host argument and safe argv/quoting is preserved. (see `src/sshpilot/api/in_process_client.py` and associated tests)
- Reverted the keepalive-default change introduced earlier by restoring the prior default (`ssh.apply_default_keepalive` now defaults back to the previous behavior) while keeping the explicit Preferences and opt-out flow intact. (see `src/sshpilot/config.py`, `src/sshpilot/core/settings/defaults.py`, `src/sshpilot/ssh_connection_builder.py`, `src/sshpilot/preferences.py`)
- Updated API docs, generated API artifacts, tests, fixtures, and documentation to remove references to `ACCEPT_ONCE` / `ACCEPT_AND_STORE` and to state that OpenSSH owns verification and persistence. (see `docs/` and regenerated artifacts)

### Testing

- Ran targeted unit and integration suites: `pytest -q tests/daemon/test_interaction_broker.py tests/daemon/test_interaction_protocol.py tests/gui/test_phase14_auth_dialogs.py tests/core/test_interaction_policy.py tests/test_connection_state.py tests/test_ssh_overrides.py tests/test_connection_field_roundtrip.py tests/api/test_public_api_snapshot.py tests/api/test_api_documentation.py` which completed with 132 passed and 1 skipped.
- Ran a broader focused suite (many daemon, SFTP, forward, and builder tests); overall most focused checks passed (154 passed) but two SFTP integration tests failed with timeouts when closing mock SFTP services (`tests/daemon/test_sftp_api_integration.py` produced two timed-out `sftp.close` cases), which appear to be environment/mock-service timeouts rather than host-key persistence regressions.
- Verified `pytest -q tests/daemon/test_interaction_openssh.py` (skipped 4 tests where the temporary sshd fixture was unavailable), ran `python -m compileall -q src`, and confirmed `git diff --check` reported no issues.

Files / behavior highlights changed by this PR: key changes in `src/sshpilot/daemon/interaction_broker.py`, `src/sshpilot/api/models/interactions.py`, `src/sshpilot/core/interaction/policy.py`, `src/sshpilot/daemon_interaction_dialogs.py`, `src/sshpilot/daemon/server.py`, `src/sshpilot/daemon/session_runtime.py`, keepalive/defaults adjustments in `src/sshpilot/config.py` / `src/sshpilot/core/settings/defaults.py` / `src/sshpilot/ssh_connection_builder.py` / `src/sshpilot/preferences.py`, and multiple updated tests and docs to reflect the new host-key model.

Behavior removed: daemon-managed known_hosts snapshots, injection of `UserKnownHostsFile=...`, promotion/merge/atomic-write host-key persistence, and typed `ACCEPT_ONCE`/`ACCEPT_AND_STORE` semantics.

Behavior preserved: canonical OpenSSH argv, authored `UserKnownHostsFile` values, `PermitLocalCommand=yes` / exact `LocalCommand` insertion and ordering, and explicit Preferences overrides (including keepalive preference semantics).

Notes: two SFTP integration close-timeout failures were observed and may merit follow-up in the integration test harness; they did not indicate host-key persistence activity by the daemon.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a703cc14fb4832883162451e3a6e953)