### PR TITLE
Route frontend terminal input through TerminalWidget

### DIFF
--- a/src/sshpilot/command_blocks.py
+++ b/src/sshpilot/command_blocks.py
@@ -1319,8 +1319,7 @@ class CommandBlocksPanel(Gtk.Box):
         insert_only = bool(self.store._config.get_setting('command_blocks.insert_only', False))
         data = command_text.encode('utf-8') if insert_only else (command_text + '\n').encode('utf-8')
         try:
-            if hasattr(terminal, 'backend') and terminal.backend:
-                terminal.backend.feed_child(data)
+            terminal.feed_child_data(data)
         except Exception as exc:
             logger.error("Failed to send command to terminal: %s", exc)
             return
@@ -1610,8 +1609,7 @@ class CommandBlocksPanel(Gtk.Box):
         insert_only = bool(self.store._config.get_setting('command_blocks.insert_only', False))
         data = command_text.encode('utf-8') if insert_only else (command_text + '\n').encode('utf-8')
         try:
-            if hasattr(terminal, 'backend') and terminal.backend:
-                terminal.backend.feed_child(data)
+            terminal.feed_child_data(data)
         except Exception as exc:
             logger.error("Failed to send command to terminal: %s", exc)
             return
@@ -1791,4 +1789,3 @@ class CommandBlocksPanel(Gtk.Box):
         self.store.update_command(cmd['id'], is_favorite=new_val)
         cmd['is_favorite'] = new_val
         self.refresh()
-

--- a/src/sshpilot/plugins/host.py
+++ b/src/sshpilot/plugins/host.py
@@ -624,9 +624,7 @@ class PluginHost:
         data = text.encode("utf-8")
 
         def _feed():
-            backend = getattr(term, "backend", None)
-            if backend is not None and hasattr(backend, "feed_child"):
-                backend.feed_child(data)
+            term.feed_child_data(data)
 
         try:
             self.run_on_ui_thread(_feed)

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -3664,7 +3664,6 @@ class PreferencesWindow(Adw.NavigationPage):
                         if hasattr(terminal, 'backend') and terminal.backend:
                             terminal.backend.set_font(font_desc)
                             count += 1
-                            count += 1
                 logger.info(f"Applied font {font_string} to {count} terminals")
         except Exception as e:
             logger.error(f"Failed to apply font to terminals: {e}")

--- a/tests/test_terminal_backend_architecture.py
+++ b/tests/test_terminal_backend_architecture.py
@@ -30,3 +30,25 @@ def test_frontend_does_not_reach_into_vte_backend():
         if re.search(r"(?:term|terminal|term_widget|terminal_widget)\.vte\b", source):
             leaked.append(f"{path.relative_to(package)}: external VTE escape hatch")
     assert not leaked, "frontend bypasses BaseTerminalBackend: " + ", ".join(leaked)
+
+
+def test_frontend_does_not_bypass_widget_input_routing():
+    package = Path(__file__).parents[1] / "src/sshpilot"
+    allowed = {"terminal.py", "terminal_backends.py"}
+    forbidden = {
+        "terminal backend child input": r"\b(?:terminal|term)\.backend\.feed_child(?:_data)?\s*\(",
+        "backend child input": r"\bbackend\.feed_child(?:_data)?\s*\(",
+    }
+
+    leaked = []
+    for path in package.rglob("*.py"):
+        if path.name in allowed:
+            continue
+        source = path.read_text()
+        for name, pattern in forbidden.items():
+            if re.search(pattern, source):
+                leaked.append(f"{path.relative_to(package)}: {name}")
+
+    assert not leaked, (
+        "frontend bypasses TerminalWidget.feed_child_data: " + ", ".join(leaked)
+    )

--- a/tests/test_terminal_pty_autofill.py
+++ b/tests/test_terminal_pty_autofill.py
@@ -1,12 +1,16 @@
 """TerminalWidget PTY auto-fill: one-shot typing when a known prompt appears."""
 import logging
 import types
+import weakref
+from unittest.mock import Mock
 
 import pytest
 
 pytest.importorskip("gi")
 
 from sshpilot.terminal import TerminalWidget
+from sshpilot import command_blocks
+from sshpilot.plugins.host import PluginHost
 
 
 def _term(*, prompt="[sshPilot] sudo password:", response="s3cret"):
