### PR TITLE
Fix immutable GTK connection consumers

### DIFF
--- a/src/sshpilot/search_utils.py
+++ b/src/sshpilot/search_utils.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable, Optional
 
 
-def connection_matches(connection: Any, query: str) -> bool:
+def connection_matches(
+    connection: Any,
+    query: str,
+    *,
+    tags: Optional[Iterable[str]] = None,
+) -> bool:
     """Return True if connection matches the search query.
 
     The search checks the connection's nickname, SSH Host alias, HostName/IP
@@ -24,7 +29,7 @@ def connection_matches(connection: Any, query: str) -> bool:
         getattr(connection, "nickname", ""),
         getattr(connection, "host", ""),
         getattr(connection, "hostname", ""),
-        " ".join(getattr(connection, "tags", None) or []),
+        " ".join(tags if tags is not None else (getattr(connection, "tags", None) or [])),
     ]
     fields = [(field or "").lower() for field in fields]
     return all(

--- a/src/sshpilot/terminal.py
+++ b/src/sshpilot/terminal.py
@@ -179,6 +179,7 @@ class TerminalWidget(Gtk.Box):
         self.last_error_message = None  # Store last SSH error for reporting
         self._last_error_detail = None  # Structured context for the Details dialog
         self._fallback_timer_id = None  # GLib timeout ID for spawn fallback
+        self._connection_updated_handler = None
 
         # Job detection state
         self._job_status = "UNKNOWN"  # IDLE, RUNNING, PROMPT, UNKNOWN
@@ -210,9 +211,14 @@ class TerminalWidget(Gtk.Box):
         # Connect to signals
         self.connect('destroy', self._on_destroy)
 
-        # Connect to connection manager signals using GObject.GObject.connect directly
-        self._connection_updated_handler = GObject.GObject.connect(connection_manager, 'connection-updated', self._on_connection_updated_signal)
-        logger.debug("Connected to connection-updated signal")
+        # Depend on the manager's presentation subscription interface rather
+        # than requiring it to be a GObject.
+        connect_after = getattr(connection_manager, 'connect_after', None)
+        if callable(connect_after):
+            self._connection_updated_handler = connect_after(
+                'connection-updated', self._on_connection_updated_signal
+            )
+            logger.debug("Connected to connection-updated signal")
 
         # Create scrolled window for terminal
         self.scrolled_window = Gtk.ScrolledWindow()
@@ -3890,15 +3896,25 @@ class TerminalWidget(Gtk.Box):
                 logger.error(f"Error disconnecting backend signals: {e}")
 
         # Disconnect from connection manager signals
-        if hasattr(self, '_connection_updated_handler') and hasattr(self.connection_manager, 'disconnect'):
+        if self._connection_updated_handler is not None:
+            disconnect = getattr(self.connection_manager, 'disconnect', None)
             try:
-                self.connection_manager.disconnect(self._connection_updated_handler)
-                logger.debug("Disconnected from connection manager signals")
+                if callable(disconnect):
+                    disconnect(self._connection_updated_handler)
+                    logger.debug("Disconnected from connection manager signals")
             except Exception as e:
                 logger.error(f"Error disconnecting from connection manager: {e}")
+            finally:
+                self._connection_updated_handler = None
 
         # Disconnect the terminal
-        self.disconnect()
+        try:
+            self.disconnect()
+        except RuntimeError:
+            logger.debug(
+                "Ignoring cleanup of partially initialized terminal",
+                exc_info=True,
+            )
 
         # Remove custom controllers and disconnect config listeners
         try:

--- a/src/sshpilot/terminal_manager.py
+++ b/src/sshpilot/terminal_manager.py
@@ -1334,7 +1334,7 @@ class TerminalManager:
 
     # --- Controlled reconnect after a connection edit ----------------------
 
-    def prompt_reconnect(self, connection):
+    def prompt_reconnect(self, connection, terminal=None):
         """Ask whether to reconnect *connection* with its updated settings."""
         dialog = Adw.AlertDialog(
             heading=_("Settings Changed"),
@@ -1346,21 +1346,19 @@ class TerminalManager:
         dialog.set_response_appearance('reconnect', Adw.ResponseAppearance.SUGGESTED)
         dialog.set_default_response('reconnect')
         dialog.set_close_response('cancel')
-        dialog.connect('response', self._on_reconnect_response, connection)
+        dialog.connect('response', self._on_reconnect_response, connection, terminal)
         dialog.present(self.window)
 
-    def _on_reconnect_response(self, dialog, response, connection):
+    def _on_reconnect_response(self, dialog, response, connection, terminal=None):
         """Handle response from the reconnect prompt."""
         window = self.window
         # Only proceed if the user confirmed and the connection is still active
         if response != 'reconnect' or connection not in window.active_terminals:
-            # Clean up the stored terminal instance if it exists
-            if hasattr(connection, '_terminal_instance'):
-                delattr(connection, '_terminal_instance')
             return
 
-        # Get the terminal instance either from active_terminals or the stored instance
-        terminal = window.active_terminals.get(connection) or getattr(connection, '_terminal_instance', None)
+        # Prefer the active mapping, with the explicitly supplied terminal as
+        # a fallback. Connection presentation DTOs must remain immutable.
+        terminal = window.active_terminals.get(connection) or terminal
         if not terminal:
             logger.warning("No terminal instance found for reconnection")
             return
@@ -1408,10 +1406,6 @@ class TerminalManager:
             )
 
         finally:
-            # Clean up the stored terminal instance
-            if hasattr(connection, '_terminal_instance'):
-                delattr(connection, '_terminal_instance')
-
             # Reset the flag after a delay to ensure it's not set during normal operations
             GLib.timeout_add(1000, self._reset_controlled_reconnect)
 

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -3116,12 +3116,17 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
 
         # Get all connections
         connections = self.connection_manager.get_connections()
-        # Attach tags so the search filter and freshly built rows see them.
+        # Daemon DTOs are immutable. Tags remain GTK-owned metadata until they
+        # become part of the daemon presentation model, so keep them sidecar.
+        tags_by_id = {}
         for conn in connections:
             try:
-                conn.tags = self.config.get_connection_tags(conn.nickname)
+                tags_by_id[conn.id] = tuple(
+                    self.config.get_connection_tags(conn.nickname) or ()
+                )
             except Exception:
-                conn.tags = []
+                tags_by_id[conn.id] = ()
+        self._connection_tags_by_id = tags_by_id
         connections_dict = {conn.nickname: conn for conn in connections}
         connections_dict.update(
             {
@@ -3143,8 +3148,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
             matches = [
                 c for c in connections
                 if (not tag_filter or tag_filter in {str(t).casefold()
-                    for t in (getattr(c, 'tags', None) or [])})
-                and (not search_text or connection_matches(c, search_text))
+                    for t in tags_by_id.get(c.id, ())})
+                and (not search_text or connection_matches(
+                    c, search_text, tags=tags_by_id.get(c.id, ())))
             ]
             for conn in sorted(matches, key=lambda c: c.nickname.lower()):
                 self.add_connection_row(conn)
@@ -3154,8 +3160,9 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
         if tag_filter:
             matches = [
                 c for c in connections
-                if tag_filter in {str(t).casefold() for t in (getattr(c, 'tags', None) or [])}
-                and (not search_text or connection_matches(c, search_text))
+                if tag_filter in {str(t).casefold() for t in tags_by_id.get(c.id, ())}
+                and (not search_text or connection_matches(
+                    c, search_text, tags=tags_by_id.get(c.id, ())))
             ]
             for conn in sorted(matches, key=lambda c: c.nickname.lower()):
                 self.add_connection_row(conn)
@@ -3196,7 +3203,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
 
             matches = [
                 c for c in connections
-                if connection_matches(c, search_text)
+                if connection_matches(c, search_text, tags=tags_by_id.get(c.id, ()))
                 and c.id not in displayed_connections
             ]
             for conn in sorted(matches, key=lambda c: c.nickname.lower()):
@@ -6192,10 +6199,6 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                         self.config.set_connection_meta(new_nickname, merged)
                 except Exception:
                     logger.debug("Failed to migrate connection meta on rename", exc_info=True)
-            try:
-                old_connection.tags = self.config.get_connection_tags(old_connection.nickname)
-            except Exception:
-                pass
             rows = self._rows_for_connection(old_connection)
             if rows:
                 for row in rows:
@@ -6663,9 +6666,15 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                 tags_changed = False
                 try:
                     fresh_tags = self.config.get_connection_tags(old_connection.nickname)
-                    if list(getattr(old_connection, 'tags', None) or []) != fresh_tags:
+                    previous_tags = getattr(self, '_connection_tags_by_id', {}).get(
+                        old_connection.id, ()
+                    )
+                    if list(previous_tags) != fresh_tags:
                         tags_changed = True
-                    old_connection.tags = fresh_tags
+                    self._connection_tags_by_id = {
+                        **getattr(self, '_connection_tags_by_id', {}),
+                        old_connection.id: tuple(fresh_tags),
+                    }
                 except Exception:
                     pass
                 rows = self._rows_for_connection(old_connection)
@@ -6683,9 +6692,7 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
 
                 # If the connection is active, ask if user wants to reconnect
                 if is_connected and terminal is not None:
-                    # Store the terminal in the connection for later use
-                    old_connection._terminal_instance = terminal
-                    self.terminal_manager.prompt_reconnect(old_connection)
+                    self.terminal_manager.prompt_reconnect(old_connection, terminal)
                 _complete_save(True)
                 # Its own block changed: drop the stale result and recompute.
                 self._invalidate_effective_check(original_nickname)

--- a/tests/test_window_search_groups.py
+++ b/tests/test_window_search_groups.py
@@ -2,7 +2,7 @@ import importlib
 import sys
 import types
 
-from sshpilot.connection_manager import Connection
+from sshpilot.api.models.connections import ConnectionSummary
 
 
 class DummyRowBase:
@@ -66,6 +66,9 @@ class DummyConnectionManager:
 class DummyConfig:
     def get_setting(self, key, default=None):
         return default
+
+    def get_connection_tags(self, nickname):
+        return ["prod"] if nickname == "bastion" else []
 
 
 class DummyGroupManager:
@@ -133,12 +136,12 @@ def test_search_results_include_matching_groups(monkeypatch):
     original_matcher = window_module.connection_matches
     match_calls = []
 
-    def recording_match(connection, query):
+    def recording_match(connection, query, *, tags=None):
         fields = [
             getattr(connection, "nickname", ""),
             getattr(connection, "host", ""),
         ]
-        result = original_matcher(connection, query)
+        result = original_matcher(connection, query, tags=tags)
         match_calls.append((connection.nickname, query, fields, result))
         return result
 
@@ -156,8 +159,14 @@ def test_search_results_include_matching_groups(monkeypatch):
         }
     }
 
-    grouped_connection = Connection({"nickname": "prod-server", "host": "prod-01"})
-    direct_connection = Connection({"nickname": "prod-bastion", "host": "bastion"})
+    grouped_connection = ConnectionSummary(
+        id="prod-server", nickname="prod-server", host="prod-01",
+        hostname="prod-01", username="user", port=22,
+    )
+    direct_connection = ConnectionSummary(
+        id="bastion", nickname="bastion", host="bastion",
+        hostname="bastion", username="user", port=22,
+    )
 
     test_window = window_module.MainWindow.__new__(window_module.MainWindow)
     test_window.connection_list = DummyListBox()
@@ -170,7 +179,7 @@ def test_search_results_include_matching_groups(monkeypatch):
     test_window._hide_hosts = False
 
     assert original_matcher(grouped_connection, "prod")
-    assert original_matcher(direct_connection, "prod")
+    assert original_matcher(direct_connection, "prod", tags=("prod",))
 
     test_window.rebuild_connection_list()
 
@@ -182,18 +191,17 @@ def test_search_results_include_matching_groups(monkeypatch):
     assert group_rows[0].group_info["name"] == "Production"
     assert match_calls == [
         ("prod-server", "prod", ["prod-server", "prod-01"], True),
-        ("prod-bastion", "prod", ["prod-bastion", "bastion"], True),
+        ("bastion", "prod", ["bastion", "bastion"], True),
     ]
     assert added_connections == [
         ("prod-server", 1, "group-1"),
-        ("prod-bastion", 0, None),
+        ("bastion", 0, None),
     ]
 
     grouped_rows = [row for row in connection_rows if row.connection.nickname == "prod-server"]
     assert len(grouped_rows) == 1
     assert grouped_rows[0].indentation == 1
 
-    direct_rows = [row for row in connection_rows if row.connection.nickname == "prod-bastion"]
+    direct_rows = [row for row in connection_rows if row.connection.nickname == "bastion"]
     assert len(direct_rows) == 1
     assert direct_rows[0].indentation == 0
-


### PR DESCRIPTION
### Motivation

- Avoid mutating frozen `ConnectionSummary` DTOs from GTK code and eliminate TypeError/FrozenInstanceError during sidebar rebuilds.
- Stop requiring `ConnectionPresentationStore` consumers to be `GObject` instances and make `TerminalWidget` subscribe via a presentation subscription interface.
- Make terminal teardown robust to partial initialization so cleanup does not raise during failed construction.
- Preserve transient terminal state (for reconnect flows) without attaching it to immutable daemon DTOs.

### Description

- Keep GTK-side tags in an ID-keyed sidecar mapping (`_connection_tags_by_id`) instead of assigning `conn.tags`, and pass tags explicitly into search/filter logic. (`window.py`, `search_utils.py`).
- Extend `connection_matches()` with an optional `tags` parameter so callers can match against presentation-owned tags without mutating DTOs. (`search_utils.py`).
- Subscribe `TerminalWidget` to connection updates via the store's `connect_after()` adapter when available and call the store's `disconnect()` adapter on teardown, removing the direct `GObject.GObject.connect()` dependency. (`terminal.py`).
- Make `_on_destroy()` tolerant of partially-initialized terminals by catching `RuntimeError` from `disconnect()` and clearing the handler safely. (`terminal.py`).
- Avoid attaching transient `_terminal_instance` state to immutable connection DTOs by passing the terminal explicitly through `prompt_reconnect()`/`_on_reconnect_response()` instead. (`terminal_manager.py`, `window.py`).
- Update the sidebar/group-search test to exercise real frozen `ConnectionSummary` objects and to validate the new tags sidecar/search behavior. (`tests/test_window_search_groups.py`).

### Testing

- Ran `python -m compileall -q src/sshpilot` successfully to ensure the tree compiles. 
- Ran focused GTK/presentation tests with `pytest -q tests/test_search_utils.py tests/test_window_search_groups.py tests/test_gtk_connection_presentation_store.py tests/test_gui_daemon_terminal.py` which completed as `18 passed, 1 skipped`.
- Ran the full test suite with `pytest -q`, yielding `2763 passed, 108 skipped` with 9 unrelated existing failures remaining in bulk-delete/mutation refresh mocks and SSH-config monitor tests that are outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70628d58c48328a5a9083135dec1fb)