### PR TITLE
Prompt unlock before revealing saved passwords/passphrases

### DIFF
--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -60,18 +60,26 @@ from gettext import gettext as _
 logger = logging.getLogger(__name__)
 
 
-def _reveal_after_unlock(app_window, anchor, start_worker):
-    """Run ``start_worker`` once the secret backend is unlocked.
+def _reveal_after_unlock(app_window, anchor, start_worker, on_declined=None):
+    """Run ``start_worker`` once the secret backend is confirmed unlocked.
 
     Password/passphrase reveal is a best-effort background fetch: a locked
     session backend (Bitwarden/Vaultwarden) silently resolves lookups to
     nothing, which used to leave the field blank with no indication the
     secret exists (#1199). Query the backend's lock state first and, if it
-    needs unlocking, prompt through the daemon-owned unlock flow before
-    fetching — mirroring the save-path gate (``_needs_secret_unlock_before_save``).
-    ``start_worker`` always runs afterwards; a still-locked backend (unlock
-    declined or failed) just keeps returning nothing, same as before this gate
-    existed.
+    needs unlocking — or the state can't be determined at all, which is
+    treated conservatively as locked, mirroring the save-path gate
+    (``_needs_secret_unlock_before_save``) — prompt through the daemon-owned
+    unlock flow before fetching.
+
+    ``start_worker`` runs only once ``prompt_unlock`` reports the backend is
+    actually unlocked. A declined/failed/unreachable unlock must not attempt
+    a lookup that is guaranteed to resolve to nothing: on a locked backend
+    that would record a false "no secret saved" result (e.g. clearing
+    ``_password_saved``), permanently hiding a secret that *is* saved. When
+    declined, ``on_declined`` runs instead so callers can reset any "reveal
+    pending" bookkeeping to allow a later retry (after the vault is unlocked
+    some other way).
     """
     controller = getattr(app_window, 'secrets_controller', None)
     state = None
@@ -79,10 +87,18 @@ def _reveal_after_unlock(app_window, anchor, start_worker):
         try:
             state = controller.load_state()
         except Exception:
+            logger.debug("Secret backend state query failed; treating as locked", exc_info=True)
             state = None
-    if state is not None and (state.needs_unlock or state.login_required):
+    if state is None or state.needs_unlock or state.login_required:
         from .secret_unlock_dialog import prompt_unlock
-        prompt_unlock(anchor, on_done=lambda _ok: start_worker())
+
+        def _after_unlock(ok):
+            if ok:
+                start_worker()
+            elif on_declined:
+                on_declined()
+
+        prompt_unlock(anchor, on_done=_after_unlock)
         return
     start_worker()
 
@@ -1368,7 +1384,10 @@ class FileListEditor(Adw.PreferencesGroup):
 
             threading.Thread(target=worker, daemon=True).start()
 
-        _reveal_after_unlock(parent, parent, _start_worker)
+        def _on_declined():
+            row._pass_reveal_pending = False
+
+        _reveal_after_unlock(parent, parent, _start_worker, on_declined=_on_declined)
 
     def _commit_passphrase(self, pass_entry, path, norm, force=False):
         """Validate an edited passphrase; persistence is deferred to dialog save."""
@@ -2387,7 +2406,10 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
 
             threading.Thread(target=worker, daemon=True).start()
 
-        _reveal_after_unlock(parent, self, _start_worker)
+        def _on_declined():
+            self._password_reveal_pending = False
+
+        _reveal_after_unlock(parent, self, _start_worker, on_declined=_on_declined)
 
     def _capture_editor_delta_baseline(self):
         """Capture the authoritative form values used to build update deltas."""

--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -60,6 +60,33 @@ from gettext import gettext as _
 logger = logging.getLogger(__name__)
 
 
+def _reveal_after_unlock(app_window, anchor, start_worker):
+    """Run ``start_worker`` once the secret backend is unlocked.
+
+    Password/passphrase reveal is a best-effort background fetch: a locked
+    session backend (Bitwarden/Vaultwarden) silently resolves lookups to
+    nothing, which used to leave the field blank with no indication the
+    secret exists (#1199). Query the backend's lock state first and, if it
+    needs unlocking, prompt through the daemon-owned unlock flow before
+    fetching — mirroring the save-path gate (``_needs_secret_unlock_before_save``).
+    ``start_worker`` always runs afterwards; a still-locked backend (unlock
+    declined or failed) just keeps returning nothing, same as before this gate
+    existed.
+    """
+    controller = getattr(app_window, 'secrets_controller', None)
+    state = None
+    if controller is not None:
+        try:
+            state = controller.load_state()
+        except Exception:
+            state = None
+    if state is not None and (state.needs_unlock or state.login_required):
+        from .secret_unlock_dialog import prompt_unlock
+        prompt_unlock(anchor, on_done=lambda _ok: start_worker())
+        return
+    start_worker()
+
+
 def _editor_details_to_connection(details):
     """Adapt a daemon ``ConnectionEditorDetails`` DTO to a form source.
 
@@ -1273,20 +1300,23 @@ class FileListEditor(Adw.PreferencesGroup):
                 pass
             return False
 
-        def worker():
-            try:
-                secret = client.reveal_key_passphrase(norm)
+        def _start_worker():
+            def worker():
                 try:
-                    value = secret.decode('utf-8')
-                finally:
-                    secret[:] = b'\0' * len(secret)
-                    secret.clear()
-            except Exception:
-                logger.warning("Daemon key passphrase reveal unavailable", exc_info=True)
-                value = False
-            GLib.idle_add(_apply, value)
+                    secret = client.reveal_key_passphrase(norm)
+                    try:
+                        value = secret.decode('utf-8')
+                    finally:
+                        secret[:] = b'\0' * len(secret)
+                        secret.clear()
+                except Exception:
+                    logger.warning("Daemon key passphrase reveal unavailable", exc_info=True)
+                    value = False
+                GLib.idle_add(_apply, value)
 
-        threading.Thread(target=worker, daemon=True).start()
+            threading.Thread(target=worker, daemon=True).start()
+
+        _reveal_after_unlock(parent, parent, _start_worker)
 
     def _on_passphrase_visibility_changed(self, row, pass_entry, norm):
         try:
@@ -1321,21 +1351,24 @@ class FileListEditor(Adw.PreferencesGroup):
             row._pass_reveal_pending = False
             return False
 
-        def worker():
-            value = ''
-            try:
-                secret = client.reveal_key_passphrase(norm)
-                try:
-                    value = secret.decode('utf-8')
-                finally:
-                    secret[:] = b'\0' * len(secret)
-                    secret.clear()
-            except Exception:
-                logger.warning("Daemon key passphrase reveal unavailable", exc_info=True)
+        def _start_worker():
+            def worker():
                 value = ''
-            GLib.idle_add(apply, value)
+                try:
+                    secret = client.reveal_key_passphrase(norm)
+                    try:
+                        value = secret.decode('utf-8')
+                    finally:
+                        secret[:] = b'\0' * len(secret)
+                        secret.clear()
+                except Exception:
+                    logger.warning("Daemon key passphrase reveal unavailable", exc_info=True)
+                    value = ''
+                GLib.idle_add(apply, value)
 
-        threading.Thread(target=worker, daemon=True).start()
+            threading.Thread(target=worker, daemon=True).start()
+
+        _reveal_after_unlock(parent, parent, _start_worker)
 
     def _commit_passphrase(self, pass_entry, path, norm, force=False):
         """Validate an edited passphrase; persistence is deferred to dialog save."""
@@ -2279,23 +2312,26 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
                 pass
             return False
 
-        def worker():
-            try:
-                from .api.connection_identity import connection_id_for
-                secret = client.reveal_connection_password(
-                    connection_id_for(self.connection)
-                )
+        def _start_worker():
+            def worker():
                 try:
-                    value = secret.decode('utf-8')
-                finally:
-                    secret[:] = b'\0' * len(secret)
-                    secret.clear()
-            except Exception:
-                logger.warning("Daemon connection password reveal unavailable", exc_info=True)
-                value = False
-            GLib.idle_add(_apply, value)
+                    from .api.connection_identity import connection_id_for
+                    secret = client.reveal_connection_password(
+                        connection_id_for(self.connection)
+                    )
+                    try:
+                        value = secret.decode('utf-8')
+                    finally:
+                        secret[:] = b'\0' * len(secret)
+                        secret.clear()
+                except Exception:
+                    logger.warning("Daemon connection password reveal unavailable", exc_info=True)
+                    value = False
+                GLib.idle_add(_apply, value)
 
-        threading.Thread(target=worker, daemon=True).start()
+            threading.Thread(target=worker, daemon=True).start()
+
+        _reveal_after_unlock(parent, self, _start_worker)
 
     def _on_password_visibility_changed(self, *_args):
         try:
@@ -2331,24 +2367,27 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
             self._password_reveal_pending = False
             return False
 
-        def worker():
-            value = ''
-            try:
-                from .api.connection_identity import connection_id_for
-                secret = client.reveal_connection_password(
-                    connection_id_for(self.connection)
-                )
-                try:
-                    value = secret.decode('utf-8')
-                finally:
-                    secret[:] = b'\0' * len(secret)
-                    secret.clear()
-            except Exception:
-                logger.warning("Daemon connection password reveal unavailable", exc_info=True)
+        def _start_worker():
+            def worker():
                 value = ''
-            GLib.idle_add(apply, value)
+                try:
+                    from .api.connection_identity import connection_id_for
+                    secret = client.reveal_connection_password(
+                        connection_id_for(self.connection)
+                    )
+                    try:
+                        value = secret.decode('utf-8')
+                    finally:
+                        secret[:] = b'\0' * len(secret)
+                        secret.clear()
+                except Exception:
+                    logger.warning("Daemon connection password reveal unavailable", exc_info=True)
+                    value = ''
+                GLib.idle_add(apply, value)
 
-        threading.Thread(target=worker, daemon=True).start()
+            threading.Thread(target=worker, daemon=True).start()
+
+        _reveal_after_unlock(parent, self, _start_worker)
 
     def _capture_editor_delta_baseline(self):
         """Capture the authoritative form values used to build update deltas."""

--- a/tests/test_connection_dialog_passphrase.py
+++ b/tests/test_connection_dialog_passphrase.py
@@ -724,6 +724,124 @@ def test_unavailable_editor_does_not_read_password_from_projection_manager():
     assert dialog.password_row.get_text() == ""
 
 
+def test_daemon_editor_prompts_unlock_before_loading_password(monkeypatch):
+    """#1199: a locked session vault must be unlocked (not silently skipped)
+    before the connection dialog tries to reveal a saved password."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class DaemonClient:
+        def __init__(self):
+            self.reveal_id = None
+
+        def reveal_connection_password(self, connection_id):
+            self.reveal_id = connection_id
+            return bytearray(b"hunter2")
+
+    class Controller:
+        def __init__(self):
+            self.state = types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+        def load_state(self):
+            return self.state
+
+    client = DaemonClient()
+    controller = Controller()
+    parent = types.SimpleNamespace(
+        connection_manager=object(),
+        client=client,
+        client_bridge=object(),
+        _daemon_ready=lambda: True,
+        secrets_controller=controller,
+    )
+
+    dialog = ConnectionDialog.__new__(ConnectionDialog)
+    dialog.parent_window = parent
+    dialog.connection = types.SimpleNamespace(nickname="web", username="root")
+    dialog.password_row = DummyEntry("")
+
+    idle_calls = []
+    pending_threads = []
+    unlock_calls = []
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+
+        def start(self):
+            pending_threads.append(self)
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        unlock_calls.append(anchor)
+        on_done(True)
+        return True
+
+    monkeypatch.setattr(dialog_module.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        dialog_module.GLib,
+        "idle_add",
+        lambda callback, *args: idle_calls.append((callback, args)),
+    )
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+
+    dialog._load_password_async()
+
+    # The unlock prompt runs before any reveal is attempted.
+    assert unlock_calls == [dialog]
+    assert len(pending_threads) == 1
+    pending_threads[0].target()
+    assert client.reveal_id == "web"
+    callback, (password,) = idle_calls[0]
+    callback(password)
+    assert dialog.password_row.get_text() == "hunter2"
+
+
+def test_daemon_editor_skips_reveal_worker_gate_when_already_unlocked(monkeypatch):
+    """No stored state, or an already-unlocked backend, must not prompt."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class DaemonClient:
+        def reveal_connection_password(self, connection_id):
+            return bytearray(b"hunter2")
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=False, login_required=False)
+
+    parent = types.SimpleNamespace(
+        connection_manager=object(),
+        client=DaemonClient(),
+        client_bridge=object(),
+        _daemon_ready=lambda: True,
+        secrets_controller=Controller(),
+    )
+
+    dialog = ConnectionDialog.__new__(ConnectionDialog)
+    dialog.parent_window = parent
+    dialog.connection = types.SimpleNamespace(nickname="web", username="root")
+    dialog.password_row = DummyEntry("")
+
+    pending_threads = []
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+
+        def start(self):
+            pending_threads.append(self)
+
+    def unexpected_prompt_unlock(*_a, **_kw):
+        raise AssertionError("must not prompt when already unlocked")
+
+    monkeypatch.setattr(dialog_module.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", unexpected_prompt_unlock)
+
+    dialog._load_password_async()
+
+    assert len(pending_threads) == 1
+
+
 def test_daemon_editor_loads_passphrase_from_protected_reveal(monkeypatch):
     import sshpilot.connection_dialog as dialog_module
     from sshpilot.connection_dialog import FileListEditor
@@ -783,6 +901,77 @@ def test_daemon_editor_loads_passphrase_from_protected_reveal(monkeypatch):
     assert entry.get_text() == "key-secret"
     assert row._pass_initial == "key-secret"
     assert row._pass_saved is True
+
+
+def test_filelisteditor_prompts_unlock_before_loading_passphrase(monkeypatch):
+    """#1199: a locked session vault must be unlocked before the key editor
+    tries to reveal a saved passphrase, instead of silently showing it empty."""
+    import sshpilot.connection_dialog as dialog_module
+    from sshpilot.connection_dialog import FileListEditor
+
+    class DaemonClient:
+        def __init__(self):
+            self.reveal_key = None
+
+        def reveal_key_passphrase(self, key_path):
+            self.reveal_key = key_path
+            return bytearray(b"key-secret")
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+    client = DaemonClient()
+    parent = types.SimpleNamespace(
+        connection_manager=object(),
+        client=client,
+        client_bridge=object(),
+        _daemon_ready=lambda: True,
+        secrets_controller=Controller(),
+    )
+
+    ed = FileListEditor.__new__(FileListEditor)
+    ed._connection_manager = parent.connection_manager
+    ed._parent_window = parent
+
+    entry = DummyEntry("")
+    row = types.SimpleNamespace(_pass_initial="", _pass_entry=entry)
+    norm = "/home/demo/.ssh/id_ed25519"
+
+    idle_calls = []
+    pending_threads = []
+    unlock_calls = []
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+
+        def start(self):
+            pending_threads.append(self)
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        unlock_calls.append(anchor)
+        on_done(True)
+        return True
+
+    monkeypatch.setattr(dialog_module.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        dialog_module.GLib,
+        "idle_add",
+        lambda callback, *args: idle_calls.append((callback, args)),
+    )
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+
+    ed._load_passphrase_async(entry, row, norm)
+
+    assert unlock_calls == [parent]
+    assert len(pending_threads) == 1
+    pending_threads[0].target()
+    assert client.reveal_key == norm
+    callback, (value,) = idle_calls[0]
+    callback(value)
+    assert entry.get_text() == "key-secret"
 
 
 def test_unavailable_editor_does_not_read_passphrase_from_projection_manager():

--- a/tests/test_connection_dialog_passphrase.py
+++ b/tests/test_connection_dialog_passphrase.py
@@ -26,6 +26,23 @@ class DummyEntry:
         return None
 
 
+class DummyPasswordEntry(DummyEntry):
+    """A DummyEntry that also tracks peek/reveal visibility state."""
+
+    def __init__(self, text=""):
+        super().__init__(text)
+        self._visible = False
+
+    def set_visibility(self, value):
+        self._visible = bool(value)
+
+    def get_visibility(self):
+        return self._visible
+
+    def set_show_peek_icon(self, *_args, **_kwargs):
+        return None
+
+
 class DummySubtitleRow(DummyEntry):
     def __init__(self, text=""):
         super().__init__(text)
@@ -658,12 +675,17 @@ def test_daemon_editor_loads_password_from_protected_reveal(monkeypatch):
     class Bridge:
         pass
 
+    class UnlockedController:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=False, login_required=False)
+
     client = DaemonClient()
     parent = types.SimpleNamespace(
         connection_manager=object(),  # read-only projection, no secret access
         client=client,
         client_bridge=Bridge(),
         _daemon_ready=lambda: True,
+        secrets_controller=UnlockedController(),
     )
 
     dialog = ConnectionDialog.__new__(ConnectionDialog)
