### PR TITLE
Fix macOS daemon startup deadlock on API version mismatch

### DIFF
--- a/src/sshpilot/api/daemon_client.py
+++ b/src/sshpilot/api/daemon_client.py
@@ -507,6 +507,7 @@ class DaemonClient:
         client_id: Optional[str] = None,
         frontend_type: Optional[str] = None,
         event_dispatch_limit: int = DEFAULT_CLIENT_EVENT_DISPATCH_LIMIT,
+        allow_api_mismatch: bool = False,
     ) -> None:
         if type(timeout) not in (int, float) or timeout <= 0:
             raise ValueError("daemon request timeout must be positive")
@@ -556,6 +557,8 @@ class DaemonClient:
         self._daemon_started_at: str = ""
         self._development_revision: str = ""
         self._daemon_api_implementation_version: str = ""
+        self._allow_api_mismatch = bool(allow_api_mismatch)
+        self._api_mismatch = False
         try:
             self._connect_and_handshake()
         except BaseException:
@@ -589,6 +592,20 @@ class DaemonClient:
     @property
     def development_revision(self) -> str:
         return self._development_revision
+
+    @property
+    def api_mismatch(self) -> bool:
+        """True when this client only connected because of ``allow_api_mismatch``.
+
+        Such a client speaks a compatible wire protocol but the peer is
+        running a different sshPilot build (typically a daemon left over
+        from a previous app version). It exists solely so an explicit,
+        user-confirmed recovery action can query status and request a
+        stop/restart of that stale peer; ordinary read/write RPCs are not
+        guaranteed to decode correctly against its DTOs and must not be
+        issued through this client.
+        """
+        return self._api_mismatch
 
     def build_mismatch(self) -> Optional[str]:
         """Return a safe reason when the daemon build looks stale, else None.
@@ -2903,12 +2920,21 @@ class DaemonClient:
             # Protocol v1 while disagreeing about protected-input and DTO
             # contracts. Reject it before normal RPCs; never downgrade a
             # secret operation or select a frontend backend.
-            error = DaemonRestartRequiredError(
-                "The background daemon uses an incompatible API implementation. "
-                "Restart the daemon/application before continuing."
-            )
-            self._fail_transport(error)
-            raise error
+            if not self._allow_api_mismatch:
+                error = DaemonRestartRequiredError(
+                    "The background daemon uses an incompatible API implementation. "
+                    "Restart the daemon/application before continuing."
+                )
+                self._fail_transport(error)
+                raise error
+            # Explicit, caller-confirmed recovery mode: keep the connection
+            # open so administrative status/stop/restart calls can reach and
+            # replace a stale peer. Capabilities are still fetched below (the
+            # capability list itself is part of the stable protocol surface)
+            # so ``_require_capability`` keeps working for those calls, but
+            # callers must never issue ordinary data RPCs through this
+            # client — its other DTOs are not guaranteed compatible.
+            self._api_mismatch = True
         capabilities = self._request("system.get_capabilities", {})
         try:
             self._capabilities = capabilities_from_wire(capabilities)

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -3902,21 +3902,22 @@ class PreferencesWindow(Adw.NavigationPage):
         try:
             from .api.daemon_client import DaemonClient
 
-            client = DaemonClient(timeout=1.0)
+            client = DaemonClient(timeout=1.0, allow_api_mismatch=True)
             try:
                 status = client.get_daemon_status()
                 resources = status.resources
-                row.set_subtitle(
-                    _(
-                        "{state} · instance {instance} · "
-                        "{sessions} sessions · {clients} clients"
-                    ).format(
-                        state=status.state.value,
-                        instance=status.server_instance_id[:8],
-                        sessions=resources.sessions_active,
-                        clients=resources.clients,
-                    )
+                subtitle = _(
+                    "{state} · instance {instance} · "
+                    "{sessions} sessions · {clients} clients"
+                ).format(
+                    state=status.state.value,
+                    instance=status.server_instance_id[:8],
+                    sessions=resources.sessions_active,
+                    clients=resources.clients,
                 )
+                if client.api_mismatch:
+                    subtitle += " · " + _("different app version — restart required")
+                row.set_subtitle(subtitle)
             finally:
                 client.close()
         except Exception as exc:
@@ -3978,7 +3979,7 @@ class PreferencesWindow(Adw.NavigationPage):
             from .api.daemon_client import DaemonClient
             from .api.models.daemon import RestartDaemonRequest
 
-            client = DaemonClient(timeout=2.0)
+            client = DaemonClient(timeout=2.0, allow_api_mismatch=True)
             try:
                 client.get_daemon_status()
                 result = client.restart_daemon(RestartDaemonRequest(force=False))
@@ -4009,7 +4010,7 @@ class PreferencesWindow(Adw.NavigationPage):
                         error_body = None
                         forced = None
                         try:
-                            forced = DaemonClient(timeout=2.0)
+                            forced = DaemonClient(timeout=2.0, allow_api_mismatch=True)
                             forced_result = forced.restart_daemon(
                                 RestartDaemonRequest(force=True, confirmation=token)
                             )

--- a/src/sshpilot/window.py
+++ b/src/sshpilot/window.py
@@ -110,6 +110,44 @@ from .plugins.registry import capabilities_for
 logger = logging.getLogger(__name__)
 
 
+def _describe_daemon_start_failure(reason: str) -> str:
+    """Human-readable sentence for a ``DaemonStartupFailure`` reason string.
+
+    Falls back to a generic sentence for reasons this map does not know
+    about (including plain exception type names) instead of leaking the
+    internal enum value into user-facing text.
+    """
+    from .daemon.launcher import DaemonStartupFailure
+
+    messages = {
+        DaemonStartupFailure.PROCESS_EXITED.value: _(
+            "The background service exited unexpectedly during startup."
+        ),
+        DaemonStartupFailure.STARTUP_TIMEOUT.value: _(
+            "The background service did not become ready in time."
+        ),
+        DaemonStartupFailure.HANDSHAKE_FAILED.value: _(
+            "The background service did not respond correctly during startup."
+        ),
+        DaemonStartupFailure.INCOMPATIBLE_PROTOCOL.value: _(
+            "A running background service uses an incompatible protocol version."
+        ),
+        DaemonStartupFailure.API_VERSION_MISMATCH.value: _(
+            "A background service from a different app version is already running."
+        ),
+        DaemonStartupFailure.MISSING_CAPABILITY.value: _(
+            "The running background service does not support required features."
+        ),
+        DaemonStartupFailure.UNSAFE_SOCKET.value: _(
+            "The background service socket location is not safe to use."
+        ),
+        DaemonStartupFailure.INTERNAL_ERROR.value: _(
+            "The background service could not be started."
+        ),
+    }
+    return messages.get(reason, _("The background service could not be started."))
+
+
 _tips_banner_css_installed = False
 
 
@@ -746,11 +784,23 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
                 type(cause).__name__,
                 getattr(getattr(cause, 'code', None), 'value', None),
             )
-        self._client_mode_warning = _(
-            "SSH Pilot requires its background service. "
-            "The service could not be started (%s). Retry, restart the service, "
-            "inspect diagnostics, or exit."
-        ) % reason
+        from .daemon.launcher import DaemonStartupFailure
+
+        self._client_mode_is_api_mismatch = (
+            reason == DaemonStartupFailure.API_VERSION_MISMATCH.value
+        )
+        if self._client_mode_is_api_mismatch:
+            self._client_mode_warning = _(
+                "SSH Pilot requires its background service, but a service from a "
+                "different app version is already running.\n"
+                "Open Settings → Terminal and use “Restart daemon” "
+                "to replace it."
+            )
+        else:
+            self._client_mode_warning = _(
+                "SSH Pilot requires its background service. %s "
+                "Retry, restart the service, inspect diagnostics, or exit."
+            ) % _describe_daemon_start_failure(reason)
         if hasattr(self, 'welcome_view') and self.welcome_view is not None:
             self.welcome_view.set_client(None)
         self._show_client_mode_warning()
@@ -773,18 +823,60 @@ class MainWindow(Adw.ApplicationWindow, WindowBroadcastMixin, WindowSessionMixin
 
     def _show_client_mode_warning(self) -> bool:
         message = self._client_mode_warning
+        is_api_mismatch = bool(getattr(self, '_client_mode_is_api_mismatch', False))
         self._client_mode_warning = None
+        self._client_mode_is_api_mismatch = False
         if not message or self._is_quitting:
             return False
         try:
             toast = Adw.Toast.new(message)
             toast.set_timeout(0)
-            toast.set_button_label(_("Retry"))
-            toast.connect("button-clicked", lambda *_args: self.retry_daemon_connection())
+            if is_api_mismatch:
+                # "Retry" alone can never succeed here: the socket is held by
+                # a service from a different build, so send the user to the
+                # one action that can actually replace it.
+                toast.set_button_label(_("Open Settings"))
+                toast.connect(
+                    "button-clicked",
+                    lambda *_args: self._open_preferences_for_daemon_restart(),
+                )
+            else:
+                toast.set_button_label(_("Retry"))
+                toast.connect("button-clicked", lambda *_args: self.retry_daemon_connection())
             self.toast_overlay.add_toast(toast)
         except Exception:
             logger.warning("Unable to display daemon recovery diagnostics")
         return False
+
+    def _open_preferences_for_daemon_restart(self) -> None:
+        """Open Settings so the user can reach Terminal → Restart daemon.
+
+        That action tolerates a background service left over from a
+        different sshPilot build (unlike ordinary startup, which refuses to
+        reuse an incompatible peer), so it is the working recovery path
+        when startup itself reported an API version mismatch.
+        """
+        preferences = getattr(self, '_preferences_window', None)
+        if preferences is None:
+            try:
+                from .preferences import PreferencesWindow
+
+                controller = self._build_ssh_overrides_controller()
+                preferences = PreferencesWindow(
+                    self, self.config, ssh_overrides_controller=controller,
+                )
+                self._preferences_window = preferences
+            except Exception:
+                logger.error(
+                    "Could not open Preferences for daemon recovery", exc_info=True
+                )
+                return
+        try:
+            preferences.present(self)
+        except Exception:
+            logger.error(
+                "Could not present Preferences for daemon recovery", exc_info=True
+            )
 
     def _maybe_restore_daemon_sessions(self) -> None:
         """Offer or auto-reattach retained daemon sessions after GTK restart.

