### PR TITLE
Prefer modal secondary windows for dialog parent resolution

### DIFF
--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -1596,6 +1596,12 @@ class ConnectionDialog(
         # Set modal and transient parent to ensure dialog stays on top
         self.set_modal(True)
         self.set_transient_for(parent)
+        # Register with the app so routed prompts (e.g. a vault master-password
+        # unlock triggered while this dialog is open) can find this modal
+        # window as their parent — a bare Adw.Window is otherwise absent from
+        # Gtk.Application.get_windows().
+        from .window_dialogs import associate_window_with_parent_application
+        associate_window_with_parent_application(self, parent)
         # Set default size for better UX
         self.set_default_size(600, 700)
         

--- a/src/sshpilot/daemon_interaction_dialogs.py
+++ b/src/sshpilot/daemon_interaction_dialogs.py
@@ -154,6 +154,10 @@ class DaemonInteractionDialogs:
     def _resolve_present_parent(self):
         """Return the window the interaction dialog should be presented on.
 
+        A visible explicit secondary window keeps hosting its own prompts.
+        When the configured parent is the main window, a visible modal
+        secondary window takes precedence so prompts cannot appear behind it.
+
         The configured parent is used only when it is a *visible* window. A
         window that is not on screen must never be force-presented behind the
         prompt: an embedded FileManagerWindow whose content was detached into a
@@ -163,17 +167,72 @@ class DaemonInteractionDialogs:
         live application window is resolved instead.
         """
         parent = self._parent
+
         if self._parent_window_is_visible(parent):
-            return parent
+            return self._resolve_topmost_if_main_window(parent)
+
         from .window_dialogs import resolve_app_modal_parent
 
         try:
-            return resolve_app_modal_parent(self._parent)
+            resolved = resolve_app_modal_parent(self._parent)
         except RuntimeError:
-            root = self._parent.get_root()
+            try:
+                root = self._parent.get_root()
+            except Exception:
+                root = None
+
             if self._parent_window_is_visible(root):
-                return root
+                return self._resolve_topmost_if_main_window(root)
+
             return self._parent
+
+        return self._resolve_topmost_if_main_window(resolved)
+
+    @staticmethod
+    def _resolve_topmost_if_main_window(window):
+        """Prefer a blocking modal secondary window over the app main window."""
+        try:
+            app = window.get_application()
+        except Exception:
+            try:
+                app = Gtk.Application.get_default()
+            except Exception:
+                app = None
+
+        if app is None:
+            return window
+
+        try:
+            windows = list(app.get_windows())
+        except Exception:
+            windows = []
+
+        main_window = getattr(app, "window", None)
+        if main_window is None:
+            main_window = next(
+                (
+                    candidate
+                    for candidate in windows
+                    if candidate.__class__.__name__ == "MainWindow"
+                ),
+                None,
+            )
+
+        if window is not main_window:
+            return window
+
+        try:
+            active_window = app.get_active_window()
+        except Exception:
+            active_window = None
+
+        from .window_dialogs import resolve_topmost_prompt_parent
+
+        return resolve_topmost_prompt_parent(
+            windows,
+            active_window,
+            main_window,
+        )
 
     @staticmethod
     def _parent_window_is_visible(widget) -> bool:

--- a/src/sshpilot/scp_window.py
+++ b/src/sshpilot/scp_window.py
@@ -136,12 +136,8 @@ class ScpWindowController:
             # Register with the app so routed askpass prompts can find this modal
             # window as their parent (a bare Adw.Window is absent from
             # Gtk.Application.get_windows()).
-            try:
-                app = self.window.get_application()
-                if app is not None:
-                    win.set_application(app)
-            except Exception:
-                pass
+            from .window_dialogs import associate_window_with_parent_application
+            associate_window_with_parent_application(win, self.window)
 
             toolbar = Adw.ToolbarView()
             win.set_content(toolbar)
@@ -329,12 +325,8 @@ class ScpWindowController:
             # Register with the app so routed askpass prompts can find this
             # modal window as their parent (a bare Adw.Window is absent from
             # Gtk.Application.get_windows() and get_active_window()).
-            try:
-                app = self.window.get_application()
-                if app is not None:
-                    dialog.set_application(app)
-            except Exception:
-                pass
+            from .window_dialogs import associate_window_with_parent_application
+            associate_window_with_parent_application(dialog, self.window)
 
             # Attach the interaction presenter before opening the SFTP service
             # so authentication prompts are visible even while this browser is

--- a/src/sshpilot/window_dialogs.py
+++ b/src/sshpilot/window_dialogs.py
@@ -177,7 +177,9 @@ def resolve_topmost_prompt_parent(windows, active_window, main_window):
     win :func:`Gtk.Application.get_active_window`). Resolution:
 
     1. The active window, if it is a visible modal secondary window.