@@ -191,6 +195,53 @@ def test_feed_child_data_daemon_with_ownership_uses_controller():
     )
     t.feed_child_data(b"typed\n")
     assert controller.sent == [b"typed\n"]
+
+
+def _daemon_terminal():
+    terminal = TerminalWidget.__new__(TerminalWidget)
+    terminal._daemon_mode = True
+    terminal._daemon_controller = Mock(input_owner=True)
+    terminal.backend = Mock()
+    return terminal
+
+
+def test_command_blocks_active_terminal_routes_daemon_input_through_widget():
+    terminal = _daemon_terminal()
+    panel = command_blocks.CommandBlocksPanel.__new__(command_blocks.CommandBlocksPanel)
+    panel.window = Mock()
+    panel.window._get_active_terminal_widget.return_value = terminal
+    panel.store = Mock()
+    panel.store._config.get_setting.return_value = False
+
+    panel._feed_terminal("uptime", "command-id")
+
+    terminal._daemon_controller.send_input.assert_called_once_with(b"uptime\n")
+    terminal.backend.feed_child_data.assert_not_called()
+    panel.store.record_use.assert_called_once_with("command-id")
+
+
+def test_command_blocks_specific_terminal_routes_daemon_input_through_widget():
+    terminal = _daemon_terminal()
+    panel = command_blocks.CommandBlocksPanel.__new__(command_blocks.CommandBlocksPanel)
+    panel.store = Mock()
+    panel.store._config.get_setting.return_value = False
+
+    panel._feed_specific_terminal("whoami", terminal, "command-id")
+
+    terminal._daemon_controller.send_input.assert_called_once_with(b"whoami\n")
+    terminal.backend.feed_child_data.assert_not_called()
+    panel.store.record_use.assert_called_once_with("command-id")
+
+
+def test_plugin_send_terminal_routes_daemon_input_through_widget():
+    terminal = _daemon_terminal()
+    host = PluginHost(connection_manager=None)
+    host._terminal_widgets["session-id"] = weakref.ref(terminal)
+
+    assert host.send_terminal("session-id", "pwd\n") is True
+
+    terminal._daemon_controller.send_input.assert_called_once_with(b"pwd\n")
+    terminal.backend.feed_child_data.assert_not_called()
 
 
 def test_pty_autofill_does_not_log_secret(caplog):


### PR DESCRIPTION
### Motivation

- Ensure all frontend paths send programmatic terminal input via the canonical widget API so daemon-backed terminals respect input ownership and avoid writing to stale local PTYs.
- Prevent frontend modules (Command Blocks and plugin host) from calling backend/VTE feed methods directly, which can bypass daemon routing and swallow delivery errors.
- Fix a minor logging regression where font-application counting was incremented twice.

### Description

- Replace direct backend writes in Command Blocks with `terminal.feed_child_data(data)` for both active and newly-connected-terminal flows in `src/sshpilot/command_blocks.py`.
- Dispatch plugin API input via the widget-level API by calling `term.feed_child_data(data)` on the UI thread in `src/sshpilot/plugins/host.py`.
- Remove the duplicate `count` increment in `Preferences.apply_font_to_terminals()` so the logged terminal count is accurate in `src/sshpilot/preferences.py`.
- Add an architecture-level unit test that rejects direct `backend.feed_child`/`backend.feed_child_data` occurrences outside `terminal.py` and `terminal_backends.py` in `tests/test_terminal_backend_architecture.py`.
- Add daemon-mode regression tests ensuring Command Blocks and plugin `send_terminal()` route input through the terminal widget controller and never call backend-local input in `tests/test_terminal_pty_autofill.py`.

### Testing

- Ran `pytest -q tests/test_terminal_backend_architecture.py tests/test_terminal_pty_autofill.py tests/test_plugin_host.py` which passed (`39 passed`).
- Ran `python -m ruff check` on the modified modules and the new tests (no new lint errors reported for the touched files).
- Ran repository checks (`git diff --check`) and the repo diff/lint checks for the change (no problems reported).
- Ran the full test suite: `pytest -q` produced `2855 passed, 105 skipped` and `8` failures that are unrelated/environmental (container runtime unavailable, daemon integration timeouts/startup, and Paramiko stub pollution) rather than regressions from these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a703eff0d5c832887139484029d9084)