### PR TITLE
Replace GTK ConnectionManager with daemon-backed ConnectionPresentationStore

### DIFF
--- a/docs/PLUGIN_SDK.md
+++ b/docs/PLUGIN_SDK.md
@@ -232,7 +232,14 @@ self.connect("unmap", lambda *_: self.ctx.release_multiplex(self._nick))
 - `run_on_ui_thread(fn, *args)` — run `fn(*args)` on the GTK main thread. Use to return from a background worker before touching UI or calling `add_connection`/`open_connection`.
 
 ### Advanced (escape hatch)
-- `ctx.config`, `ctx.connection_manager` — live internal objects. Stable enough that the built-in backends use them, but prefer the named APIs; treat these as advanced.
+- `ctx.config` is legacy application UI configuration. `ctx.connection_manager`
+  is **deprecated and presentation-only in GTK**: it contains immutable daemon
+  snapshots and must not be used for persistence, secrets, migrations, config
+  file access, or process launch. Use the named `PluginContext` operations for
+  those tasks. Headless daemon plugins receive their separate core context;
+  GTK plugins receive UI registration, event subscriptions, snapshots, and
+  daemon-mediated operations. A duplicate mutable backend is never created for
+  compatibility.
 
 #### Advanced UI — credential dialogs
 

--- a/src/sshpilot/gtk/__init__.py
+++ b/src/sshpilot/gtk/__init__.py
@@ -1,5 +1,6 @@
 """GTK presentation adapters (must not be imported by core/api/daemon)."""
 
 from .interaction import GtkInteractionProvider, get_default_provider, set_default_provider
+from .connection_store import ConnectionPresentationStore
 
-__all__ = ["GtkInteractionProvider", "get_default_provider", "set_default_provider"]
+__all__ = ["ConnectionPresentationStore", "GtkInteractionProvider", "get_default_provider", "set_default_provider"]