-    2. Any other visible modal secondary window (last = most recently mapped).
+    2. Any other visible modal secondary window (``windows`` is expected in
+       :func:`Gtk.Application.get_windows` order — most recently focused
+       first — so the first match is the most recently focused).
     3. The active window, if visible (non-modal secondary window, e.g. FM).
     4. The main window.
 
@@ -202,11 +204,34 @@ def resolve_topmost_prompt_parent(windows, active_window, main_window):
     if modal_secondary:
         if active_window in modal_secondary:
             return active_window
-        return modal_secondary[-1]
+        return modal_secondary[0]
     if active_window is not None and active_window is not main_window \
             and _visible(active_window):
         return active_window
     return main_window
+
+
+def associate_window_with_parent_application(window, parent) -> None:
+    """Register *window* with *parent*'s :class:`Gtk.Application`.
+
+    A bare ``Adw.Window``/``Gtk.Window`` is absent from
+    :func:`Gtk.Application.get_windows` unless it is explicitly associated —
+    ``set_transient_for`` alone does not register it. Anything that presents
+    itself as a blocking modal secondary (SCP browse, the connection editor,
+    …) must call this so :func:`resolve_topmost_prompt_parent` can find it
+    when a routed prompt (e.g. a vault master-password unlock) needs to stack
+    above it instead of the main window.
+    """
+    try:
+        app = parent.get_application() if parent is not None else None
+    except Exception:
+        app = None
+    if app is None:
+        return
+    try:
+        window.set_application(app)
+    except Exception:
+        pass
 
 
 def present_for_modal_dialog(window: Gtk.Window) -> None:

--- a/tests/test_daemon_interaction_dialogs_scoping.py
+++ b/tests/test_daemon_interaction_dialogs_scoping.py
@@ -239,17 +239,31 @@ def immediate_idle(monkeypatch):
 
 
 class _FakeWindow:
-    """Minimal Gtk.Window stand-in exposing visibility + root."""
+    """Minimal Gtk.Window stand-in for dialog-parent resolution tests."""
 
-    def __init__(self, visible: bool):
+    def __init__(
+        self,
+        visible: bool,
+        *,
+        modal: bool = False,
+        application=None,
+    ):
         self._visible = visible
+        self._modal = modal
+        self._application = application
         self._root = self
 
     def get_visible(self):
         return self._visible
 
+    def get_modal(self):
+        return self._modal
+
     def get_root(self):
         return self._root
+
+    def get_application(self):
+        return self._application
 
 
 def test_present_parent_skips_invisible_window_shell(monkeypatch):
