### PR TITLE
Security: keep SSH key passphrases out of argv and logs

### DIFF
--- a/src/sshpilot/askpass_utils.py
+++ b/src/sshpilot/askpass_utils.py
@@ -1,5 +1,6 @@
 # askpass_utils.py
 import atexit
+from contextlib import contextmanager
 import logging
 import os
 import re
@@ -192,7 +193,9 @@ def _sweep_stale_session_files(directory: "str | None") -> None:
     try:
         now = time.time()
         for name in os.listdir(directory or tempfile.gettempdir()):
-            if not name.startswith('sshpilot-pw-'):
+            if not name.startswith(
+                ("sshpilot-pw-", "sshpilot-passphrase-")
+            ):
                 continue
             path = os.path.join(directory or tempfile.gettempdir(), name)
             try:
@@ -283,6 +286,40 @@ def stage_session_password(password: str) -> "dict[str, str]":
     path = _stage_session_password_file(password)
     return {"SSHPILOT_SESSION_PASSWORD_FILE": path} if path else {}
 
+@contextmanager
+def staged_session_passphrase(passphrase: str):
+    """Stage *passphrase* in a scoped 0600 file for repeated AskPass reads."""
+    if not passphrase:
+        raise ValueError("A non-empty passphrase is required")
+
+    directory = _session_password_dir()
+    _sweep_stale_session_files(directory)
+
+    fd, path = tempfile.mkstemp(
+        prefix="sshpilot-passphrase-",
+        dir=directory,
+        text=False,
+    )
+
+    try:
+        try:
+            os.write(fd, passphrase.encode())
+        finally:
+            os.close(fd)
+
+        os.chmod(path, 0o600)
+        yield path
+
+    finally:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except Exception:
+            logger.debug(
+                "Unable to remove staged passphrase file: %s",
+                path,
+            )
 
 def lookup_ssh_password(host: str, username: str) -> str:
     """Look up a stored SSH login password via the selected secret backend."""
@@ -1079,23 +1116,26 @@ def _handle_password_prompt(prompt: str, log_fn) -> "str | None":
     )
 
 
-def _resolve_passphrase_for_askpass(key_path: str, log_fn) -> "str | None":
-    """Resolve a key passphrase from session file, local store, or main-app IPC."""
-    # Check one-shot session passphrase written by the main app
+def _read_staged_session_passphrase(log_fn) -> "str | None":
+    """Read a scoped session passphrase exactly, without consuming its file."""
     session_passphrase_file = os.environ.get("SSHPILOT_SESSION_PASSPHRASE_FILE", "")
     if session_passphrase_file and os.path.exists(session_passphrase_file):
         try:
-            with open(session_passphrase_file, encoding="utf-8") as f:
-                session_passphrase = f.read().strip()
+            with open(session_passphrase_file, "rb") as f:
+                session_passphrase = f.read().decode()
             if session_passphrase:
                 log_fn("ASKPASS: Found session passphrase from secure temp file")
-                try:
-                    os.unlink(session_passphrase_file)
-                except Exception:
-                    pass
                 return session_passphrase
         except Exception as exc:
             log_fn(f"ASKPASS: Error reading session passphrase file: {exc}")
+    return None
+
+
+def _resolve_passphrase_for_askpass(key_path: str, log_fn) -> "str | None":
+    """Resolve a key passphrase from session file, local store, or main-app IPC."""
+    session_passphrase = _read_staged_session_passphrase(log_fn)
+    if session_passphrase is not None:
+        return session_passphrase
 
     # Resolve from storage. Two routes:
     #   * local — read the selected backend in this subprocess. Instant for the
@@ -1243,6 +1283,13 @@ def handle_askpass_cli(prompt: str) -> "str | None":
         )
 
     key_path = _extract_key_path(prompt)
+    # New-key generation prompts do not include a key path and occur twice.
+    # A scoped session file is authoritative for this subprocess and remains
+    # available until its parent command exits.
+    if os.environ.get("SSHPILOT_SESSION_PASSPHRASE_FILE"):
+        session_passphrase = _read_staged_session_passphrase(_log)
+        if session_passphrase is not None:
+            return session_passphrase
     if not key_path:
         _log("ASKPASS: Could not extract key path from prompt")
         return None
