### PR TITLE
Fix GTK presentation-store dispatch and refresh races

### DIFF
--- a/src/sshpilot/gtk/connection_store.py
+++ b/src/sshpilot/gtk/connection_store.py
@@ -19,7 +19,9 @@ class ConnectionPresentationStore:
     or process APIs. ``on_changed`` lets a GTK adapter replace its list model.
     """
 
-    def __init__(self, *, on_changed: Optional[Callable[[Tuple[ConnectionSummary, ...]], None]] = None):
+    def __init__(self, *,
+                 dispatch: Optional[Callable[[Callable[[], None]], object]] = None,
+                 on_changed: Optional[Callable[[Tuple[ConnectionSummary, ...]], None]] = None):
         self._lock = RLock()
         self._by_id: Dict[str, ConnectionSummary] = {}
         self._client = None
@@ -29,6 +31,10 @@ class ConnectionPresentationStore:
         self._refresh_generation = 0
         self._pending_events = []
         self._on_changed = on_changed
+        # Core clients publish events on their dispatch thread.  Frontends must
+        # explicitly choose where observers run; the immediate default keeps
+        # this toolkit-independent and makes headless tests deterministic.
+        self._dispatch = dispatch or (lambda callback: callback())
         self._handlers = {}
         self._next_handler_id = 1
 
@@ -98,28 +104,79 @@ class ConnectionPresentationStore:
             lambda event: self._accept_event(event, generation, instance_id)
         )
         try:
-            self.rebuild(client.list_connections())
+            snapshot = self._resynchronize(client, generation, instance_id)
         except BaseException:
             subscription.unsubscribe()
             raise
         with self._lock:
-            pending = tuple(self._pending_events)
-            self._pending_events = []
-            self._refresh_generation = 0
             if generation != self._generation:
                 subscription.unsubscribe()
             else:
                 self._subscription = subscription
-        for event in sorted(pending, key=lambda item: item.sequence):
-            self._accept_event(event, generation, instance_id)
-        return self.snapshot()
+        return snapshot
 
     def refresh(self) -> Tuple[ConnectionSummary, ...]:
         with self._lock:
             client = self._client
+            generation = self._generation
+            instance_id = getattr(client, "server_instance_id", None)
+            if client is not None:
+                self._refresh_generation = generation
+                self._pending_events = []
         if client is not None:
-            self.rebuild(client.list_connections())
+            try:
+                return self._resynchronize(client, generation, instance_id)
+            except BaseException:
+                # A failed snapshot must not strand the store in buffering
+                # mode. Resume from the still-valid live projection and apply
+                # everything received while the request was in flight.
+                with self._lock:
+                    pending = tuple(self._pending_events)
+                    self._pending_events = []
+                    if self._refresh_generation == generation:
+                        self._refresh_generation = 0
+                for event in sorted(pending, key=lambda item: item.sequence):
+                    self._accept_event(event, generation, instance_id)
+                raise
         return self.snapshot()
+
+    def _resynchronize(self, client, generation: int,
+                       instance_id: Optional[str]) -> Tuple[ConnectionSummary, ...]:
+        """Replace a snapshot and buffered events without a live-mode gap."""
+        connections = client.list_connections()
+        replacement: Dict[str, ConnectionSummary] = {}
+        for connection in connections:
+            if not isinstance(connection, ConnectionSummary):
+                raise TypeError("presentation store only accepts ConnectionSummary DTOs")
+            replacement[connection.id] = connection
+
+        with self._lock:
+            if generation != self._generation or client is not self._client:
+                return tuple(self._by_id.values())
+            previous = self._by_id
+            self._by_id = replacement
+            # Keep the lock while draining. Event callbacks arriving during the
+            # replay block here and observe live mode only after replay ends.
+            pending = sorted(self._pending_events, key=lambda item: item.sequence)
+            self._pending_events = []
+            for event in pending:
+                self._apply_event_locked(event)
+            self._refresh_generation = 0
+            current = dict(self._by_id)
+            snapshot = tuple(current.values())
+
+        self._publish_projection_change(previous, current, snapshot)
+        return snapshot
+
+    def _publish_projection_change(self, previous, replacement, snapshot) -> None:
+        self._notify(snapshot)
+        for connection_id in previous.keys() - replacement.keys():
+            self._emit("connection-removed", previous[connection_id])
+        for connection_id in replacement.keys() - previous.keys():
+            self._emit("connection-added", replacement[connection_id])
+        for connection_id in replacement.keys() & previous.keys():
+            if replacement[connection_id] != previous[connection_id]:
+                self._emit("connection-updated", replacement[connection_id])
 
     def close(self) -> None:
         with self._lock:
@@ -139,25 +196,32 @@ class ConnectionPresentationStore:
             if self._refresh_generation == generation:
                 self._pending_events.append(event)
                 return
-            if event.sequence <= self._last_sequence:
+            if not self._apply_event_locked(event):
                 return
-            self._last_sequence = event.sequence
-            if event.type is EventType.CONNECTION_DELETED:
-                self._by_id.pop(event.payload.id, None)
-                signal_name = "connection-removed"
-            else:
-                self._by_id[event.payload.id] = event.payload
-                signal_name = ("connection-added" if event.type is EventType.CONNECTION_CREATED
-                               else "connection-updated")
+            signal_name = ("connection-removed" if event.type is EventType.CONNECTION_DELETED
+                           else "connection-added" if event.type is EventType.CONNECTION_CREATED
+                           else "connection-updated")
             snapshot = tuple(self._by_id.values())
         self._notify(snapshot)
         self._emit(signal_name, event.payload)
 
+    def _apply_event_locked(self, event: CoreEvent) -> bool:
+        if event.sequence <= self._last_sequence:
+            return False
+        self._last_sequence = event.sequence
+        if event.type is EventType.CONNECTION_DELETED:
+            self._by_id.pop(event.payload.id, None)
+        else:
+            self._by_id[event.payload.id] = event.payload
+        return True
+
     def _notify(self, snapshot: Tuple[ConnectionSummary, ...]) -> None:
         if self._on_changed is not None:
-            self._on_changed(snapshot)
+            self._dispatch(lambda: self._on_changed(snapshot))
 
     def _emit(self, signal_name: str, connection: ConnectionSummary) -> None:
-        for registered_name, callback in tuple(self._handlers.values()):
+        with self._lock:
+            handlers = tuple(self._handlers.values())
+        for registered_name, callback in handlers:
             if registered_name == signal_name:
-                callback(self, connection)
+                self._dispatch(lambda callback=callback: callback(self, connection))

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -237,7 +237,11 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         key_dir = Path(get_config_dir()) if effective_isolated else None
         # Compatibility attribute while call sites migrate terminology. This is
         # a DTO projection, never a persistence-capable backend manager.
-        self.connection_manager = ConnectionPresentationStore()
+        self.connection_manager = ConnectionPresentationStore(
+            dispatch=lambda callback: GLib.idle_add(
+                lambda: (callback(), GLib.SOURCE_REMOVE)[1]
+            )
+        )
 
         # Wire GTK interaction provider for core.interaction requests.
         try:

--- a/tests/test_gtk_connection_presentation_store.py
+++ b/tests/test_gtk_connection_presentation_store.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+from queue import Queue
+from threading import Barrier, Thread
 
 from sshpilot.api.events import CoreEvent, EventType
 from sshpilot.api.models.connections import ConnectionSummary
@@ -78,6 +80,57 @@ def test_reconnect_refreshes_and_ignores_old_daemon_events():
 
     assert old.subscription.closed
     assert new.list_calls == 1
+    assert store.snapshot() == (summary("new"),)
+
+
+def test_observers_are_marshaled_through_injected_dispatcher():
+    scheduled = Queue()
+    delivered = []
+    client = Client("daemon-a", [])
+    store = ConnectionPresentationStore(
+        dispatch=scheduled.put,
+        on_changed=delivered.append,
+    )
+
+    store.attach_client(client)
+    assert delivered == []
+    scheduled.get_nowait()()
+    assert delivered == [()]
+
+    worker = Thread(target=client.emit, args=(
+        EventType.CONNECTION_CREATED, summary("worker"), 1,
+    ))
+    worker.start()
+    worker.join()
+
+    assert delivered == [()]
+    scheduled.get_nowait()()
+    assert delivered[-1] == (summary("worker"),)
+
+
+def test_refresh_replays_event_arriving_while_snapshot_is_in_flight():
+    entered = Barrier(2)
+    release = Barrier(2)
+    client = Client("daemon-a", [summary("old")])
+    store = ConnectionPresentationStore()
+    store.attach_client(client)
+    original_list = client.list_connections
+
+    def blocked_list():
+        result = original_list()
+        entered.wait()
+        release.wait()
+        return result
+
+    client.list_connections = blocked_list
+    refresh_thread = Thread(target=store.refresh)
+    refresh_thread.start()
+    entered.wait()
+    client.emit(EventType.CONNECTION_DELETED, summary("old"), 10)
+    client.emit(EventType.CONNECTION_CREATED, summary("new"), 11)
+    release.wait()
+    refresh_thread.join()
+
     assert store.snapshot() == (summary("new"),)
 
 


### PR DESCRIPTION
### Motivation

- Prevent GTK UI callbacks from being invoked on the daemon/client event thread by giving the presentation store a pluggable dispatcher so frontends can marshal notifications to the main loop.
- Eliminate races where buffered daemon events could be lost during attach/refresh by introducing a single atomic resynchronization flow that installs the snapshot and replays buffered events in order.
- Make refresh behavior robust against snapshot failures so live processing resumes and in-flight events are not dropped.
- Add deterministic tests for dispatcher marshalling and a barrier-based refresh/event race to cover the new logic.

### Description

- Add an injectable `dispatch` callable to `ConnectionPresentationStore` and use it to deliver `on_changed` notifications and signal handlers instead of calling them inline. (src/sshpilot/gtk/connection_store.py)
- Configure `MainWindow` to pass a GTK dispatcher that uses `GLib.idle_add()` so presentation callbacks run on the GTK main thread. (src/sshpilot/window.py)
- Replace separate `rebuild()`/`refresh()` flows with an atomic `_resynchronize()` operation that: installs the authoritative snapshot, replays buffered events in sequence while holding the lock, clears buffering state, and then publishes projection diffs. (src/sshpilot/gtk/connection_store.py)
- Introduce `_apply_event_locked()` and `_publish_projection_change()` helpers to centralize event application and projection-diff emission. (src/sshpilot/gtk/connection_store.py)
- Ensure `refresh()` recovers live processing if the snapshot request raises by draining pending events and resuming live mode. (src/sshpilot/gtk/connection_store.py)
- Update signal emission to capture handlers under the lock but dispatch callbacks through the injected dispatcher to avoid running handler code on the daemon thread. (src/sshpilot/gtk/connection_store.py)
- Add deterministic tests that verify dispatcher marshalling and a barrier-controlled refresh/event race without timing sleeps. (tests/test_gtk_connection_presentation_store.py)

### Testing

- Ran `python -m pytest -q tests/test_gtk_connection_presentation_store.py` and the new store tests passed. (all tests in that file succeeded)
- Ran `python -m pytest -q tests/test_gtk_connection_presentation_store.py tests/test_plugin_context_connections.py tests/test_plugin_secrets.py` and the combined suite passed (16 tests total).
- Ran repository checks (`git diff --check` equivalent) and no style/whitespace problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a705eb89de48328bac271a2c7282e53)