### PR TITLE
Fix untranslated UI strings

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -31,6 +31,7 @@ src/sshpilot/log_viewer.py
 src/sshpilot/macos_menubar.py
 src/sshpilot/main.py
 src/sshpilot/omni_search.py
+src/sshpilot/plugins/builtin/docker_manager/__init__.py
 src/sshpilot/plugins/builtin/docker_manager/dialogs.py
 src/sshpilot/plugins/builtin/docker_manager/page.py
 src/sshpilot/plugins/builtin/docker_manager/tab_compose.py
@@ -44,6 +45,7 @@ src/sshpilot/plugins/builtin/kubernetes_protocol/__init__.py
 src/sshpilot/plugins/builtin/mosh_protocol/__init__.py
 src/sshpilot/plugins/builtin/serial_protocol/__init__.py
 src/sshpilot/plugins/builtin/telnet_protocol/__init__.py
+src/sshpilot/plugins/registry_client.py
 src/sshpilot/port_utils.py
 src/sshpilot/preferences.py
 src/sshpilot/rbw_setup.py
@@ -60,6 +62,7 @@ src/sshpilot/terminal.py
 src/sshpilot/terminal_manager.py
 src/sshpilot/terminal_search.py
 src/sshpilot/text_editor.py
+src/sshpilot/theme_selector.py
 src/sshpilot/web_tab.py
 src/sshpilot/welcome_page.py
 src/sshpilot/window.py