@@ -1584,6 +1631,7 @@ def get_ssh_env_with_askpass(
         env.pop("SSHPILOT_PASSWORD_HOSTS", None)
     env.pop("SSHPILOT_SESSION_PASSWORD_ID", None)
     env.pop("SSHPILOT_SESSION_PASSWORD_FILE", None)
+    env.pop("SSHPILOT_SESSION_PASSPHRASE_FILE", None)
     if session_password:
         env.update(stage_session_password(session_password))
     return env

--- a/src/sshpilot/key_manager.py
+++ b/src/sshpilot/key_manager.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Dict
 
 from gi.repository import GObject
 
+from .askpass_utils import get_ssh_env_with_askpass, staged_session_passphrase
 from .platform_utils import get_ssh_dir
 from .key_utils import _SKIPPED_FILENAMES as _SHARED_SKIPPED_FILENAMES, _is_private_key
 
@@ -164,10 +165,28 @@ class KeyManager(GObject.Object):
             cmd += ["-C", comment]
 
             cmd += ["-f", str(key_path)]
-            cmd += ["-N", passphrase or ""]  # empty => no passphrase
-
-            logger.debug("Running ssh-keygen: %s", " ".join(cmd))
-            completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            logger.debug("Running ssh-keygen for key path: %s", key_path)
+            if passphrase:
+                env = get_ssh_env_with_askpass("force")
+                with staged_session_passphrase(passphrase) as passphrase_file:
+                    env["SSHPILOT_SESSION_PASSPHRASE_FILE"] = passphrase_file
+                    completed = subprocess.run(
+                        cmd,
+                        env=env,
+                        stdin=subprocess.DEVNULL,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+            else:
+                # An explicit empty value keeps unencrypted generation
+                # non-interactive without exposing a secret.
+                completed = subprocess.run(
+                    [*cmd, "-N", ""],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
 
             if completed.returncode != 0:
                 # Surface stderr as the UI message
@@ -189,6 +208,12 @@ class KeyManager(GObject.Object):
             return key
 
         except Exception as e:
-            logger.error("Key generation failed: %s", e, exc_info=True)
+            if passphrase:
+                # Exception messages from encoding/process boundaries are not
+                # trusted to exclude their input. Never route a passphrase-adjacent
+                # exception through logging.
+                logger.error("Passphrase-protected key generation failed")
+            else:
+                logger.error("Key generation failed: %s", e, exc_info=True)
             # Re-raise the exception so the UI can handle it properly
             raise

--- a/src/sshpilot/ssh_connection_validator.py
+++ b/src/sshpilot/ssh_connection_validator.py
@@ -15,6 +15,8 @@ import subprocess
 
 from gettext import gettext as _
 
+from .askpass_utils import get_ssh_env_with_askpass, staged_session_passphrase
+
 logger = logging.getLogger(__name__)
 
 
@@ -191,10 +193,36 @@ class SSHConnectionValidator:
             return False
 
         try:
-            # Run ssh-keygen -y to test the passphrase
-            result = subprocess.run([
-                'ssh-keygen', '-y', '-P', passphrase, '-f', key_path
-            ], capture_output=True, text=True, timeout=10)
+            # Run ssh-keygen -y with the existing AskPass helper. The secret is
+            # staged in a scoped file and never placed in argv or the env.
+            cmd = ['ssh-keygen', '-y', '-f', key_path]
+            if passphrase:
+                env = get_ssh_env_with_askpass("force")
+                with staged_session_passphrase(passphrase) as passphrase_file:
+                    env["SSHPILOT_SESSION_PASSPHRASE_FILE"] = passphrase_file
+                    result = subprocess.run(
+                        cmd,
+                        env=env,
+                        stdin=subprocess.DEVNULL,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+            else:
+                result = subprocess.run(
+                    [
+                        "ssh-keygen",
+                        "-y",
+                        "-P",
+                        "",
+                        "-f",
+                        key_path,
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
 
             # Exit code 0 means the passphrase is valid
             return result.returncode == 0
@@ -205,5 +233,8 @@ class SSHConnectionValidator:
             # This shouldn't happen since we're capturing output, but handle it
             return False
         except Exception as e:
-            logger.error(f"Error verifying passphrase for key {key_path}: {e}")
+            if passphrase:
+                logger.error("Error verifying passphrase for key %s", key_path)
+            else:
+                logger.error("Error checking unencrypted key %s: %s", key_path, e)
             return False

--- a/tests/test_key_passphrase_security.py
+++ b/tests/test_key_passphrase_security.py
@@ -1,0 +1,170 @@
+import logging
+import os
+import stat
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from sshpilot.askpass_utils import handle_askpass_cli, staged_session_passphrase
+from sshpilot.key_manager import KeyManager
+from sshpilot.ssh_connection_validator import SSHConnectionValidator
+
+
+SECRET = "  leading and trailing passphrase\t "
+
+
+def _successful_result():
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _assert_mode_0600(path):
+    # Windows' stat result maps every writable regular file to 0666; POSIX
+    # permission bits are meaningful (and enforced) on the project's Unix
+    # runtime targets and CI.
+    if os.name != "nt":
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_staged_passphrase_is_0600_reusable_exact_and_removed(monkeypatch):
+    staged_path = None
+
+    with staged_session_passphrase(SECRET) as path:
+        staged_path = path
+        _assert_mode_0600(path)
+        assert Path(path).read_text(encoding="utf-8") == SECRET
+
+        monkeypatch.setenv("SSHPILOT_SESSION_PASSPHRASE_FILE", path)
+        assert handle_askpass_cli("Enter passphrase (empty for no passphrase):") == SECRET
+        assert handle_askpass_cli("Enter same passphrase again:") == SECRET
+        assert os.path.exists(path)
+
+    assert staged_path is not None
+    assert not os.path.exists(staged_path)
+
+
+def test_staged_passphrase_is_removed_when_command_raises():
+    staged_path = None
+
+    try:
+        with staged_session_passphrase(SECRET) as path:
+            staged_path = path
+            raise RuntimeError("simulated command failure")
+    except RuntimeError:
+        pass
+
+    assert staged_path is not None
+    assert not os.path.exists(staged_path)
+
+
+def test_sweep_removes_only_stale_staged_passphrase_files(monkeypatch, tmp_path):
+    from sshpilot.askpass_utils import (
+        _SESSION_PASSWORD_TTL,
+        _sweep_stale_session_files,
+    )
+
+    now = 1_000_000.0
+    stale_path = tmp_path / "sshpilot-passphrase-stale"
+    fresh_path = tmp_path / "sshpilot-passphrase-fresh"
+    stale_path.write_text("stale", encoding="utf-8")
+    fresh_path.write_text("fresh", encoding="utf-8")
+    stale_time = now - _SESSION_PASSWORD_TTL - 1
+    os.utime(stale_path, (stale_time, stale_time))
+    os.utime(fresh_path, (now, now))
+    monkeypatch.setattr("sshpilot.askpass_utils.time.time", lambda: now)
+
+    _sweep_stale_session_files(str(tmp_path))
+
+    assert not stale_path.exists()
+    assert fresh_path.exists()
+
+
+def test_generate_key_keeps_passphrase_out_of_argv_env_and_logs(
+    monkeypatch, tmp_path, caplog
+):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        key_path = Path(argv[argv.index("-f") + 1])
+        key_path.write_text("private", encoding="utf-8")
+        Path(f"{key_path}.pub").write_text("public", encoding="utf-8")
+        passphrase_file = kwargs["env"]["SSHPILOT_SESSION_PASSPHRASE_FILE"]
+        _assert_mode_0600(passphrase_file)
+        assert Path(passphrase_file).read_text(encoding="utf-8") == SECRET
+        return _successful_result()
+
+    monkeypatch.setattr(
+        "sshpilot.key_manager.get_ssh_env_with_askpass",
+        lambda _require: {"SAFE_VALUE": "visible"},
+    )
+    monkeypatch.setattr("sshpilot.key_manager.subprocess.run", fake_run)
+
+    manager = KeyManager(tmp_path)
+    monkeypatch.setattr(manager, "emit", lambda *_args: None, raising=False)
+    caplog.set_level(logging.DEBUG)
+    key = manager.generate_key("id_secure", passphrase=SECRET)
+
+    assert key is not None
+    argv, kwargs = calls[0]
+    assert SECRET not in argv
+    assert "-N" not in argv
+    assert all(SECRET not in str(value) for value in kwargs["env"].values())
+    staged_path = kwargs["env"]["SSHPILOT_SESSION_PASSPHRASE_FILE"]
+    assert not os.path.exists(staged_path)
+    assert SECRET not in caplog.text
+
+
+def test_verify_key_passphrase_keeps_secret_out_of_argv_and_env(
+    monkeypatch, tmp_path, caplog
+):
+    key_path = tmp_path / "id_secure"
+    key_path.write_text("private", encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        passphrase_file = kwargs["env"]["SSHPILOT_SESSION_PASSPHRASE_FILE"]
+        assert Path(passphrase_file).read_text(encoding="utf-8") == SECRET
+        return _successful_result()
+
+    monkeypatch.setattr(
+        "sshpilot.ssh_connection_validator.get_ssh_env_with_askpass",
+        lambda _require: {"SAFE_VALUE": "visible"},
+    )
+    monkeypatch.setattr(
+        "sshpilot.ssh_connection_validator.subprocess.run", fake_run
+    )
+
+    caplog.set_level(logging.DEBUG)
+    assert SSHConnectionValidator().verify_key_passphrase(str(key_path), SECRET)
+
+    argv, kwargs = calls[0]
+    assert SECRET not in argv
+    assert "-P" not in argv
+    assert all(SECRET not in str(value) for value in kwargs["env"].values())
+    staged_path = kwargs["env"]["SSHPILOT_SESSION_PASSPHRASE_FILE"]
+    assert not os.path.exists(staged_path)
+    assert SECRET not in caplog.text
+
+
+def test_verify_key_passphrase_empty_uses_explicit_empty_passphrase(
+    monkeypatch, tmp_path
+):
+    key_path = tmp_path / "id_unencrypted"
+    key_path.write_text("private", encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _successful_result()
+
+    monkeypatch.setattr(
+        "sshpilot.ssh_connection_validator.subprocess.run", fake_run
+    )
+
+    assert SSHConnectionValidator().verify_key_passphrase(str(key_path), "")
+
+    argv, kwargs = calls[0]
+    assert argv == ["ssh-keygen", "-y", "-P", "", "-f", str(key_path)]
+    assert "env" not in kwargs
+    assert kwargs["stdin"] is subprocess.DEVNULL


### PR DESCRIPTION
Closes #1144

Summary

This fixes SSH private-key passphrase exposure through ssh-keygen process arguments and debug logging.

The implementation reuses sshPilot's existing AskPass infrastructure and does not introduce a separate authentication path.

Changes
Remove non-empty SSH key passphrases from ssh-keygen argv during key generation.
Remove non-empty passphrases from ssh-keygen -P verification.
Stop logging secret-bearing ssh-keygen command lines.
Reuse the existing AskPass infrastructure with SSH_ASKPASS_REQUIRE=force.
Stage transient key passphrases in a mode-0600 runtime file and expose only its path to the child process.
Preserve passphrases exactly, including leading/trailing whitespace.
Support repeated AskPass reads because ssh-keygen requests a new-key passphrase twice.
Remove staged passphrase files after subprocess completion or exceptions.
Clean up stale staged passphrase files from interrupted runs.
Keep empty-passphrase operations explicitly non-interactive with -N "" / -P "".
Tests

Added regression coverage for:

passphrase absence from subprocess argv
passphrase absence from direct environment values
passphrase absence from logs
mode-0600 staged secret files on POSIX
repeated AskPass reads
exact whitespace preservation
cleanup after normal completion and exceptions
stale secret-file cleanup
explicit empty-passphrase verification
Validation

pytest -v tests/test_key_passphrase_security.py

6 passed

ruff check src/ tests/

Passed

git diff --check

Passed

The broader test suite was also attempted on Windows. Existing Unix-specific tests could not be fully collected because the Windows environment does not provide modules such as pwd and resource, and several AskPass tests depend on POSIX path/symlink behavior and socket.AF_UNIX.

The focused security regression suite passes.