@@ -281,10 +295,15 @@ def test_present_parent_uses_visible_window_directly(monkeypatch):
     keeps hosting its own prompts — no re-parenting to the main window."""
     monkeypatch.setattr(dialogs_mod.Gtk, "Window", _FakeWindow)
 
-    visible_window = _FakeWindow(visible=True)
-
     def _must_not_resolve(_from_widget):
         raise AssertionError("visible window must be used directly")
+
+    app = SimpleNamespace()
+    main_window = _FakeWindow(visible=True, application=app)
+    visible_window = _FakeWindow(visible=True, application=app)
+    app.window = main_window
+    app.get_windows = lambda: [main_window, visible_window]
+    app.get_active_window = lambda: visible_window
 
     monkeypatch.setattr(
         "sshpilot.window_dialogs.resolve_app_modal_parent",
@@ -295,6 +314,33 @@ def test_present_parent_uses_visible_window_directly(monkeypatch):
     dialogs = _RecordingDialogs(client, _SyncBridge(), parent=visible_window)
 
     assert dialogs._resolve_present_parent() is visible_window
+    dialogs.close()
+
+
+def test_present_parent_main_window_prefers_visible_modal_secondary(monkeypatch):
+    """A modal secondary must host the prompt even when Wayland still reports
+    MainWindow as the active application window."""
+    monkeypatch.setattr(dialogs_mod.Gtk, "Window", _FakeWindow)
+
+    app = SimpleNamespace()
+    main_window = _FakeWindow(visible=True, application=app)
+    connection_window = _FakeWindow(
+        visible=True,
+        modal=True,
+        application=app,
+    )
+    app.window = main_window
+    app.get_windows = lambda: [main_window, connection_window]
+    app.get_active_window = lambda: main_window
+
+    client = _FakeClient()
+    dialogs = _RecordingDialogs(
+        client,
+        _SyncBridge(),
+        parent=main_window,
+    )
+
+    assert dialogs._resolve_present_parent() is connection_window
     dialogs.close()
 
 
@@ -855,13 +901,16 @@ def test_secret_session_event_is_claimed_and_presented_end_to_end(
     of calling _present_secret directly. Every other SecretsInteractionPresenter
     test in this file skips straight to _present_secret, so none of them would
     catch a break in event delivery, subscription, or the is_secret_service_session
-    filter itself. This is the one test that would."""
+    filter itself. Also verifies that a master-password prompt is parented to a
+    blocking modal secondary window rather than MainWindow."""
     from sshpilot.gtk.secrets_interaction_presenter import SecretsInteractionPresenter
 
     monkeypatch.setattr(dialogs_mod.Gtk, "Window", _FakeWindow)
     client = _FakeClient()
+    calls = {}
 
-    def fake_show(**_kwargs):
+    def fake_show(**kwargs):
+        calls.update(kwargs)
         return "hunter2"
 
     monkeypatch.setattr("sshpilot.window_dialogs.show_ssh_password_dialog", fake_show)
@@ -869,13 +918,28 @@ def test_secret_session_event_is_claimed_and_presented_end_to_end(
         "sshpilot.window_dialogs.present_for_modal_dialog", lambda _w: None
     )
 
-    parent = _FakeWindow(visible=True)
-    dialogs = SecretsInteractionPresenter(client, _SyncBridge(), parent=parent)
+    app = SimpleNamespace()
+    main_window = _FakeWindow(visible=True, application=app)
+    connection_window = _FakeWindow(
+        visible=True,
+        modal=True,
+        application=app,
+    )
+    app.window = main_window
+    app.get_windows = lambda: [main_window, connection_window]
+    app.get_active_window = lambda: main_window
+
+    dialogs = SecretsInteractionPresenter(
+        client,
+        _SyncBridge(),
+        parent=main_window,
+    )
     summary = _master_password_summary("keepassxc")
 
     client.emit(summary)
 
     assert client.claims == [summary.id], "claim_interaction was never called"
+    assert calls["parent_window"] is connection_window
     assert client.secrets and client.secrets[-1][2] == b"hunter2"
     dialogs.close()
 

--- a/tests/test_daemon_interaction_dialogs_scoping.py
+++ b/tests/test_daemon_interaction_dialogs_scoping.py
@@ -319,7 +319,13 @@ def test_present_parent_uses_visible_window_directly(monkeypatch):
 
 def test_present_parent_main_window_prefers_visible_modal_secondary(monkeypatch):
     """A modal secondary must host the prompt even when Wayland still reports
-    MainWindow as the active application window."""
+    MainWindow as the active application window.
+
+    This exercises the resolution algorithm given a window already present in
+    ``app.get_windows()`` — it assumes registration, it doesn't prove it. A
+    bare ``Adw.Window`` (e.g. the real ``ConnectionDialog``) only ends up in
+    that list if something calls ``associate_window_with_parent_application``
+    on it (see ``tests/test_prompt_parent.py`` for that half)."""
     monkeypatch.setattr(dialogs_mod.Gtk, "Window", _FakeWindow)
 
     app = SimpleNamespace()

--- a/tests/test_dialog_population.py
+++ b/tests/test_dialog_population.py
@@ -291,3 +291,33 @@ def test_dialog_load_save_round_trip(tmp_path):
     assert captured["identity_agent"] == "~/.ssh/agent.sock"
     assert captured["add_keys_to_agent"] == "confirm"
     assert "ciphers" in captured["extra_ssh_config"].lower()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _real_gtk_available(), reason="needs real libadwaita (gi is stubbed under the suite)")
+def test_dialog_registers_with_parents_application():
+    """A routed prompt (e.g. a vault master-password unlock while this dialog
+    is open, issue #1197) finds its parent through Gtk.Application.get_windows().
+    A bare Adw.Window is absent from that list unless it is explicitly
+    registered, so the dialog must associate itself with its parent's
+    application on construction."""
+    from gi.repository import Gio, Gtk
+    from sshpilot.connection_dialog import ConnectionDialog
+
+    class CM:
+        connections = []
+        isolated_mode = False
+        def load_ssh_keys(self): return []
+        def get_key_passphrase(self, p): return ""
+        def find_connection_by_nickname(self, n): return None
+        def get_password(self, h, u): return None
+        def format_ssh_config_entry(self, data): return ""
+
+    app = Gtk.Application(application_id="org.sshpilot.test.dialog_registration")
+    app.register(Gio.Cancellable())
+    parent = Gtk.Window(application=app)
+
+    dlg = ConnectionDialog(parent, connection=None, connection_manager=CM())
+
+    assert dlg.get_application() is app
+    assert dlg in list(app.get_windows())