--- a/src/sshpilot/actions.py
+++ b/src/sshpilot/actions.py
@@ -13,7 +13,7 @@ from .file_manager_integration import (
 from .shortcut_utils import get_primary_modifier_label
 from .platform_utils import is_macos
 from .shortcut_utils import TOGGLE_FULLSCREEN_ACTION
-from .i18n import ui_language_codes as _ui_language_codes
+from .i18n import N_, ui_language_codes as _ui_language_codes
 from . import wol
 
 HAS_NAV_SPLIT = hasattr(Adw, 'NavigationSplitView')
@@ -26,11 +26,11 @@ logger = logging.getLogger(__name__)
 
 
 HEADERBAR_VISIBILITY_ACTIONS = (
-    ('headerbar-sidebar-toggle', 'Sidebar Toggle Button', 'ui.headerbar_show_sidebar_toggle', False),
-    ('headerbar-split-view', 'Split View Button', 'ui.headerbar_show_split_view', False),
-    ('headerbar-commands', 'Command Snippets Button', 'ui.headerbar_show_commands', True),
-    ('headerbar-theme-menu', 'Theme Menu', 'ui.headerbar_show_theme_toggle', False),
-    ('headerbar-local-terminal', 'Local Terminal Button', 'ui.headerbar_show_local_terminal', True),
+    ('headerbar-sidebar-toggle', N_('Sidebar Toggle Button'), 'ui.headerbar_show_sidebar_toggle', False),
+    ('headerbar-split-view', N_('Split View Button'), 'ui.headerbar_show_split_view', False),
+    ('headerbar-commands', N_('Command Snippets Button'), 'ui.headerbar_show_commands', True),
+    ('headerbar-theme-menu', N_('Theme Menu'), 'ui.headerbar_show_theme_toggle', False),
+    ('headerbar-local-terminal', N_('Local Terminal Button'), 'ui.headerbar_show_local_terminal', True),
 )
 
 

--- a/src/sshpilot/plugins/builtin/docker_manager/__init__.py
+++ b/src/sshpilot/plugins/builtin/docker_manager/__init__.py
@@ -13,6 +13,7 @@ image/volume cleanup.
 
 from __future__ import annotations
 
+from gettext import gettext as _
 import logging
 
 from ...api import PluginContext, SshPilotPlugin
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 _ICON = "brand-docker-symbolic"
 _LOCAL_TARGET = "__local__"
-_LOCAL_TITLE = "Local"
+_LOCAL_TITLE = _("Local")
 
 
 class Plugin(SshPilotPlugin):
@@ -36,12 +37,12 @@ class Plugin(SshPilotPlugin):
             return
         # Tools-menu "Docker Console" → sidebar selection, else Local. The page
         # itself is never opened directly; on_activate handles the click.
-        ctx.ui.register_page("manager", "Docker Console", _ICON, lambda: None,
+        ctx.ui.register_page("manager", _("Docker Console"), _ICON, lambda: None,
                              on_activate=self._open_from_tools)
         # Right-click a connection → a per-host Docker Console tab (API >= 1.7).
         register_action = getattr(ctx.ui, "register_connection_action", None)
         if callable(register_action):
-            register_action("open", "Docker Console", _ICON, self._open_host_page)
+            register_action("open", _("Docker Console"), _ICON, self._open_host_page)
 
     # --- one tab per host (reused if already open) ---------------------
     def _open_host_page(self, nickname: str) -> None:

--- a/src/sshpilot/plugins/registry_client.py
+++ b/src/sshpilot/plugins/registry_client.py
@@ -7,6 +7,7 @@ context so it works inside Flatpak/PyInstaller bundles.
 
 from __future__ import annotations
 
+from gettext import gettext as _
 import hashlib
 import json
 import ssl
@@ -52,7 +53,9 @@ def _read_url(url: str, timeout: int) -> bytes:
         with urllib.request.urlopen(req, timeout=timeout, context=_ssl_ctx()) as resp:
             return resp.read()
     except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
-        raise RegistryError(f"Could not reach {url}: {exc}") from exc
+        raise RegistryError(
+            _("Could not reach {url}: {error}").format(url=url, error=exc)
+        ) from exc
 
 
 def fetch_index(url: str = DEFAULT_REGISTRY_URL, timeout: int = HTTP_TIMEOUT) -> dict:
@@ -60,9 +63,11 @@ def fetch_index(url: str = DEFAULT_REGISTRY_URL, timeout: int = HTTP_TIMEOUT) ->
     try:
         data = json.loads(raw)
     except ValueError as exc:
-        raise RegistryError(f"Invalid registry JSON: {exc}") from exc
+        raise RegistryError(
+            _("Invalid registry JSON: {error}").format(error=exc)
+        ) from exc
     if not isinstance(data, dict) or data.get("schemaVersion") != 1:
-        raise RegistryError("Unsupported or missing registry schemaVersion.")
+        raise RegistryError(_("Unsupported or missing registry schemaVersion."))
     return data
 
 
@@ -122,11 +127,11 @@ def download_package(download_url: str, checksum_url: str, dest: str,
     checksum asset. Returns the verified hash; raises RegistryError otherwise."""
     expected = _parse_checksum(_read_url(checksum_url, timeout))
     if not expected:
-        raise RegistryError("Could not read the package checksum.")
+        raise RegistryError(_("Could not read the package checksum."))
     data = _read_url(download_url, timeout)
     actual = hashlib.sha256(data).hexdigest()
     if actual != expected:
-        raise RegistryError("Checksum mismatch — refusing to install.")
+        raise RegistryError(_("Checksum mismatch — refusing to install."))
     with open(dest, "wb") as fh:
         fh.write(data)
     return actual

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -942,10 +942,10 @@ class PreferencesWindow(Adw.NavigationPage):
         )
 
         color_display_options = Gtk.StringList()
-        color_display_options.append("Colored Rows")
-        color_display_options.append("Color Badges")
-        color_display_options.append("Accent Bars")
-        color_display_options.append("Color Dots")
+        color_display_options.append(_("Colored Rows"))
+        color_display_options.append(_("Color Badges"))
+        color_display_options.append(_("Accent Bars"))
+        color_display_options.append(_("Color Dots"))
         self.group_color_display_row.set_model(color_display_options)
 
         current_mode = 'fill'
@@ -1260,7 +1260,7 @@ class PreferencesWindow(Adw.NavigationPage):
             for name in self._startup_session_names:
                 session_model.append(name)
         else:
-            session_model.append("(no saved sessions)")
+            session_model.append(_("(no saved sessions)"))
 
         self.startup_session_row = Gtk.DropDown()
         self.startup_session_row.set_model(session_model)
@@ -1313,9 +1313,9 @@ class PreferencesWindow(Adw.NavigationPage):
         self.theme_row.set_subtitle(_("Choose light, dark, or follow system theme"))
 
         themes = Gtk.StringList()
-        themes.append("Follow System")
-        themes.append("Light")
-        themes.append("Dark")
+        themes.append(_("Follow System"))
+        themes.append(_("Light"))
+        themes.append(_("Dark"))
         self.theme_row.set_model(themes)
 
         # Load saved theme preference
@@ -1647,30 +1647,30 @@ class PreferencesWindow(Adw.NavigationPage):
             headerbar_group.add(row)
 
         _add_headerbar_switch(
-            "Sidebar Toggle Button",
-            "Show the button that hides/shows the sidebar (F9 still works when hidden)",
+            _("Sidebar Toggle Button"),
+            _("Show the button that hides/shows the sidebar (F9 still works when hidden)"),
             'ui.headerbar_show_sidebar_toggle',
             default=False,
         )
         _add_headerbar_switch(
-            "Split View Button",
-            "Show the split-view button (the grid icon that starts a split view)",
+            _("Split View Button"),
+            _("Show the split-view button (the grid icon that starts a split view)"),
             'ui.headerbar_show_split_view',
             default=False,
         )
         _add_headerbar_switch(
-            "Command Snippets Button",
-            "Show the command snippets toggle button",
+            _("Command Snippets Button"),
+            _("Show the command snippets toggle button"),
             'ui.headerbar_show_commands',
         )
         _add_headerbar_switch(
-            "Theme Menu",
-            "Show the application theme menu beside the commands button",
+            _("Theme Menu"),
+            _("Show the application theme menu beside the commands button"),
             'ui.headerbar_show_theme_toggle',
         )
         _add_headerbar_switch(
-            "Local Terminal Button",
-            "Show the button that opens a local terminal",
+            _("Local Terminal Button"),
+            _("Show the button that opens a local terminal"),
             'ui.headerbar_show_local_terminal',
         )
 
@@ -5518,7 +5518,7 @@ class PreferencesWindow(Adw.NavigationPage):
             self.accent_color_row,
             'accent-color-override',
             Gdk.RGBA(0.2, 0.5, 0.9, 1.0),
-            'Using system accent color',
+            _('Using system accent color'),
         )
 
     def _set_color_button(self, button, row, setting_name, default_rgba, default_subtitle):


### PR DESCRIPTION
## Summary

Fixes several UI strings that were not going through gettext correctly.

These issues became visible while testing the recently added French localization, but they affect all non-English languages.

This PR only fixes the internationalization paths. It does not update the French or German translation catalogs.

## Changes

- Mark header bar visibility labels for gettext extraction
- Translate header bar button labels and descriptions in Preferences
- Translate theme choices in Preferences
- Translate group appearance choices
- Translate the empty saved-session label
- Include `theme_selector.py` in `POTFILES`
- Make the Docker Console / Local labels use gettext
- Make plugin registry user-facing errors translatable
- Add the relevant source files to `POTFILES`

This exposes 24 additional user-facing strings to gettext.

Plugin names and descriptions coming from the external plugin registry are intentionally left unchanged, since the current registry schema does not support localized metadata.

## Validation

- gettext POT generation succeeds
- POT grows from 1,958 to 1,982 messages
- 24 new user-facing msgids are extracted
- `tests/test_i18n_language.py` — 21 passed
- targeted Docker / registry / menu tests — 94 passed, 24 skipped
- Meson build succeeds
- Meson validation tests — 2/2 passed
- runtime checks confirm existing translations are now used:
  - `Follow System` → `Selon le système`
  - `Light` → `Clair`
  - `Dark` → `Sombre`
  - `Docker Console` → `Console Docker`

No translation catalogs (`fr.po`, `de.po`, `.mo`) are modified in this PR.