### PR TITLE
Fix Browse button still hidden behind modal for specific-key selectio…

### DIFF
--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -904,7 +904,12 @@ class KeyChooserDialog(Adw.Window):
                 self._on_add(path)
             self.close()
         try:
-            self._on_browse(_chosen)
+            # Pass THIS dialog as the parent: it's the topmost window the
+            # user is looking at when they click Browse, stacked above
+            # ConnectionDialog. Letting the callback default to
+            # ConnectionDialog would reopen the file chooser one layer below
+            # the visible modal (issue #1103 regression).
+            self._on_browse(_chosen, self)
         except Exception:
             logger.debug("Key chooser browse failed", exc_info=True)
 
@@ -2060,7 +2065,7 @@ class ConnectionDialog(
             logger.debug("Certificate discovery failed", exc_info=True)
         return out
 
-    def _browse_file(self, title, on_chosen, filters=None):
+    def _browse_file(self, title, on_chosen, filters=None, parent=None):
         try:
             dialog = Gtk.FileDialog(title=title)
             try:
@@ -2080,12 +2085,17 @@ class ConnectionDialog(
                 except Exception:
                     logger.debug("File chooser cancelled or failed", exc_info=True)
 
-            # Parent the chooser to THIS dialog — the window the user is
-            # looking at — never to ``get_transient_for()``. The connection
-            # dialog is modal and stacked above its transient parent, so a
-            # chooser parented to the MainWindow opens invisibly behind the
-            # modal dialog on Wayland portal stacks (issue #1103).
-            dialog.open(self, None, _done)
+            # Parent the chooser to THE WINDOW THE USER IS ACTUALLY LOOKING
+            # AT — never to ``get_transient_for()`` and never unconditionally
+            # to ``self`` (this ConnectionDialog). ConnectionDialog is modal
+            # and stacked above its transient parent, so a chooser parented
+            # to the MainWindow opens invisibly behind the modal dialog on
+            # Wayland portal stacks (issue #1103). But when browsing is
+            # triggered from a dialog stacked *above* ConnectionDialog (e.g.
+            # KeyChooserDialog), the caller must pass that dialog as
+            # ``parent`` — otherwise the same "hidden behind a modal" bug
+            # reappears one layer up (issue #1103 regression).
+            dialog.open(parent or self, None, _done)
         except Exception:
             logger.debug("Failed to open file chooser", exc_info=True)
 
@@ -2118,10 +2128,10 @@ class ConnectionDialog(
         )
         dialog.present()
 
-    def _browse_key(self, on_chosen):
-        self._browse_file(_("Select SSH Key File"), on_chosen)
+    def _browse_key(self, on_chosen, parent=None):
+        self._browse_file(_("Select SSH Key File"), on_chosen, parent=parent)
 
-    def _browse_cert(self, on_chosen):
+    def _browse_cert(self, on_chosen, parent=None):
         filters = None
         try:
             cert_filter = Gtk.FileFilter()
@@ -2136,7 +2146,7 @@ class ConnectionDialog(
             filters.append(all_filter)
         except Exception:
             filters = None
-        self._browse_file(_("Select SSH Certificate File"), on_chosen, filters=filters)
+        self._browse_file(_("Select SSH Certificate File"), on_chosen, filters=filters, parent=parent)
 
     def _generate_ssh_config_from_settings(self):
         """Generate SSH config block from current connection settings"""

--- a/tests/test_connection_dialog_fixes.py
+++ b/tests/test_connection_dialog_fixes.py
@@ -194,3 +194,76 @@ def test_browse_file_delivers_chosen_path(monkeypatch, tmp_path):
     holder["callback"](holder["dialog"], object())
 
     assert chosen == ["/home/alice/.ssh/id_ed25519"]
+
+
+def test_browse_key_uses_explicit_parent_when_given(monkeypatch, tmp_path):
+    """``_browse_key``/``_browse_file`` must parent the chooser to an explicit
+    ``parent`` when one is supplied, not fall back to ``self`` (ConnectionDialog).
+
+    This is the regression from issue #1103: the key-selection flow opens
+    ``KeyChooserDialog`` *above* ConnectionDialog, and its "Browse..." row
+    calls back into ConnectionDialog._browse_key. Always parenting to
+    ConnectionDialog reopens the file chooser one window layer below the
+    modal the user is actually looking at, so it appears hidden again."""
+    from sshpilot import connection_dialog as cd
+    from sshpilot.connection_dialog import ConnectionDialog
+
+    opened = []
+
+    class _FakeDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_initial_folder(self, gfile):
+            pass
+
+        def set_filters(self, filters):
+            pass
+
+        def open(self, parent, _cancellable, _callback):
+            opened.append(parent)
+
+    monkeypatch.setattr(cd.Gtk, "FileDialog", _FakeDialog)
+    monkeypatch.setattr(cd, "get_ssh_dir", lambda: str(tmp_path))
+
+    connection_dialog_self = types.SimpleNamespace(
+        get_transient_for=lambda: cd.Gtk.Window.__new__(cd.Gtk.Window))
+    connection_dialog_self._browse_file = types.MethodType(
+        ConnectionDialog.__dict__["_browse_file"], connection_dialog_self)
+    key_chooser_dialog = types.SimpleNamespace(name="key-chooser")
+
+    browse_key = types.MethodType(
+        ConnectionDialog.__dict__["_browse_key"], connection_dialog_self)
+    browse_key(lambda path: None, key_chooser_dialog)
+
+    assert opened == [key_chooser_dialog], (
+        "Browsing from within KeyChooserDialog must parent the file "
+        "chooser to KeyChooserDialog (the visible topmost window), not "
+        "to ConnectionDialog underneath it"
+    )
+
+
+def test_key_chooser_dialog_passes_itself_as_browse_parent():
+    """KeyChooserDialog._on_browse_clicked must hand itself to the on_browse
+    callback so the eventual file chooser parents to the dialog the user is
+    actually looking at."""
+    from sshpilot.connection_dialog import KeyChooserDialog
+
+    calls = []
+
+    def fake_on_browse(chosen, parent):
+        calls.append(parent)
+
+    self = types.SimpleNamespace(
+        _on_add=lambda path: None,
+        _on_browse=fake_on_browse,
+        close=lambda: None,
+    )
+
+    method = KeyChooserDialog.__dict__["_on_browse_clicked"]
+    types.MethodType(method, self)()
+
+    assert calls == [self], (
+        "KeyChooserDialog must pass itself as the parent for the browse "
+        "callback, not rely on the callback defaulting to some other window"
+    )


### PR DESCRIPTION
…n (#1103)

The earlier fix parented the Gtk.FileDialog to ConnectionDialog instead of the MainWindow so it wouldn't open behind the modal connection dialog. But the "Use Specific Key(s)" flow opens a further KeyChooserDialog on top of ConnectionDialog, and its "Browse..." row called back into ConnectionDialog._browse_key, which still parented the chooser to ConnectionDialog — one window layer below the dialog actually on screen. On Wayland portal stacks this reproduced the exact same "Browse does nothing" symptom, just one level up.

_browse_file/_browse_key/_browse_cert now accept an explicit parent, and KeyChooserDialog passes itself when invoking the browse callback so the chooser parents to whatever window the user is actually looking at.

## Summary

Describe the user-visible or technical outcome and how it was validated.

## API and architecture

- [ ] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary
- [ ] Public DTOs or client methods were updated
- [ ] Capabilities were updated and only implemented support is advertised
- [ ] Events and structured errors were updated
- [ ] State, ordering, threading, cancellation, and security semantics were reviewed
- [ ] Contract tests were updated
- [ ] API documentation was updated
- [ ] `docs/api/CHANGELOG.md` was updated
- [ ] Compatibility and protocol-version impact were reviewed
- [ ] Generated API artifacts and the public-surface snapshot were deliberately refreshed

For an API-affecting change, complete the applicable items above and explain
any intentionally deferred client or transport work.

## Testing

List the commands run and any checks that were not available.