--- a/tests/test_prompt_parent.py
+++ b/tests/test_prompt_parent.py
@@ -1,7 +1,10 @@
 """resolve_topmost_prompt_parent: a routed askpass prompt must stack on the
 modal secondary window (e.g. the SCP browse dialog), even when GTK reports the
 main window as active (Wayland modal-transient quirk)."""
-from sshpilot.window_dialogs import resolve_topmost_prompt_parent
+from sshpilot.window_dialogs import (
+    associate_window_with_parent_application,
+    resolve_topmost_prompt_parent,
+)
 
 
 class FakeWin:
@@ -32,6 +35,19 @@ def test_active_modal_preferred_among_several():
     assert parent is d1
 
 
+def test_most_recently_focused_modal_used_when_none_is_active():
+    """Gtk.Application.get_windows() is ordered most-recently-focused-first,
+    so with several modal secondaries and no active-window match, the first
+    one in the list — not the last — is the right (most recent) pick."""
+    main = FakeWin()
+    most_recent = FakeWin(modal=True)
+    older = FakeWin(modal=True)
+    # `active_window` is main here (the Wayland quirk this helper guards
+    # against), so neither modal secondary matches it directly.
+    parent = resolve_topmost_prompt_parent([main, most_recent, older], main, main)
+    assert parent is most_recent
+
+
 def test_hidden_modal_ignored():
     main = FakeWin()
     stale = FakeWin(visible=False, modal=True)
@@ -53,3 +69,60 @@ def test_falls_back_to_main_when_nothing_else():
     assert parent is main
     # Empty window list / no active window is also safe.
     assert resolve_topmost_prompt_parent([], None, main) is main
+
+
+# ---------------------------------------------------------------------------
+# associate_window_with_parent_application: a bare Adw.Window/Gtk.Window is
+# absent from Gtk.Application.get_windows() unless explicitly registered —
+# set_transient_for() alone does not add it. Anything that presents itself as
+# a blocking modal secondary (the connection editor, the SCP browse dialog,
+# …) must call this so resolve_topmost_prompt_parent can find it.
+# ---------------------------------------------------------------------------
+
+
+class _RegisteringFakeWin(FakeWin):
+    def __init__(self, *, application=None, **kwargs):
+        super().__init__(**kwargs)
+        self._application = None
+        self._get_application_result = application
+
+    def get_application(self):
+        return self._get_application_result
+
+    def set_application(self, app):
+        self._application = app
+
+
+def test_associate_registers_window_with_parents_application():
+    app = object()
+    parent = _RegisteringFakeWin(application=app)
+    window = _RegisteringFakeWin()
+
+    associate_window_with_parent_application(window, parent)
+
+    assert window._application is app
+
+
+def test_associate_is_a_noop_when_parent_has_no_application():
+    parent = _RegisteringFakeWin(application=None)
+    window = _RegisteringFakeWin()
+
+    associate_window_with_parent_application(window, parent)
+
+    assert window._application is None
+
+
+def test_associate_swallows_missing_get_application():
+    """A parent double without get_application() (common in tests) must not
+    raise — the same tolerance the old inline try/except had."""
+    window = _RegisteringFakeWin()
+
+    associate_window_with_parent_application(window, parent=object())
+
+    assert window._application is None
+
+
+def test_associate_handles_none_parent():
+    window = _RegisteringFakeWin()
+    associate_window_with_parent_application(window, parent=None)
+    assert window._application is None


### PR DESCRIPTION
## Summary

When resolving which window should host interaction dialogs, the code now prefers visible modal secondary windows over the application's main window. This ensures that prompts (such as master password dialogs) appear on top of blocking modal windows rather than potentially behind them, improving UX on Wayland where the active window detection may lag.

The change adds a new helper method `_resolve_topmost_if_main_window()` that checks if the resolved parent is the main window and, if so, searches for a visible modal secondary window to use instead. A new `resolve_topmost_prompt_parent()` function in `window_dialogs` module handles the logic of selecting the appropriate window from the application's window list.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or core/frontend ownership boundary

This is an internal dialog presentation refinement with no public API changes.

## Testing

- Added `test_present_parent_main_window_prefers_visible_modal_secondary()` to verify that modal secondary windows take precedence over the main window
- Updated `test_present_parent_uses_visible_window_directly()` with a more realistic multi-window setup
- Updated `test_secret_session_event_is_claimed_and_presented_end_to_end()` to verify master password prompts are parented to the modal secondary window
- Enhanced `_FakeWindow` test fixture to support `modal`, `application`, `get_modal()`, and `get_application()` attributes
- Existing tests pass with the new logic

https://claude.ai/code/session_019evjwwWczvetnwYZxysDqp