### PR TITLE
Fix PyXterm daemon decoder initialization

### DIFF
--- a/src/sshpilot/terminal_backends.py
+++ b/src/sshpilot/terminal_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import codecs
 import logging
 import os
 from typing import Any, Callable, Mapping, Optional, Protocol, Sequence
@@ -216,7 +217,6 @@ class VTETerminalBackend:
     """VTE based terminal backend."""
 
     def __init__(self, owner: "TerminalWidget") -> None:
-        import codecs
         self.owner = owner
         self.vte = Vte.Terminal()
         self.widget = self.vte

--- a/tests/test_pyxterm_flow_control.py
+++ b/tests/test_pyxterm_flow_control.py
@@ -1,7 +1,7 @@
 """xterm.js-style pending-callback flow control for PyXtermBridgeBackend."""
 import codecs
 
-from sshpilot.terminal_backends import PyXtermBridgeBackend
+from sshpilot.terminal_backends import PyXtermBridgeBackend, PyXtermTerminalBackend
 
 
 class _FakeBridge:
@@ -42,6 +42,20 @@ def _make_backend():
     b._scripts = []
     b._run_javascript = b._scripts.append
     return b
+
+
+def test_normal_construction_initializes_daemon_decoder(monkeypatch):
+    """The public constructor must create the stateful daemon decoder itself."""
+    monkeypatch.setattr(
+        PyXtermTerminalBackend,
+        "__init__",
+        lambda self, owner: setattr(self, "owner", owner),
+    )
+
+    backend = PyXtermBridgeBackend(object())
+
+    assert backend._daemon_decoder.decode(b"\xc3", final=False) == ""
+    assert backend._daemon_decoder.decode(b"\xa9", final=False) == "é"
 
 
 def test_small_chunks_use_fast_path_without_ack():
@@ -124,7 +138,7 @@ def test_daemon_feed_preserves_utf8_split_across_frames():
     b._daemon_decoder = codecs.getincrementaldecoder("utf-8")("replace")
     displayed = []
     b._on_pty_output = displayed.append
-    encoded = "سلام".encode("utf-8")
+    encoded = "سلام".encode()
 
     # Deliberately split every two-byte Persian code point in half.
     for byte in encoded:


### PR DESCRIPTION
### Motivation

- Prevent `NameError` when constructing the PyXterm bridge backend by ensuring the UTF-8 incremental decoder can be created from the public constructor.

### Description

- Move `import codecs` to module scope so `PyXtermBridgeBackend` can call `codecs.getincrementaldecoder` during `__init__`.
- Remove the ineffective local `import codecs` from `VTETerminalBackend.__init__`.
- Add `test_normal_construction_initializes_daemon_decoder` to exercise the real `PyXtermBridgeBackend` constructor and verify decoder state across split UTF-8 bytes.
- Tidy an existing test by using `"سلام".encode()` instead of passing an unnecessary encoding argument.

### Testing

- Ran `pytest -q tests/test_pyxterm_flow_control.py tests/test_pyxterm_daemon_feed.py` and observed all tests pass (`23 passed`).
- Ran `ruff check src/sshpilot/terminal_backends.py tests/test_pyxterm_flow_control.py` with no remaining issues.
- Ran `git diff --check` with no whitespace or diff-check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70515b92088328abc1461d2dd9dcdc)