--- a/src/sshpilot/gtk/connection_store.py
+++ b/src/sshpilot/gtk/connection_store.py
@@ -1,0 +1,163 @@
+"""Read-only, daemon-backed connection presentation state for GTK."""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+from sshpilot.api.events import CoreEvent, EventType
+from sshpilot.api.models.connections import ConnectionSummary
+
+_CONNECTION_EVENTS = frozenset({EventType.CONNECTION_CREATED, EventType.CONNECTION_UPDATED,
+                                EventType.CONNECTION_DELETED})
+
+
+class ConnectionPresentationStore:
+    """Replaceable projection of one daemon instance's immutable DTO graph.
+
+    The store has intentionally no configuration, secret-storage, migration,
+    or process APIs. ``on_changed`` lets a GTK adapter replace its list model.
+    """
+
+    def __init__(self, *, on_changed: Optional[Callable[[Tuple[ConnectionSummary, ...]], None]] = None):
+        self._lock = RLock()
+        self._by_id: Dict[str, ConnectionSummary] = {}
+        self._client = None
+        self._subscription = None
+        self._generation = 0
+        self._last_sequence = -1
+        self._refresh_generation = 0
+        self._pending_events = []
+        self._on_changed = on_changed
+        self._handlers = {}
+        self._next_handler_id = 1
+
+    @property
+    def connections(self) -> Tuple[ConnectionSummary, ...]:
+        return self.snapshot()
+
+    def snapshot(self) -> Tuple[ConnectionSummary, ...]:
+        with self._lock:
+            return tuple(self._by_id.values())
+
+    def get_connections(self) -> Tuple[ConnectionSummary, ...]:
+        return self.snapshot()
+
+    def get_connection_by_id(self, connection_id: str) -> Optional[ConnectionSummary]:
+        with self._lock:
+            return self._by_id.get(connection_id)
+
+    get_connection_by_uuid = get_connection_by_id
+    find_connection_by_nickname = get_connection_by_id
+
+    def rebuild(self, connections: Iterable[ConnectionSummary]) -> None:
+        """Atomically rebuild from daemon DTOs."""
+        replacement: Dict[str, ConnectionSummary] = {}
+        for connection in connections:
+            if not isinstance(connection, ConnectionSummary):
+                raise TypeError("presentation store only accepts ConnectionSummary DTOs")
+            replacement[connection.id] = connection
+        with self._lock:
+            previous = self._by_id
+            self._by_id = replacement
+            snapshot = tuple(replacement.values())
+        self._notify(snapshot)
+        for connection_id in previous.keys() - replacement.keys():
+            self._emit("connection-removed", previous[connection_id])
+        for connection_id in replacement.keys() - previous.keys():
+            self._emit("connection-added", replacement[connection_id])
+        for connection_id in replacement.keys() & previous.keys():
+            if replacement[connection_id] != previous[connection_id]:
+                self._emit("connection-updated", replacement[connection_id])
+
+    def connect_after(self, signal_name: str, callback: Callable) -> int:
+        """Small signal adapter retained for GTK presentation consumers."""
+        handler_id = self._next_handler_id
+        self._next_handler_id += 1
+        self._handlers[handler_id] = (signal_name, callback)
+        return handler_id
+
+    def disconnect(self, handler_id: int) -> None:
+        self._handlers.pop(handler_id, None)
+
+    def attach_client(self, client) -> Tuple[ConnectionSummary, ...]:
+        """Subscribe to a daemon and perform a full authoritative refresh."""
+        with self._lock:
+            old_subscription = self._subscription
+            self._subscription = None
+            self._generation += 1
+            generation = self._generation
+            self._client = client
+            self._last_sequence = -1
+            self._refresh_generation = generation
+            self._pending_events = []
+        if old_subscription is not None:
+            old_subscription.unsubscribe()
+        instance_id = getattr(client, "server_instance_id", None)
+        subscription = client.subscribe_events(
+            lambda event: self._accept_event(event, generation, instance_id)
+        )
+        try:
+            self.rebuild(client.list_connections())
+        except BaseException:
+            subscription.unsubscribe()
+            raise
+        with self._lock:
+            pending = tuple(self._pending_events)
+            self._pending_events = []
+            self._refresh_generation = 0
+            if generation != self._generation:
+                subscription.unsubscribe()
+            else:
+                self._subscription = subscription
+        for event in sorted(pending, key=lambda item: item.sequence):
+            self._accept_event(event, generation, instance_id)
+        return self.snapshot()
+
+    def refresh(self) -> Tuple[ConnectionSummary, ...]:
+        with self._lock:
+            client = self._client
+        if client is not None:
+            self.rebuild(client.list_connections())
+        return self.snapshot()
+
+    def close(self) -> None:
+        with self._lock:
+            self._generation += 1
+            subscription, self._subscription = self._subscription, None
+            self._client = None
+        if subscription is not None:
+            subscription.unsubscribe()
+
+    def _accept_event(self, event: CoreEvent, generation: int, instance_id: Optional[str]) -> None:
+        if event.type not in _CONNECTION_EVENTS:
+            return
+        with self._lock:
+            current_instance = getattr(self._client, "server_instance_id", None)
+            if generation != self._generation or current_instance != instance_id:
+                return
+            if self._refresh_generation == generation:
+                self._pending_events.append(event)
+                return
+            if event.sequence <= self._last_sequence:
+                return
+            self._last_sequence = event.sequence
+            if event.type is EventType.CONNECTION_DELETED:
+                self._by_id.pop(event.payload.id, None)
+                signal_name = "connection-removed"
+            else:
+                self._by_id[event.payload.id] = event.payload
+                signal_name = ("connection-added" if event.type is EventType.CONNECTION_CREATED
+                               else "connection-updated")
+            snapshot = tuple(self._by_id.values())
+        self._notify(snapshot)
+        self._emit(signal_name, event.payload)
+
+    def _notify(self, snapshot: Tuple[ConnectionSummary, ...]) -> None:
+        if self._on_changed is not None:
+            self._on_changed(snapshot)
+
+    def _emit(self, signal_name: str, connection: ConnectionSummary) -> None:
+        for registered_name, callback in tuple(self._handlers.values()):
+            if registered_name == signal_name:
+                callback(self, connection)

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -42,7 +42,8 @@ HAS_TIMED_ANIMATION = hasattr(Adw, 'TimedAnimation')
 
 from gettext import gettext as _
 
-from .connection_manager import ConnectionManager, Connection, ConnectionState
+from .connection_manager import Connection, ConnectionState
+from .gtk.connection_store import ConnectionPresentationStore
 from .config import Config
 from .key_manager import KeyManager
 from .update_checker import check_for_updates_async
@@ -234,13 +235,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                 self._config_changed_handler = None
         effective_isolated = isolated or bool(self.config.get_setting('ssh.use_isolated_config', False))
         key_dir = Path(get_config_dir()) if effective_isolated else None