--- a/tests/api/test_daemon_client_protocol.py
+++ b/tests/api/test_daemon_client_protocol.py
@@ -481,3 +481,63 @@ def test_non_recursive_remove_also_requires_a_current_daemon(tmp_path):
 
     thread.join(2)
     assert requests == []
+
+
+def test_allow_api_mismatch_connects_to_a_stale_daemon_for_recovery(tmp_path):
+    """``allow_api_mismatch`` is the narrow, explicit recovery path used to
+    stop/replace a daemon left over from a different sshPilot build (e.g. a
+    macOS app bundle upgraded in place while the old daemon process is still
+    resident) — it must still complete the handshake instead of raising."""
+    old_api = "0.18"
+    assert old_api != API_IMPLEMENTATION_VERSION
+
+    socket_path = tmp_path / "recovery.sock"
+
+    def _action(peer):
+        peer.settimeout(0.5)
+        try:
+            decode_envelope(receive_frame(peer))
+        except TimeoutError:
+            pass
+
+    thread, release = _connected_protocol_server(
+        socket_path,
+        _action,
+        api_implementation_version=old_api,
+        supported=["daemon.status", "daemon.control"],
+    )
+    client = DaemonClient(
+        socket_path=socket_path, client_version="test", allow_api_mismatch=True
+    )
+    try:
+        assert client.api_mismatch is True
+        assert client.get_capabilities().api_implementation_version == old_api
+    finally:
+        release.set()
+        client.close()
+    thread.join(2)
+
+
+def test_default_client_still_rejects_a_stale_daemon(tmp_path):
+    """The ordinary (non-recovery) constructor path is unchanged: it must
+    keep refusing an incompatible peer rather than silently tolerating it."""
+    old_api = "0.18"
+    socket_path = tmp_path / "no-recovery.sock"
+
+    def _action(peer):
+        peer.settimeout(0.5)
+        try:
+            decode_envelope(receive_frame(peer))
+        except TimeoutError:
+            pass
+
+    thread, release = _connected_protocol_server(
+        socket_path,
+        _action,
+        api_implementation_version=old_api,
+    )
+    with pytest.raises(SshPilotError) as caught:
+        DaemonClient(socket_path=socket_path, client_version="test")
+    assert caught.value.code is ErrorCode.API_VERSION_MISMATCH
+    release.set()
+    thread.join(2)