@@ -797,7 +819,7 @@ def test_daemon_editor_prompts_unlock_before_loading_password(monkeypatch):
 
 
 def test_daemon_editor_skips_reveal_worker_gate_when_already_unlocked(monkeypatch):
-    """No stored state, or an already-unlocked backend, must not prompt."""
+    """An already-unlocked backend must not prompt."""
     import sshpilot.connection_dialog as dialog_module
 
     class DaemonClient:
@@ -842,6 +864,212 @@ def test_daemon_editor_skips_reveal_worker_gate_when_already_unlocked(monkeypatc
     assert len(pending_threads) == 1
 
 
+def test_password_peek_gates_on_unlock_and_recovers_after_decline(monkeypatch):
+    """Peeking a saved password while locked must prompt to unlock rather than
+    silently revealing nothing. A declined/cancelled unlock must not wedge
+    ``_password_reveal_pending`` forever — a later peek (after the vault is
+    unlocked some other way) must still be able to succeed."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class DaemonClient:
+        def reveal_connection_password(self, connection_id):
+            return bytearray(b"hunter2")
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+    parent = types.SimpleNamespace(
+        connection_manager=object(),
+        client=DaemonClient(),
+        client_bridge=object(),
+        _daemon_ready=lambda: True,
+        secrets_controller=Controller(),
+    )
+
+    dialog = ConnectionDialog.__new__(ConnectionDialog)
+    dialog.parent_window = parent
+    dialog.connection = types.SimpleNamespace(nickname="web", username="root")
+    dialog.password_row = DummyPasswordEntry("")
+    dialog.password_row.set_visibility(True)
+    dialog._password_saved = True
+
+    pending_threads = []
+    idle_calls = []
+    unlock_results = [False, True]
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+
+        def start(self):
+            pending_threads.append(self)
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        on_done(unlock_results.pop(0))
+
+    monkeypatch.setattr(dialog_module.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        dialog_module.GLib, "idle_add",
+        lambda callback, *args: idle_calls.append((callback, args)),
+    )
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+
+    # First peek: unlock declined -> no reveal attempted, pending flag cleared.
+    dialog._on_password_visibility_changed()
+    assert pending_threads == []
+    assert dialog._password_reveal_pending is False
+
+    # Second peek: unlock succeeds -> reveal proceeds and completes normally.
+    dialog._on_password_visibility_changed()
+    assert len(pending_threads) == 1
+    pending_threads[0].target()
+    callback, (value,) = idle_calls[0]
+    callback(value)
+    assert dialog.password_row.get_text() == "hunter2"
+    assert dialog._password_reveal_pending is False
+
+
+def test_reveal_after_unlock_runs_worker_directly_when_unlocked():
+    """Unit coverage of the shared gate: an already-unlocked backend runs the
+    worker with no unlock prompt at all."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=False, login_required=False)
+
+    app_window = types.SimpleNamespace(secrets_controller=Controller())
+    calls = []
+    dialog_module._reveal_after_unlock(
+        app_window, object(), lambda: calls.append("worker"))
+    assert calls == ["worker"]
+
+
+def test_reveal_after_unlock_runs_worker_only_when_unlock_succeeds(monkeypatch):
+    """#1201 review: the worker must run when (and only when) prompt_unlock
+    reports success — never unconditionally after the prompt merely returns."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+    app_window = types.SimpleNamespace(secrets_controller=Controller())
+    anchor = object()
+    calls = []
+    unlock_calls = []
+
+    def fake_prompt_unlock(passed_anchor, on_done=None, **_kw):
+        unlock_calls.append(passed_anchor)
+        on_done(True)
+
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+    dialog_module._reveal_after_unlock(
+        app_window, anchor, lambda: calls.append("worker"))
+    assert unlock_calls == [anchor]
+    assert calls == ["worker"]
+
+
+def test_reveal_after_unlock_skips_worker_and_runs_on_declined_when_unlock_fails(monkeypatch):
+    """A cancelled/failed unlock must not attempt a doomed lookup — that would
+    otherwise record a false "no secret saved" result. ``on_declined`` runs
+    instead so the caller can reset "reveal pending" bookkeeping."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+    app_window = types.SimpleNamespace(secrets_controller=Controller())
+    calls = []
+    declined = []
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        on_done(False)
+
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+    dialog_module._reveal_after_unlock(
+        app_window, object(), lambda: calls.append("worker"),
+        on_declined=lambda: declined.append(1))
+    assert calls == []
+    assert declined == [1]
+
+
+def test_reveal_after_unlock_gates_on_login_required(monkeypatch):
+    """``login_required`` alone (no ``needs_unlock``) must still gate the
+    reveal — the daemon-owned unlock flow handles both states."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=False, login_required=True)
+
+    app_window = types.SimpleNamespace(secrets_controller=Controller())
+    calls = []
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        calls.append("prompted")
+        on_done(True)
+
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+    dialog_module._reveal_after_unlock(
+        app_window, object(), lambda: calls.append("worker"))
+    assert calls == ["prompted", "worker"]
+
+
+def test_reveal_after_unlock_treats_missing_controller_as_locked(monkeypatch):
+    """No reachable secrets_controller (e.g. daemon capability not advertised)
+    must be treated conservatively as locked, mirroring
+    ``_needs_secret_unlock_before_save`` — never a fail-open straight fetch."""
+    import sshpilot.connection_dialog as dialog_module
+
+    app_window = types.SimpleNamespace()  # no secrets_controller attribute at all
+    calls = []
+    unlock_calls = []
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        unlock_calls.append(anchor)
+        on_done(False)
+
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+    dialog_module._reveal_after_unlock(
+        app_window, object(), lambda: calls.append("worker"))
+    assert unlock_calls  # gated through prompt_unlock rather than fetching straight away
+    assert calls == []
+
+
+def test_reveal_after_unlock_treats_state_query_failure_as_locked(monkeypatch):
+    """A transient failure reading lock state must not be treated as
+    "unlocked" — that would reproduce #1199 by reading a possibly-locked
+    backend without ever prompting."""
+    import sshpilot.connection_dialog as dialog_module
+
+    class BrokenController:
+        def load_state(self):
+            raise RuntimeError("daemon unreachable")
+
+    app_window = types.SimpleNamespace(secrets_controller=BrokenController())
+    calls = []
+    unlock_calls = []
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        unlock_calls.append(anchor)
+        on_done(True)
+
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+    dialog_module._reveal_after_unlock(
+        app_window, object(), lambda: calls.append("worker"))
+    assert unlock_calls
+    assert calls == ["worker"]
+
+
 def test_daemon_editor_loads_passphrase_from_protected_reveal(monkeypatch):
     import sshpilot.connection_dialog as dialog_module
     from sshpilot.connection_dialog import FileListEditor
@@ -857,12 +1085,17 @@ def test_daemon_editor_loads_passphrase_from_protected_reveal(monkeypatch):
     class Bridge:
         pass
 
+    class UnlockedController:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=False, login_required=False)
+
     client = DaemonClient()
     parent = types.SimpleNamespace(
         connection_manager=object(),  # read-only projection, no secret access
         client=client,
         client_bridge=Bridge(),
         _daemon_ready=lambda: True,
+        secrets_controller=UnlockedController(),
     )
 
     ed = FileListEditor.__new__(FileListEditor)
@@ -972,6 +1205,75 @@ def test_filelisteditor_prompts_unlock_before_loading_passphrase(monkeypatch):
     callback, (value,) = idle_calls[0]
     callback(value)
     assert entry.get_text() == "key-secret"
+
+
+def test_passphrase_peek_gates_on_unlock_and_recovers_after_decline(monkeypatch):
+    """Same #1201 review concern as the password peek, for the key editor:
+    a declined unlock must clear ``row._pass_reveal_pending`` so a later peek
+    can still succeed instead of being wedged forever."""
+    import sshpilot.connection_dialog as dialog_module
+    from sshpilot.connection_dialog import FileListEditor
+
+    class DaemonClient:
+        def reveal_key_passphrase(self, key_path):
+            return bytearray(b"key-secret")
+
+    class Controller:
+        def load_state(self):
+            return types.SimpleNamespace(needs_unlock=True, login_required=False)
+
+    parent = types.SimpleNamespace(
+        connection_manager=object(),
+        client=DaemonClient(),
+        client_bridge=object(),
+        _daemon_ready=lambda: True,
+        secrets_controller=Controller(),
+    )
+
+    ed = FileListEditor.__new__(FileListEditor)
+    ed._connection_manager = parent.connection_manager
+    ed._parent_window = parent
+
+    entry = DummyPasswordEntry("")
+    entry.set_visibility(True)
+    row = types.SimpleNamespace(_pass_initial="", _pass_entry=entry, _pass_saved=True)
+    norm = "/home/demo/.ssh/id_ed25519"
+
+    pending_threads = []
+    idle_calls = []
+    unlock_results = [False, True]
+
+    class DeferredThread:
+        def __init__(self, target, daemon=False):
+            self.target = target
+
+        def start(self):
+            pending_threads.append(self)
+
+    def fake_prompt_unlock(anchor, on_done=None, **_kw):
+        on_done(unlock_results.pop(0))
+
+    monkeypatch.setattr(dialog_module.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        dialog_module.GLib, "idle_add",
+        lambda callback, *args: idle_calls.append((callback, args)),
+    )
+    monkeypatch.setattr(
+        "sshpilot.secret_unlock_dialog.prompt_unlock", fake_prompt_unlock)
+
+    # First peek: unlock declined -> no reveal attempted, pending flag cleared.
+    ed._on_passphrase_visibility_changed(row, entry, norm)
+    assert pending_threads == []
+    assert row._pass_reveal_pending is False
+
+    # Second peek: unlock succeeds -> reveal proceeds and completes normally.
+    ed._on_passphrase_visibility_changed(row, entry, norm)
+    assert len(pending_threads) == 1
+    pending_threads[0].target()
+    callback, (value,) = idle_calls[0]
+    callback(value)
+    assert entry.get_text() == "key-secret"
+    assert row._pass_reveal_pending is False
 
 
 def test_unavailable_editor_does_not_read_passphrase_from_projection_manager():


### PR DESCRIPTION
## Summary

When a session vault (Bitwarden/Vaultwarden) is locked, password and passphrase reveal operations silently fail and return nothing, leaving fields blank with no indication that secrets exist. This change adds an unlock gate before attempting to reveal saved passwords and passphrases, mirroring the existing save-path behavior.

Users will now be prompted to unlock the vault before the connection dialog or key editor attempts to reveal a saved password/passphrase, ensuring they're aware the secret exists and have the opportunity to unlock it.

## Changes

- Added `_reveal_after_unlock()` helper function that checks the secrets controller's lock state and prompts for unlock if needed before executing a reveal operation
- Updated `ConnectionDialog._load_password_async()` to gate password reveal behind the unlock check
- Updated `ConnectionDialog._on_password_visibility_changed()` to gate password reveal behind the unlock check  
- Updated `FileListEditor._load_passphrase_async()` to gate passphrase reveal behind the unlock check
- Updated `FileListEditor._on_passphrase_visibility_changed()` to gate passphrase reveal behind the unlock check

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or core/frontend ownership boundary

This is a UI-only change that improves the user experience when interacting with locked secret backends. No API contracts, DTOs, or capabilities are affected.

## Testing

Added comprehensive test coverage:
- `test_daemon_editor_prompts_unlock_before_loading_password`: Verifies the connection dialog prompts for unlock before revealing a saved password
- `test_daemon_editor_skips_reveal_worker_gate_when_already_unlocked`: Verifies no prompt occurs when the vault is already unlocked
- `test_filelisteditor_prompts_unlock_before_loading_passphrase`: Verifies the key editor prompts for unlock before revealing a saved passphrase

All new tests pass and validate the unlock gate behavior in both locked and unlocked states.

https://claude.ai/code/session_01AqGiNG369UUPNZfWGuyMEF