-        # GTK managers are presentation snapshots; daemon owns identity migration.
-        daemon_requested = True
-        self.connection_manager = ConnectionManager(
-            self.config,
-            isolated_mode=effective_isolated,
-            identity_migration_enabled=not daemon_requested,
-        )
+        # Compatibility attribute while call sites migrate terminology. This is
+        # a DTO projection, never a persistence-capable backend manager.
+        self.connection_manager = ConnectionPresentationStore()
 
         # Wire GTK interaction provider for core.interaction requests.
         try:
@@ -314,6 +311,8 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         self._api_client_selection_request = None
         self._client_mode_warning = None
         self._compose_api_client(app)
+        if self.client is not None:
+            self.connection_manager.attach_client(self.client)
 
         # UI state
         self.active_terminals: Dict[Connection, TerminalWidget] = {}  # most recent terminal per connection
@@ -350,7 +349,8 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         self._setup_omnisearch_shortcut()
         self.setup_connections()
         self.setup_signals()
-        self._setup_ssh_config_monitor()
+        # Authoritative SSH files are monitored by the daemon; GTK refreshes
+        # from connection events and never installs a filesystem watcher.
 
         # Apply the persisted sidebar mode (full / minimal icon strip).
         try:
@@ -425,6 +425,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             selection.client.close()
             return
         self.client = selection.client
+        self.connection_manager.attach_client(self.client)
         self._api_client_selection_pending = False
         self._api_client_selection_request = None
         app = self.get_application()
@@ -1255,196 +1256,24 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         except Exception:
             logger.debug("Failed to prime effective-config warning", exc_info=True)
 
-    def _ssh_config_path(self):
-        path = getattr(self.connection_manager, 'ssh_config_path', None)
-        if not path:
-            from .platform_utils import get_ssh_dir
-            path = os.path.join(get_ssh_dir(), 'config')
-        return os.path.abspath(os.path.expanduser(path))
-
-    def _ssh_config_fingerprint(self):
-        return self._ssh_config_file_fingerprint(self._ssh_config_path())
-
-    @staticmethod
-    def _ssh_config_file_fingerprint(path):
-        try:
-            stat = os.stat(path)
-            return (stat.st_ino, stat.st_size, stat.st_mtime_ns)
-        except OSError:
-            return None
-
-    def _ssh_config_paths(self):
-        root = self._ssh_config_path()
-        paths = {root}
-        try:
-            from .ssh_config_utils import resolve_ssh_config_files
-            paths.update(
-                os.path.abspath(os.path.expanduser(path))
-                for path in resolve_ssh_config_files(root)
-                if path
-            )
-        except Exception:
-            logger.debug("Failed to resolve SSH config includes", exc_info=True)
-        return paths
-
-    def _ssh_config_fingerprints(self):
-        return {
-            path: self._ssh_config_file_fingerprint(path)
-            for path in self._ssh_config_paths()
-        }
-
     def _reload_ssh_config(self, create_missing=True):
-        """Reload connections after any internal or external config save."""
+        """Compatibility callback: refresh only from the attached daemon."""
         try:
-            self.connection_manager.load_ssh_config(
-                create_missing=create_missing)
-            self.group_manager.bind_connections(
-                self.connection_manager.get_connections()
-            )
+            self.connection_manager.refresh()
+            self.group_manager.bind_connections(self.connection_manager.get_connections())
             checker = getattr(self, 'effective_config_checker', None)
             if checker is not None:
                 checker.invalidate()
-
             self.rebuild_connection_list()
-            if hasattr(self, '_ssh_config_monitors'):
-                self._refresh_ssh_config_monitors()
-            logger.info("SSH config reloaded after file change")
-        except Exception as e:
-            logger.error(
-                "Failed to refresh connections after SSH config change: %s", e)
+        except Exception as error:
+            logger.error("Failed to refresh daemon connection state: %s", error)
 
     def _observe_and_reload_ssh_config(self):
-        """Record the current file state and reload immediately."""
-        self._ssh_config_observed_fingerprints = (
-            self._ssh_config_fingerprints())
+        """Compatibility callback for dialogs; no local file is observed."""
         self._reload_ssh_config()
 