--- a/tests/architecture/test_core_boundary.py
+++ b/tests/architecture/test_core_boundary.py
@@ -169,6 +169,9 @@ DAEMON_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("terminal_manager.py", "DaemonLauncher"),
         ("terminal_manager.py", "DaemonLaunchError"),
         ("terminal_manager.py", "DaemonStartupFailure"),
+        # Startup client-selection toast: map DaemonLaunchError.reason to a
+        # human-readable message instead of leaking the raw enum value.
+        ("window.py", "DaemonStartupFailure"),
         # Reserved ``secret-session`` interaction namespace: frontend dialog
         # layers filter on it so secret-backend interactions are presented by
         # the app-wide SecretsInteractionPresenter, never the session-scoped one.

--- a/tests/test_window_client_composition.py
+++ b/tests/test_window_client_composition.py
@@ -221,6 +221,51 @@ def test_failed_selection_leaves_key_manager_none():
     window.plugin_connection_services.detach_client.assert_called_once_with()
 
 
+def test_api_version_mismatch_uses_friendly_message_and_marks_mismatch():
+    """A stale daemon from a different app build (e.g. left running after a
+    macOS DMG upgrade) must not leak the raw ``api_version_mismatch`` enum
+    value into the toast, and must be flagged so the toast offers the one
+    action that can actually recover (Preferences ▸ Restart daemon) instead
+    of a useless Retry."""
+    from sshpilot.daemon.launcher import DaemonLaunchError, DaemonStartupFailure
+
+    window = _make_window()
+    window.client = object()
+    window._api_client_selection_pending = True
+    window._api_client_selection_request = object()
+    window.plugin_connection_services.detach_client = MagicMock()
+    window.connection_runtime_status.close = MagicMock()
+    window._show_client_mode_warning = lambda: None
+
+    window._handle_client_selection_error(
+        DaemonLaunchError(DaemonStartupFailure.API_VERSION_MISMATCH)
+    )
+
+    assert window._client_mode_is_api_mismatch is True
+    assert "api_version_mismatch" not in window._client_mode_warning
+    assert "different app version" in window._client_mode_warning
+
+
+def test_other_daemon_failure_keeps_retry_action_and_friendly_text():
+    from sshpilot.daemon.launcher import DaemonLaunchError, DaemonStartupFailure
+
+    window = _make_window()
+    window.client = object()
+    window._api_client_selection_pending = True
+    window._api_client_selection_request = object()
+    window.plugin_connection_services.detach_client = MagicMock()
+    window.connection_runtime_status.close = MagicMock()
+    window._show_client_mode_warning = lambda: None
+
+    window._handle_client_selection_error(
+        DaemonLaunchError(DaemonStartupFailure.STARTUP_TIMEOUT)
+    )
+
+    assert window._client_mode_is_api_mismatch is False
+    assert "startup_timeout" not in window._client_mode_warning
+    assert "did not become ready in time" in window._client_mode_warning
+
+
 # ---------------------------------------------------------------------------
 # _apply_client_selection (newly completed async selection)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A daemon left over from a previous app build (e.g. a macOS DMG upgraded in place while the old app's detached daemon process is still running) made startup fail forever: the launcher refused to reuse the incompatible peer, the toast leaked the raw api_version_mismatch enum value instead of an explanation, and neither the toast's Retry button nor Preferences' "Restart daemon" action (which builds its own DaemonClient) could actually reach the stale daemon to replace it, since DaemonClient's constructor aborted the connection as soon as the mismatch was detected.

