### PR TITLE
Fix macOS PTY smoke test client bugs; add PATH/verbose diagnostics

### DIFF
--- a/scripts/verify_macos_pty_spawn.py
+++ b/scripts/verify_macos_pty_spawn.py
@@ -242,10 +242,20 @@ def main() -> int:
                 "PATH": f"{fake_bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
             }
         )
+        print(f"daemon PATH (as launched): {environment['PATH']}", file=sys.stderr)
         log_path = temp / "daemon.log"
         with log_path.open("w+") as log_file:
+            # --verbose: on a failure this script dumps daemon.log to stderr
+            # (see the except block below). Without DEBUG level, that dump
+            # can't show which "ssh" the daemon's own subprocess calls
+            # actually resolved to — the readiness probe logs
+            # ("ssh readiness probe/capability for <path>: ...") are the
+            # only direct evidence of whether PATH-shadowing (see
+            # _write_fake_ssh) is actually reaching the daemon's env in a
+            # packaged build, as opposed to a real system ssh silently
+            # taking over.
             process = subprocess.Popen(
-                [str(executable), "--daemon", "--socket", str(socket_path)],
+                [str(executable), "--daemon", "--verbose", "--socket", str(socket_path)],
                 stdin=subprocess.DEVNULL,
                 stdout=log_file,
                 stderr=subprocess.STDOUT,


### PR DESCRIPTION
## Summary

Follow-up to #1168. That PR fixed two real bugs in
`scripts/verify_macos_pty_spawn.py`'s test client (subscribe-before-attach
ordering, and extending from the raw `TerminalOutput` event instead of
`.data`), confirmed by the next CI run: the client now receives real bytes
instead of silently dropping them.

But those bytes turned out to be genuine OpenSSH output
(`Warning: Permanently added '127.0.0.1' (ED25519) to the list of known
hosts.`) plus a real password-interaction prompt — the daemon spawned the
system `ssh` against a real local sshd on the runner, not this test's
PATH-shadowed fake `ssh` stand-in. My local reproduction (Linux, non-frozen)
never caught this: `sys.frozen` is false there, so it never exercised the
packaged build's `--internal-pty-child` re-exec path, where PATH-shadowing
apparently isn't reaching the daemon's actual `ssh` invocation.

This PR adds diagnostics only, no behavior change:
- Daemon launched with `--verbose`, so a failure's `daemon.log` dump
  includes the `ssh_readiness` DEBUG lines showing what `ssh` each
  daemon-issued probe actually resolved to.
- Prints the test's own constructed `PATH` up front for comparison.

Goal: get concrete evidence from the next manual-dispatch CI run on whether
PATH-shadowing never reached the daemon's environment at all, or was lost
partway through the packaged re-exec — before attempting a real fix.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary

## Testing

- `python3 -m py_compile scripts/verify_macos_pty_spawn.py`
- Ran the smoke test locally (Linux, non-frozen daemon) against a fake
  bundle wrapper — passes cleanly; this path was already exercised by #1168
  and is unaffected by this diagnostics-only change.
- Real validation requires the manual `workflow_dispatch` run of
  "Build macOS PyInstaller Bundle" on macOS CI, not available locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYWcmTP9CC93cU4y6iCxpr)_