-    def _reload_ssh_config_if_changed(self):
-        self._ssh_config_reload_timeout_id = 0
-        fingerprints = self._ssh_config_fingerprints()
-        if fingerprints == self._ssh_config_observed_fingerprints:
-            return False
-        self._ssh_config_observed_fingerprints = fingerprints
-        self._reload_ssh_config(create_missing=False)
-        return False
-
-    def _on_connection_manager_config_written(self, _manager, path):
-        """Prevent the directory watcher from replaying an app-owned write."""
-        path = os.path.abspath(os.path.expanduser(path))
-        if path in self._ssh_config_observed_fingerprints:
-            self._ssh_config_observed_fingerprints[path] = (
-                self._ssh_config_file_fingerprint(path))
-
-    def _on_ssh_config_directory_changed(
-            self, _monitor, file, other_file, _event_type):
-        try:
-            changed_paths = {
-                os.path.abspath(candidate.get_path())
-                for candidate in (file, other_file)
-                if candidate is not None and candidate.get_path()
-            }
-            if not changed_paths.intersection(
-                    self._ssh_config_observed_fingerprints):
-                return
-            timeout_id = getattr(
-                self, '_ssh_config_reload_timeout_id', 0)
-            if timeout_id:
-                GLib.source_remove(timeout_id)
-            self._ssh_config_reload_timeout_id = GLib.timeout_add(
-                150, self._reload_ssh_config_if_changed)
-        except Exception:
-            logger.debug("Error handling SSH config change", exc_info=True)
-
-    def _refresh_ssh_config_monitors(self):
-        """Watch directories containing the root config and resolved Includes."""
-        for monitor, handler_id in getattr(
-                self, '_ssh_config_monitors', {}).values():
-            try:
-                monitor.disconnect(handler_id)
-            except Exception:
-                pass
-            try:
-                monitor.cancel()
-            except Exception:
-                pass
-        self._ssh_config_monitors = {}
-        self._ssh_config_observed_fingerprints = (
-            self._ssh_config_fingerprints())
-        window_ref = weakref.ref(self)
-
-        def _changed(monitor, file, other_file, event_type):
-            window = window_ref()
-            if window is not None:
-                window._on_ssh_config_directory_changed(
-                    monitor, file, other_file, event_type)
-
-        for config_dir in {
-                os.path.dirname(path)
-                for path in self._ssh_config_observed_fingerprints
-        }:
-            try:
-                monitor = Gio.File.new_for_path(config_dir).monitor_directory(
-                    Gio.FileMonitorFlags.WATCH_MOVES, None)
-                handler_id = monitor.connect("changed", _changed)
-                self._ssh_config_monitors[config_dir] = (
-                    monitor, handler_id)
-            except Exception:
-                logger.debug(
-                    "Failed to monitor SSH config directory %s",
-                    config_dir, exc_info=True)
-
-    def _setup_ssh_config_monitor(self):
-        """Set up lifetime-safe monitoring for root and included config files."""
-        self._ssh_config_reload_timeout_id = 0
-        self._ssh_config_monitors = {}
-        self._refresh_ssh_config_monitors()
-        window_ref = weakref.ref(self)
-
-        def _written(manager, path):
-            window = window_ref()
-            if window is not None:
-                window._on_connection_manager_config_written(manager, path)
-
-        try:
-            self._ssh_config_written_handler = (
-                self.connection_manager.connect_after(
-                    'config-written', _written))
-        except Exception:
-            self._ssh_config_written_handler = None
-            logger.debug(
-                "Failed to observe app-owned SSH config writes",
-                exc_info=True)
-
     def _teardown_ssh_config_monitor(self):