DaemonClient gains an explicit allow_api_mismatch flag for this one recovery scenario: it keeps the handshake connection open so administrative status/stop/restart calls can reach and replace a stale peer, while ordinary clients keep rejecting an incompatible daemon as before. Preferences' daemon status/restart flows opt into it, which is enough to make "Restart daemon" a working fix. The startup toast now shows a human-readable message instead of the raw enum, and points the user at Preferences when the failure is specifically a version mismatch.


Claude-Session: https://claude.ai/code/session_01VUw6Nv8Up6kiwMwNyNxNvW

## Summary

Describe the user-visible or technical outcome and how it was validated.

## API and architecture

- [ ] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary
- [ ] Public DTOs or client methods were updated
- [ ] Capabilities were updated and only implemented support is advertised
- [ ] Events and structured errors were updated
- [ ] State, ordering, threading, cancellation, and security semantics were reviewed
- [ ] Contract tests were updated
- [ ] API documentation was updated
- [ ] `docs/api/CHANGELOG.md` was updated
- [ ] Compatibility and protocol-version impact were reviewed
- [ ] Generated API artifacts and the public-surface snapshot were deliberately refreshed

For an API-affecting change, complete the applicable items above and explain
any intentionally deferred client or transport work.

## Testing

List the commands run and any checks that were not available.