-        """Release timeouts, native monitors, and manager signal handlers."""
-        timeout_id = getattr(self, '_ssh_config_reload_timeout_id', 0)
-        if timeout_id:
-            try:
-                GLib.source_remove(timeout_id)
-            except Exception:
-                pass
-            self._ssh_config_reload_timeout_id = 0
-
-        for monitor, handler_id in getattr(
-                self, '_ssh_config_monitors', {}).values():
-            try:
-                monitor.disconnect(handler_id)
-            except Exception:
-                pass
-            try:
-                monitor.cancel()
-            except Exception:
-                pass
-        self._ssh_config_monitors = {}
-
-        handler_id = getattr(self, '_ssh_config_written_handler', None)
-        if handler_id is not None:
-            try:
-                GObject.Object.disconnect(
-                    self.connection_manager, handler_id)
-            except Exception:
-                pass
-            self._ssh_config_written_handler = None
+        """Compatibility no-op: GTK never creates configuration monitors."""
 
     def _rows_for_connection(self, connection) -> List[Gtk.ListBoxRow]:
         """Return every visible row representing ``connection``.
@@ -3987,7 +3816,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         # Refresh connection from disk to ensure latest auth method
         if connection is not None and not as_new:
             try:
-                self.connection_manager.load_ssh_config()
+                self.connection_manager.refresh()
                 refreshed = self.connection_manager.find_connection_by_nickname(connection.nickname)
                 if refreshed:
                     connection = refreshed
@@ -4272,37 +4101,10 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             self.show_connection_dialog(connection, skip_group_warning=True)
 
     def _open_ssh_config_editor(self):
-        try:
-            # Single editor for the SSH config: the GtkSourceView-backed editor,
-            # which self-degrades to a plain TextView if GtkSourceView is absent.
-            from .text_editor import RemoteFileEditorWindow
-            from .ssh_config_utils import validate_ssh_config_text
-
-            config_path = self._ssh_config_path()
-            config_name = os.path.basename(config_path)
-
-            editor = RemoteFileEditorWindow(
-                parent=self,
-                file_path=config_path,
-                file_name=config_name,
-                is_local=True,
-                sftp_manager=None,
-                file_manager_window=None,
-                pre_save_validator=validate_ssh_config_text,
-                on_local_saved=self._observe_and_reload_ssh_config,
-                language_id="sshconfig",
-                show_outline=True,
-            )
-
-            # Set custom title for SSH config editor (the path shows as the
-            # header subtitle automatically).
-            editor.set_title(_("Edit SSH Config"))  # window/taskbar title
-            if hasattr(editor, 'set_editor_title'):
-                editor.set_editor_title(_("SSH Config"))
-
-            editor.present()
-        except Exception as e:
-            logger.error(f"Failed to open SSH config editor: {e}")
+        self.show_toast(_(
+            "Direct SSH config editing is unavailable; use connection dialogs "
+            "so changes are validated and saved by the background service."
+        ))
 
     def show_connection_selection_for_ssh_copy(self):
         """Open the ssh-copy-id dialog with no server preselected; its
@@ -5075,7 +4877,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     self._deleting_connections_batch = False
                     self.group_manager._save_groups()
                     try:
-                        self.connection_manager.load_ssh_config()
+                        self.connection_manager.refresh()
                     except Exception:
                         logger.exception(
                             "Failed to reload connections after batch deletion"
@@ -5128,7 +4930,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             if self._is_quitting:
                 return
             try:
-                self.connection_manager.load_ssh_config()
+                self.connection_manager.refresh()
                 self.rebuild_connection_list()
             except Exception as error:
                 logger.warning(
@@ -6668,7 +6470,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                     conf = getattr(self.connection_manager, 'config', None)
                     if conf and hasattr(conf, 'load_json_config'):
                         conf.config_data = conf.load_json_config()
-                    self.connection_manager.load_ssh_config()
+                    self.connection_manager.refresh()
                     self.rebuild_connection_list()
                 except Exception as error:
                     logger.warning(

--- a/src/sshpilot/window_dialogs.py
+++ b/src/sshpilot/window_dialogs.py
@@ -2102,7 +2102,7 @@ class WindowConfigDialogsMixin:
                 try:
                     self.config.config_data = self.config.load_json_config()
                     if self.connection_manager:
-                        self.connection_manager.load_ssh_config()
+                        self.connection_manager.refresh()
                     if self.group_manager:
                         self.group_manager._load_groups()
                     self.rebuild_connection_list()
@@ -2149,7 +2149,7 @@ class WindowConfigDialogsMixin:
                         try:
                             self.config.config_data = self.config.load_json_config()
                             if self.connection_manager:
-                                self.connection_manager.load_ssh_config()
+                                self.connection_manager.refresh()
                             # Reload group manager to pick up imported groups and colors
                             if self.group_manager:
                                 self.group_manager._load_groups()

--- a/tests/test_gtk_connection_presentation_store.py
+++ b/tests/test_gtk_connection_presentation_store.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+
+from sshpilot.api.events import CoreEvent, EventType
+from sshpilot.api.models.connections import ConnectionSummary
+from sshpilot.gtk.connection_store import ConnectionPresentationStore
+
+
+def summary(connection_id, nickname=None):
+    return ConnectionSummary(
+        id=connection_id, nickname=nickname or connection_id, host=connection_id,
+        hostname=f"{connection_id}.example", username="user", port=22,
+    )
+
+
+class Subscription:
+    def __init__(self):
+        self.closed = False
+
+    def unsubscribe(self):
+        self.closed = True
+
+
+class Client:
+    def __init__(self, instance_id, connections):
+        self.server_instance_id = instance_id
+        self.connections = list(connections)
+        self.callback = None
+        self.subscription = Subscription()
+        self.list_calls = 0
+
+    def subscribe_events(self, callback):
+        self.callback = callback
+        return self.subscription
+
+    def list_connections(self):
+        self.list_calls += 1
+        return list(self.connections)
+
+    def emit(self, event_type, payload, sequence):
+        self.callback(CoreEvent(event_type, payload, sequence,
+                                datetime.now(timezone.utc)))
+
+
+def test_store_rebuilds_entirely_from_immutable_daemon_dtos():
+    store = ConnectionPresentationStore()
+    dto = summary("one")
+    store.rebuild([dto])
+
+    assert store.snapshot() == (dto,)
+    assert store.get_connection_by_id("one") is dto
+    assert isinstance(store.connections, tuple)
+
+
+def test_daemon_events_update_presentation_store():
+    changed = []
+    client = Client("daemon-a", [summary("one")])
+    store = ConnectionPresentationStore(on_changed=changed.append)
+    store.attach_client(client)
+    two = summary("two")
+
+    client.emit(EventType.CONNECTION_CREATED, two, 1)
+    client.emit(EventType.CONNECTION_DELETED, summary("one"), 2)
+
+    assert store.snapshot() == (two,)
+    assert changed[-1] == (two,)
+
+
+def test_reconnect_refreshes_and_ignores_old_daemon_events():
+    old = Client("daemon-old", [summary("old")])
+    new = Client("daemon-new", [summary("new")])
+    store = ConnectionPresentationStore()
+    store.attach_client(old)
+    old_callback = old.callback
+
+    store.attach_client(new)
+    old_callback(CoreEvent(EventType.CONNECTION_CREATED, summary("stale"), 99,
+                           datetime.now(timezone.utc)))
+
+    assert old.subscription.closed
+    assert new.list_calls == 1
+    assert store.snapshot() == (summary("new"),)
+
+
+def test_gtk_window_does_not_create_or_reload_backend_manager():
+    source = open("src/sshpilot/window.py", encoding="utf-8").read()
+    assert "ConnectionManager(" not in source
+    assert ".load_ssh_config(" not in source
+    assert "self._setup_ssh_config_monitor()" not in source


### PR DESCRIPTION
### Motivation

- Remove GTK's duplicate, persistence-capable `ConnectionManager` so the GTK UI does not hold an independent authoritative configuration graph separate from the daemon. 
- Provide a read-only, presentation-focused projection that is rebuilt from daemon DTOs and updated from daemon connection events. 
- Ensure GTK never reads/writes SSH config, touches secure storage, spawns processes, or performs persistence migrations. 

### Description

- Add `ConnectionPresentationStore` as a GTK-only, read-only projection that stores immutable `ConnectionSummary` DTOs, supports snapshot access and lookup by connection ID, buffers events during full refresh, enforces sequence ordering, and ignores stale events from prior daemon instances. (`src/sshpilot/gtk/connection_store.py`).
- Export the presentation store in the GTK package (`src/sshpilot/gtk/__init__.py`) and replace instantiation of the persistence-capable backend in the main window with the presentation store, attaching it to the selected daemon client on reconnect/selection. (`src/sshpilot/window.py`).
- Replace GTK internal calls that previously invoked local config reloads with presentation refreshes from the attached daemon (`.refresh()`), remove GTK filesystem monitoring for authoritative SSH files, and disable direct SSH-config editing in the GTK editor path in favor of daemon-mediated dialogs. (`src/sshpilot/window.py`, `src/sshpilot/window_dialogs.py`).
- Update plugin compatibility documentation to mark the GTK `connection_manager` surface as presentation-only and deprecated for persistence or secret access, and to recommend daemon-mediated APIs for plugins. (`docs/PLUGIN_SDK.md`).
- Add unit tests that assert rebuilding from daemon DTOs, event-driven updates, reconnect refresh semantics, stale-event rejection, and the absence of GTK-instantiated authoritative backends. (`tests/test_gtk_connection_presentation_store.py`).

### Testing

- Ran `python -m compileall -q src/sshpilot` to verify modules compile successfully, which completed without errors. 
- Executed the new and related unit tests with `pytest -q tests/test_gtk_connection_presentation_store.py tests/test_plugin_host.py`, and the test suite passed (tests related to the presentation store and plugin host passed).
- Ran `git diff --check` and repository status checks to ensure no outstanding formatting or whitespace issues remained after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7058b19a708328aa696ce0a5dafe49)