### PR TITLE
Fix encrypted backup export deadlock on GTK main thread

### DIFF
--- a/src/sshpilot/daemon/interaction_broker.py
+++ b/src/sshpilot/daemon/interaction_broker.py
@@ -67,6 +67,10 @@ from sshpilot.logging_support import log_context
 DEFAULT_SECRET_INTERACTION_TIMEOUT = 120.0
 DEFAULT_HOST_KEY_INTERACTION_TIMEOUT = 180.0
 DEFAULT_PRESENCE_INTERACTION_TIMEOUT = 600.0
+# Backup export/import encryption passphrase prompts are a short, self-contained
+# step in an otherwise fast local operation — 120s (tuned for SSH auth retries)
+# leaves the UI looking hung far longer than the prompt itself warrants.
+DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT = 30.0
 DEFAULT_COMPLETED_INTERACTION_LIMIT = 100
 DEFAULT_ASKPASS_WORKERS = 4
 DEFAULT_ASKPASS_QUEUE_LIMIT = 32
@@ -772,14 +776,16 @@ class InteractionBroker:
         connection_id: ConnectionId,
         interaction_type: InteractionType,
         prompt: InteractionPrompt,
+        timeout: Optional[float] = None,
     ) -> Optional[bytearray]:
         """Collect one secret for a daemon-owned non-process operation."""
-        result = self._request_client_secret_result(
+        result, _state = self._request_client_secret_result(
             owner_client_id=owner_client_id,
             session_id=session_id,
             connection_id=connection_id,
             interaction_type=interaction_type,
             prompt=prompt,
+            timeout=timeout,
         )
         return None if result is None else result.secret
 
@@ -791,21 +797,48 @@ class InteractionBroker:
         connection_id: ConnectionId,
         interaction_type: InteractionType,
         prompt: InteractionPrompt,
+        timeout: Optional[float] = None,
     ) -> tuple[Optional[bytearray], RememberPolicy]:
         """Like :meth:`request_client_secret`, but also reports the
         ``remember_policy`` the client attached to its response (e.g. a
         "remember this" checkbox) — needed by callers that offer to persist
         the secret without a second prompt."""
-        result = self._request_client_secret_result(
+        result, _state = self._request_client_secret_result(
             owner_client_id=owner_client_id,
             session_id=session_id,
             connection_id=connection_id,
             interaction_type=interaction_type,
             prompt=prompt,
+            timeout=timeout,
         )
         if result is None:
             return None, RememberPolicy.DO_NOT_STORE
         return result.secret, result.remember_policy
+
+    def request_client_secret_with_status(
+        self,
+        *,
+        owner_client_id: ClientId,
+        session_id: SessionId,
+        connection_id: ConnectionId,
+        interaction_type: InteractionType,
+        prompt: InteractionPrompt,
+        timeout: Optional[float] = None,
+    ) -> tuple[Optional[bytearray], InteractionState]:
+        """Like :meth:`request_client_secret`, but also reports the
+        interaction's final :class:`InteractionState`. Callers that need to
+        tell an explicit user cancellation apart from a timed-out prompt
+        (rather than collapsing both into a bare ``None``) should use this
+        instead of :meth:`request_client_secret`."""
+        result, state = self._request_client_secret_result(
+            owner_client_id=owner_client_id,
+            session_id=session_id,
+            connection_id=connection_id,
+            interaction_type=interaction_type,
+            prompt=prompt,
+            timeout=timeout,
+        )
+        return (None if result is None else result.secret), state
 
     def _request_client_secret_result(
         self,
@@ -815,8 +848,10 @@ class InteractionBroker:
         connection_id: ConnectionId,
         interaction_type: InteractionType,
         prompt: InteractionPrompt,
-    ) -> Optional[InteractionResult]:
-        """Run one direct-scope interaction and return its raw result.
+        timeout: Optional[float] = None,
+    ) -> tuple[Optional[InteractionResult], InteractionState]:
+        """Run one direct-scope interaction and return its raw result plus
+        its final :class:`InteractionState`.
 
         Registering ``owner_client_id`` as the session's direct scope owner
         (via ``_direct_scope_owners``) is what makes the server actually
@@ -836,6 +871,7 @@ class InteractionBroker:
                 raise ValueError("protected interaction scope is already active")
             self._direct_scope_owners[session_id] = owner_client_id
         result: Optional[InteractionResult] = None
+        state = InteractionState.CANCELLED
         try:
             summary = self.create(
                 session_id=session_id,
@@ -843,11 +879,12 @@ class InteractionBroker:
                 interaction_type=interaction_type,
                 prompt=prompt,
                 attempt=1,
+                timeout=timeout,
             )
-            result = self.wait_for_result(summary.id)
+            result, state = self._wait_for_result_with_state(summary.id)
             if result is None or result.secret is None:
-                return None
-            return result
+                return None, state
+            return result, state
         finally:
             with self._condition:
                 self._direct_scope_owners.pop(session_id, None)
@@ -1083,6 +1120,20 @@ class InteractionBroker:
         *,
         cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Optional[InteractionResult]:
+        result, _state = self._wait_for_result_with_state(
+            interaction_id, cancel_check=cancel_check
+        )
+        return result
+
+    def _wait_for_result_with_state(
+        self,
+        interaction_id: InteractionId,
+        *,
+        cancel_check: Optional[Callable[[], bool]] = None,
+    ) -> tuple[Optional[InteractionResult], InteractionState]:
+        """Like :meth:`wait_for_result`, but also returns the interaction's
+        final state so callers can distinguish ``CANCELLED`` from
+        ``EXPIRED`` instead of both collapsing to ``None``."""
         changed_summary: Optional[InteractionSummary] = None
         with self._condition:
             record = self._record_locked(interaction_id)
@@ -1122,9 +1173,10 @@ class InteractionBroker:
                 record.result_taken = True
                 result = record.result
                 record.result = None
+            final_state = record.summary.state
         if changed_summary is not None:
             self._publish(EventType.INTERACTION_STATE_CHANGED, changed_summary)
-        return result
+        return result, final_state
 
     @staticmethod
     def _transport_is_closed(transport: socket.socket) -> bool:

--- a/src/sshpilot/daemon/secret_backend_service.py
+++ b/src/sshpilot/daemon/secret_backend_service.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sshpilot.api.errors import ErrorCode, SshPilotError
 from sshpilot.api.models.common import ConnectionId, SessionId
 from sshpilot.api.models.interactions import (
+    InteractionState,
     InteractionType,
     PasswordPrompt,
     RememberPolicy,
@@ -1022,18 +1023,28 @@ class SecretBackendService:
             opts = dict(options or {})
             passphrase = None
             if opts.get("encrypted"):
-                prompt = self._prompt_for_secret(
+                from sshpilot.daemon.interaction_broker import (
+                    DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT,
+                )
+
+                prompt, state = self._prompt_for_secret_with_status(
                     "Enter a passphrase to encrypt the backup",
                     owner_client_id=owner_client_id,
+                    timeout=DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT,
                 )
                 if prompt is None:
+                    message = (
+                        "Encryption password request timed out"
+                        if state is InteractionState.EXPIRED
+                        else "Encryption cancelled"
+                    )
                     return SecretTransferResult(
                         operation="export",
                         path=destination,
                         counts={},
                         warnings=(),
                         status=SecretOperationState.INTERACTION_REQUIRED,
-                        message="Encryption cancelled",
+                        message=message,
                     )
                 passphrase = prompt.decode("utf-8", "replace")
                 _clear_secret(prompt)
@@ -1535,9 +1546,31 @@ class SecretBackendService:
 
         Returns the secret as a bytearray (the caller must clear it), or ``None``
         when the interaction was cancelled, expired, or the broker is unavailable.
+        See :meth:`_prompt_for_secret_with_status` for why this is routed
+        through ``request_client_secret`` rather than a bare create() +
+        wait_for_result().
+        """
+        secret, _state = self._prompt_for_secret_with_status(
+            message, owner_client_id=owner_client_id
+        )
+        return secret
 
-        Routed through ``request_client_secret`` (not a bare ``create()`` +
-        ``wait_for_result()``): the server only forwards
+    def _prompt_for_secret_with_status(
+        self,
+        message: str,
+        *,
+        owner_client_id,
+        timeout: Optional[float] = None,
+    ) -> Tuple[Optional[bytearray], InteractionState]:
+        """Like :meth:`_prompt_for_secret`, but also returns the interaction's
+        final :class:`InteractionState` so callers can tell an explicit user
+        cancellation apart from a timed-out prompt, and can request a
+        shorter-than-default ``timeout`` for a self-contained prompt (e.g.
+        the backup encryption passphrase) without touching the timeout used
+        by every other secret prompt.
+
+        Routed through ``request_client_secret_with_status`` (not a bare
+        ``create()`` + ``wait_for_result()``): the server only forwards
         INTERACTION_CREATED/STATE_CHANGED events for a synthetic
         ``secret-session-N`` scope to a client that is registered as that
         scope's owner (see ``DaemonServer._client_can_interact``) — a
@@ -1554,7 +1587,7 @@ class SecretBackendService:
             )
         session_id = _next_secret_session_id()
         connection_id = ConnectionId(f"secret-{session_id}")
-        return self._broker.request_client_secret(
+        return self._broker.request_client_secret_with_status(
             owner_client_id=owner_client_id,
             session_id=session_id,
             connection_id=connection_id,
@@ -1567,6 +1600,7 @@ class SecretBackendService:
                 can_remember=False,
                 stored_secret_available=False,
             ),
+            timeout=timeout,
         )
 
     def _prompt_for_master_password(

--- a/src/sshpilot/window_dialogs.py
+++ b/src/sshpilot/window_dialogs.py
@@ -1236,12 +1236,66 @@ class WindowConfigDialogsMixin:
         warn.connect('response', on_warn)
         warn.present()
 
+    def _run_local_export(self, *, export_path, connections, options, encrypt):
+        """Run the daemon-owned ``.spbk`` export off the GTK main thread.
+
+        The daemon RPC below blocks on the encryption passphrase interaction
+        (when ``encrypt``): the interaction can only be claimed and answered
+        once the GTK main loop is free to process it, so the RPC must not run
+        on the calling (GTK) thread — see ``_export_to_ssh_server``/
+        ``_run_daemon_import`` for the same pattern. Running it inline on the
+        caller used to deadlock the export until the interaction expired
+        (issue #1200)."""
+        controller = self._secrets_controller()
+        from .bitwarden_backup_setup import progress_dialog
+        cancelled = {'v': False}
+        _set_status, close_spinner = progress_dialog(
+            self, _("Export Backup"),
+            _("Exporting backup — this may take a while…"),
+            on_cancel=lambda: cancelled.__setitem__('v', True))
+
+        def worker():
+            try:
+                result = controller.export_backup(
+                    destination=export_path,
+                    connection_ids=self._connection_ids_for(connections),
+                    options={**options, 'encrypted': bool(encrypt)})
+                payload = ('ok', result)
+            except Exception as e:
+                logger.error(f"Export failed: {e}")
+                payload = ('error', str(e))
+            GLib.idle_add(lambda: (_report(payload), False)[1])
+
+        def _report(p):
+            if cancelled['v']:
+                return   # user cancelled the wait
+            close_spinner()
+            if p[0] != 'ok':
+                self._simple_dialog(_("Export Failed"), p[1])
+                return
+            result = p[1]
+            if result.status.value != 'success':
+                self._simple_dialog(
+                    _("Export Failed"),
+                    result.message or _("Unknown error"))
+                return
+            counts = result.counts or {}
+            msg = _("Backup saved to:\n{}\n\n{} credential(s) and {} private key(s) "
+                    "included; encryption: {}.").format(
+                export_path, counts.get('credentials', 0),
+                counts.get('private_keys', 0),
+                _("on") if encrypt else _("off"))
+            if result.warnings:
+                msg += "\n\n" + "\n\n".join(result.warnings)
+            self._simple_dialog(_("Export Successful"), msg)
+
+        threading.Thread(target=worker, daemon=True).start()
+
     def _choose_export_path(self, connections, encrypt, options):
         """Pick a ``.spbk`` path (GTK file picker), then run the daemon-owned export.
 
         ``encrypt`` is a flag: the passphrase itself is collected by a protected
         interaction inside the daemon, so it never passes through this window."""
-        controller = self._secrets_controller()
         file_dialog = Gtk.FileDialog()
         file_dialog.set_title(_("Export Backup"))
         file_dialog.set_initial_name(
@@ -1277,29 +1331,9 @@ class WindowConfigDialogsMixin:
                 export_path += '.spbk'
 
             def do_export(*_args):
-                try:
-                    result = controller.export_backup(
-                        destination=export_path,
-                        connection_ids=self._connection_ids_for(connections),
-                        options={**options, 'encrypted': bool(encrypt)})
-                except Exception as e:
-                    logger.error(f"Export failed: {e}")
-                    self._simple_dialog(_("Export Failed"), str(e))
-                    return
-                if result.status.value != 'success':
-                    self._simple_dialog(
-                        _("Export Failed"),
-                        result.message or _("Unknown error"))
-                    return
-                counts = result.counts or {}
-                msg = _("Backup saved to:\n{}\n\n{} credential(s) and {} private key(s) "
-                        "included; encryption: {}.").format(
-                    export_path, counts.get('credentials', 0),
-                    counts.get('private_keys', 0),
-                    _("on") if encrypt else _("off"))
-                if result.warnings:
-                    msg += "\n\n" + "\n\n".join(result.warnings)
-                self._simple_dialog(_("Export Successful"), msg)
+                self._run_local_export(
+                    export_path=export_path, connections=connections,
+                    options=options, encrypt=encrypt)
 
             self._run_after_vault_unlock_for_secrets(
                 do_export,

--- a/tests/daemon/test_interaction_broker.py
+++ b/tests/daemon/test_interaction_broker.py
@@ -245,6 +245,94 @@ def test_expiry_wakes_waiter_and_rejects_late_response() -> None:
         broker.close()
 
 
+def test_request_client_secret_with_status_reports_expired_not_cancelled(
+    broker: InteractionBroker,
+) -> None:
+    """Issue #1200: a timed-out backup-encryption prompt must be reported as
+    EXPIRED, not collapsed into the same ``None`` a user cancellation returns —
+    the ``timeout`` override (used for the shorter backup-encryption prompt) is
+    exercised here, independent of the broker's configured default."""
+    secret, state = broker.request_client_secret_with_status(
+        owner_client_id=CLIENT_A,
+        session_id=SessionId("secret-timeout-1"),
+        connection_id=ConnectionId("secret-timeout-1"),
+        interaction_type=InteractionType.PASSWORD,
+        prompt=PasswordPrompt(
+            username="Secret backend", hostname="secret backend", port=22,
+            attempt=1, can_remember=False, stored_secret_available=False),
+        timeout=0.03,
+    )
+    assert secret is None
+    assert state is InteractionState.EXPIRED
+
+
+def test_request_client_secret_with_status_reports_explicit_cancel(
+    broker: InteractionBroker,
+) -> None:
+    """A real user cancellation must still report CANCELLED, distinct from
+    a timeout — see the EXPIRED counterpart above."""
+    session_id = SessionId("secret-cancel-1")
+    connection_id = ConnectionId("secret-cancel-1")
+    outcome: dict = {}
+
+    def waiter() -> None:
+        secret, state = broker.request_client_secret_with_status(
+            owner_client_id=CLIENT_A,
+            session_id=session_id,
+            connection_id=connection_id,
+            interaction_type=InteractionType.PASSWORD,
+            prompt=PasswordPrompt(
+                username="Secret backend", hostname="secret backend", port=22,
+                attempt=1, can_remember=False, stored_secret_available=False),
+        )
+        outcome["secret"] = secret
+        outcome["state"] = state
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    try:
+        interaction = None
+        deadline = time.monotonic() + 1.0
+        while interaction is None and time.monotonic() < deadline:
+            for candidate in broker.list(CLIENT_A):
+                if candidate.session_id == session_id:
+                    interaction = candidate
+                    break
+            if interaction is None:
+                time.sleep(0.01)
+        assert interaction is not None, "interaction was never created"
+        broker.claim(interaction.id, CLIENT_A)
+        broker.respond(
+            InteractionDecisionRequest(
+                interaction_id=interaction.id,
+                secret_decision=SecretDecision.CANCEL,
+                remember_policy=RememberPolicy.DO_NOT_STORE,
+            ),
+            CLIENT_A,
+        )
+    finally:
+        thread.join(1)
+    assert not thread.is_alive()
+    assert outcome["secret"] is None
+    assert outcome["state"] is InteractionState.CANCELLED
+
+
+def test_backup_encryption_timeout_constant_is_shorter_than_default_secret_timeout() -> None:
+    """Pins the ~30s design target for the backup-encryption prompt (issue
+    #1200): far shorter than the general 120s secret-interaction timeout, so
+    an unattended export fails fast instead of looking hung for two minutes."""
+    from sshpilot.daemon.interaction_broker import (
+        DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT,
+        DEFAULT_SECRET_INTERACTION_TIMEOUT,
+    )
+
+    assert DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT == 30.0
+    assert (
+        DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT
+        < DEFAULT_SECRET_INTERACTION_TIMEOUT
+    )
+
+
 def test_session_cancel_and_close_leave_no_active_interactions(
     broker: InteractionBroker,
 ) -> None:

--- a/tests/daemon/test_secret_backend_service.py
+++ b/tests/daemon/test_secret_backend_service.py
@@ -248,6 +248,13 @@ class FakeBroker:
             result, "remember_policy", RememberPolicy.DO_NOT_STORE
         )
 
+    def request_client_secret_with_status(self, *, owner_client_id, **kwargs) -> Any:
+        from sshpilot.api.models.interactions import InteractionState
+
+        secret = self.request_client_secret(owner_client_id=owner_client_id, **kwargs)
+        state = InteractionState.CANCELLED if secret is None else InteractionState.ANSWERED
+        return secret, state
+
 
 def _write_settings(path: Path, secrets: Optional[Dict[str, Any]] = None) -> Path:
     config = {
@@ -297,6 +304,132 @@ def _all_strings(value: Any, out: Optional[List[str]] = None) -> List[str]:
         for item in value:
             _all_strings(item, out)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Issue #1200: encrypted backup export — encrypted roundtrip, shorter
+# operation-specific timeout, and cancellation vs. expiration messaging.
+# ---------------------------------------------------------------------------
+
+def test_export_backup_encrypted_roundtrip_decrypts_with_correct_password(tmp_path):
+    """The full ``SecretBackendService.export_backup`` surface (interaction broker
+    included, not just the lower ``daemon_export_backup`` helper): the produced
+    ``.spbk`` is genuinely encrypted, decrypts with the correct passphrase, and a
+    wrong passphrase fails cleanly instead of returning garbage."""
+    from sshpilot.backup_archive import (
+        SpbkPassphraseError,
+        is_spbk,
+        read_spbk,
+        spbk_is_encrypted,
+    )
+
+    service, _manager, _backends, broker, _path = _make_service(
+        tmp_path, expected_secrets=["s3cr3t"])
+    dest = tmp_path / "encrypted.spbk"
+    result = service.export_backup(
+        destination=str(dest),
+        options={"app_settings": True, "ssh_config": False, "known_hosts": False,
+                 "secrets": False, "private_keys": False, "encrypted": True},
+        owner_client_id="client-1",
+    )
+    assert result.status.value == "success", result.message
+    assert is_spbk(str(dest))
+    assert spbk_is_encrypted(str(dest))
+    # The passphrase went through the protected interaction, never as a param.
+    assert broker.created and broker.created[0][1]["interaction_type"].value == "password"
+
+    manifest = read_spbk(str(dest), "s3cr3t")
+    assert "app_config" in manifest
+
+    with pytest.raises(SpbkPassphraseError):
+        read_spbk(str(dest), "wrong-password")
+
+
+def test_export_backup_uses_shorter_backup_encryption_timeout(tmp_path):
+    """The encryption-passphrase interaction must use the shorter, operation-
+    specific backup-encryption timeout, not the general 120s secret timeout."""
+    from sshpilot.daemon.interaction_broker import (
+        DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT,
+    )
+
+    service, _manager, _backends, broker, _path = _make_service(
+        tmp_path, expected_secrets=["s3cr3t"])
+    dest = tmp_path / "encrypted.spbk"
+    result = service.export_backup(
+        destination=str(dest),
+        options={"app_settings": True, "ssh_config": False, "known_hosts": False,
+                 "secrets": False, "private_keys": False, "encrypted": True},
+        owner_client_id="client-1",
+    )
+    assert result.status.value == "success", result.message
+    assert len(broker.created) == 1
+    _interaction_id, kwargs = broker.created[0]
+    assert kwargs.get("timeout") == DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT
+
+
+def test_export_backup_reports_timeout_distinctly_from_cancellation(tmp_path):
+    """A timed-out encryption prompt must not be reported with the same message
+    as an explicit user cancellation (issue #1200: the old code always said
+    'Encryption cancelled', even when the user never touched anything)."""
+    from sshpilot.api.models.interactions import InteractionState
+
+    class _ExpiredBroker(FakeBroker):
+        def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+            self.create(**kwargs)
+            return None, InteractionState.EXPIRED
+
+    service, _manager, _backends, _broker, _path = _make_service(
+        tmp_path, broker=_ExpiredBroker())
+    result = service.export_backup(
+        destination=str(tmp_path / "never-written.spbk"),
+        options={"app_settings": True, "ssh_config": False, "known_hosts": False,
+                 "secrets": False, "private_keys": False, "encrypted": True},
+        owner_client_id="client-1",
+    )
+    assert result.status == SecretOperationState.INTERACTION_REQUIRED
+    assert result.message == "Encryption password request timed out"
+
+
+def test_export_backup_reports_explicit_cancellation(tmp_path):
+    """An actual user cancellation must still read as a cancellation, distinct
+    from the timeout message above."""
+    from sshpilot.api.models.interactions import InteractionState
+
+    class _CancelledBroker(FakeBroker):
+        def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+            self.create(**kwargs)
+            return None, InteractionState.CANCELLED
+
+    service, _manager, _backends, _broker, _path = _make_service(
+        tmp_path, broker=_CancelledBroker())
+    result = service.export_backup(
+        destination=str(tmp_path / "never-written.spbk"),
+        options={"app_settings": True, "ssh_config": False, "known_hosts": False,
+                 "secrets": False, "private_keys": False, "encrypted": True},
+        owner_client_id="client-1",
+    )
+    assert result.status == SecretOperationState.INTERACTION_REQUIRED
+    assert result.message == "Encryption cancelled"
+
+
+def test_export_backup_unencrypted_never_prompts(tmp_path):
+    """Unencrypted export must not touch the interaction broker at all — it
+    should be unaffected by any of the encrypted-export changes above."""
+    service, _manager, _backends, broker, _path = _make_service(tmp_path)
+    dest = tmp_path / "plain.spbk"
+    result = service.export_backup(
+        destination=str(dest),
+        options={"app_settings": True, "ssh_config": False, "known_hosts": False,
+                 "secrets": False, "private_keys": False, "encrypted": False},
+        owner_client_id="client-1",
+    )
+    assert result.status.value == "success", result.message
+    assert broker.created == []
+
+    from sshpilot.backup_archive import is_spbk, spbk_is_encrypted
+
+    assert is_spbk(str(dest))
+    assert not spbk_is_encrypted(str(dest))
 
 
 # ---------------------------------------------------------------------------
@@ -1069,6 +1202,15 @@ def test_import_backup_retries_wrong_passphrase(tmp_path, monkeypatch):
             result = self.wait_for_result(summary.id)
             return None if result is None else result.secret
 
+        def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+            from sshpilot.api.models.interactions import InteractionState
+
+            secret = self.request_client_secret(owner_client_id=owner_client_id, **kwargs)
+            state = (
+                InteractionState.CANCELLED if secret is None else InteractionState.ANSWERED
+            )
+            return secret, state
+
     calls = []
 
     def _fake_import(_manager, *, source, options, passphrase, settings_path, manifest, **_kwargs):
@@ -1123,6 +1265,15 @@ def test_import_backup_gives_up_after_bounded_wrong_passphrases(tmp_path, monkey
             summary = self.create(**kwargs)
             result = self.wait_for_result(summary.id)
             return None if result is None else result.secret
+
+        def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+            from sshpilot.api.models.interactions import InteractionState
+
+            secret = self.request_client_secret(owner_client_id=owner_client_id, **kwargs)
+            state = (
+                InteractionState.CANCELLED if secret is None else InteractionState.ANSWERED
+            )
+            return secret, state
 
     def _fake_import(_manager, *, source, options, passphrase, settings_path, manifest, **_kwargs):
         return SecretTransferResult(

--- a/tests/daemon/test_secret_dispatch.py
+++ b/tests/daemon/test_secret_dispatch.py
@@ -839,6 +839,11 @@ def test_real_daemon_login_params_are_identifiers_only(tmp_path):
         def request_client_secret(self, *, owner_client_id, **kwargs):
             return None
 
+        def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+            from sshpilot.api.models.interactions import InteractionState
+
+            return None, InteractionState.CANCELLED
+
     socket_path = tmp_path / "secrets2.sock"
     socket_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     settings_path = tmp_path / "config2.json"

--- a/tests/daemon/test_secret_transfer.py
+++ b/tests/daemon/test_secret_transfer.py
@@ -558,6 +558,13 @@ class _OneShotBroker:
         result = self.wait_for_result(summary.id)
         return None if result is None else result.secret
 
+    def request_client_secret_with_status(self, *, owner_client_id, **kwargs):
+        from sshpilot.api.models.interactions import InteractionState
+
+        secret = self.request_client_secret(owner_client_id=owner_client_id, **kwargs)
+        state = InteractionState.CANCELLED if secret is None else InteractionState.ANSWERED
+        return secret, state
+
 
 def test_service_preview_caches_manifest_so_import_never_reprompts(monkeypatch, tmp_path):
     config_dir, _ = _isolate_paths(monkeypatch, tmp_path)

--- a/tests/test_local_export_threading.py
+++ b/tests/test_local_export_threading.py
@@ -1,0 +1,221 @@
+"""Regression coverage for issue #1200: local ``.spbk`` export deadlock.
+
+``_run_local_export`` (extracted from ``_choose_export_path``, mirroring the
+already-threaded ``_export_to_ssh_server``/``_run_daemon_import`` pattern) must
+run the blocking ``export_backup()`` daemon RPC off the GTK main thread. The
+daemon's encryption-passphrase interaction can only be claimed/answered once
+that same thread's main loop is free to process it, so calling the RPC inline
+(the old code) deadlocks an encrypted export until the interaction expires.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+
+from sshpilot.window_dialogs import WindowConfigDialogsMixin
+
+
+class _ExportWin(WindowConfigDialogsMixin):
+    def __init__(self):
+        self.dialogs = []
+
+    def _simple_dialog(self, heading, body):
+        self.dialogs.append((heading, body))
+
+
+class _MainLoopSimulator:
+    """Stands in for the GTK main loop: ``idle_add`` only queues callbacks —
+    they run only when ``drain()`` is called, exactly like the real GLib main
+    loop only runs callbacks on the thread that is pumping it."""
+
+    def __init__(self):
+        self._queue = []
+        self._lock = threading.Lock()
+
+    def idle_add(self, callback):
+        with self._lock:
+            self._queue.append(callback)
+        return 0
+
+    def drain(self):
+        while True:
+            with self._lock:
+                if not self._queue:
+                    return
+                callback = self._queue.pop(0)
+            callback()
+
+
+def test_local_export_does_not_deadlock_encryption_interaction(monkeypatch):
+    """Test 1 from the issue: export_backup() cannot complete until a
+    frontend interaction scheduled on the (simulated) GTK main-loop side is
+    processed. The export must run off the calling thread so that thread
+    stays free to pump the loop and answer the interaction."""
+    win = _ExportWin()
+    loop = _MainLoopSimulator()
+    monkeypatch.setattr("sshpilot.window_dialogs.GLib.idle_add", loop.idle_add)
+    monkeypatch.setattr(
+        "sshpilot.bitwarden_backup_setup.progress_dialog",
+        lambda *a, **kw: (lambda _t: None, lambda: None))
+
+    interaction_answered = threading.Event()
+    export_thread_ident = {}
+
+    class Controller:
+        def export_backup(self, **kwargs):
+            export_thread_ident['id'] = threading.get_ident()
+            # Mirrors the daemon: the encryption-passphrase interaction is
+            # delivered to the frontend via the same idle_add the real
+            # password dialog would use, and can only be answered once
+            # something pumps the (simulated) main loop.
+            loop.idle_add(interaction_answered.set)
+            if not interaction_answered.wait(timeout=2.0):
+                raise AssertionError(
+                    "encryption interaction was never processed — the "
+                    "caller's thread is blocked inside export_backup "
+                    "(issue #1200 deadlock)")
+            return SimpleNamespace(
+                status=SimpleNamespace(value="success"),
+                counts={"credentials": 0, "private_keys": 0}, warnings=())
+
+    win.secrets_controller = Controller()
+    calling_thread_ident = threading.get_ident()
+
+    win._run_local_export(
+        export_path="/tmp/x.spbk", connections=[], options={}, encrypt=True)
+
+    # The call above must return immediately — it only shows a progress
+    # dialog and starts a worker thread — leaving this ("GTK main") thread
+    # free to pump the loop, exactly as GTK is between event-loop iterations.
+    # Keep pumping until the interaction is answered: checking 'id' alone
+    # would race, exiting right after it is set but before the interaction
+    # callback that follows it is queued.
+    deadline = time.monotonic() + 2.0
+    while not interaction_answered.is_set() and time.monotonic() < deadline:
+        loop.drain()
+        time.sleep(0.01)
+
+    assert export_thread_ident.get('id') is not None, "export_backup was never called"
+    assert export_thread_ident['id'] != calling_thread_ident, (
+        "export_backup ran on the calling (GTK) thread — the fix must run "
+        "it on a worker thread")
+    assert interaction_answered.is_set(), "interaction was never answered"
+
+    # Drain the worker's completion callback too (also delivered via idle_add).
+    deadline = time.monotonic() + 2.0
+    while not win.dialogs and time.monotonic() < deadline:
+        loop.drain()
+        time.sleep(0.01)
+
+    assert win.dialogs, "export completion was never reported to the UI"
+    assert win.dialogs[0] == ("Export Successful", (
+        "Backup saved to:\n/tmp/x.spbk\n\n0 credential(s) and 0 private "
+        "key(s) included; encryption: on."))
+
+
+def test_local_export_surfaces_worker_exception(monkeypatch):
+    """Exceptions raised inside the worker thread must be reported to the
+    user, not swallowed or left to crash a background thread silently."""
+    win = _ExportWin()
+
+    class Thread:
+        def __init__(self, target, daemon):
+            assert daemon is True
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr("sshpilot.window_dialogs.threading.Thread", Thread)
+    monkeypatch.setattr(
+        "sshpilot.window_dialogs.GLib.idle_add", lambda cb: (cb(), False)[1])
+    monkeypatch.setattr(
+        "sshpilot.bitwarden_backup_setup.progress_dialog",
+        lambda *a, **kw: (lambda _t: None, lambda: None))
+
+    class Controller:
+        def export_backup(self, **kwargs):
+            raise RuntimeError("daemon unreachable")
+
+    win.secrets_controller = Controller()
+    win._run_local_export(
+        export_path="/tmp/x.spbk", connections=[], options={}, encrypt=False)
+
+    assert len(win.dialogs) == 1
+    assert win.dialogs[0][0] == "Export Failed"
+    assert "daemon unreachable" in win.dialogs[0][1]
+
+
+def test_local_export_unencrypted_success(monkeypatch):
+    """Unencrypted export must be unaffected by the threading fix."""
+    win = _ExportWin()
+
+    class Thread:
+        def __init__(self, target, daemon):
+            assert daemon is True
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    calls = []
+
+    class Controller:
+        def export_backup(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                status=SimpleNamespace(value="success"),
+                counts={"credentials": 3, "private_keys": 1}, warnings=())
+
+    monkeypatch.setattr("sshpilot.window_dialogs.threading.Thread", Thread)
+    monkeypatch.setattr(
+        "sshpilot.window_dialogs.GLib.idle_add", lambda cb: (cb(), False)[1])
+    monkeypatch.setattr(
+        "sshpilot.bitwarden_backup_setup.progress_dialog",
+        lambda *a, **kw: (lambda _t: None, lambda: None))
+
+    win.secrets_controller = Controller()
+    win._run_local_export(
+        export_path="/tmp/plain.spbk", connections=[],
+        options={"app_settings": True}, encrypt=False)
+
+    assert len(calls) == 1
+    assert calls[0]["options"]["encrypted"] is False
+    assert len(win.dialogs) == 1
+    assert win.dialogs[0][0] == "Export Successful"
+    assert "encryption: off" in win.dialogs[0][1]
+
+
+def test_local_export_reports_encryption_timeout_message(monkeypatch):
+    """The daemon's distinct timeout message must reach the user unchanged —
+    not rewritten to a generic 'cancelled' message on the frontend."""
+    win = _ExportWin()
+
+    class Thread:
+        def __init__(self, target, daemon):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    class Controller:
+        def export_backup(self, **kwargs):
+            return SimpleNamespace(
+                status=SimpleNamespace(value="interaction_required"),
+                message="Encryption password request timed out",
+                counts={}, warnings=())
+
+    monkeypatch.setattr("sshpilot.window_dialogs.threading.Thread", Thread)
+    monkeypatch.setattr(
+        "sshpilot.window_dialogs.GLib.idle_add", lambda cb: (cb(), False)[1])
+    monkeypatch.setattr(
+        "sshpilot.bitwarden_backup_setup.progress_dialog",
+        lambda *a, **kw: (lambda _t: None, lambda: None))
+
+    win.secrets_controller = Controller()
+    win._run_local_export(
+        export_path="/tmp/x.spbk", connections=[], options={}, encrypt=True)
+
+    assert win.dialogs == [
+        ("Export Failed", "Encryption password request timed out"),
+    ]


### PR DESCRIPTION
## Summary

Fixes issue #1200: encrypted `.spbk` backup exports deadlock when the encryption passphrase interaction times out. The root cause is that `export_backup()` was called synchronously on the GTK main thread, blocking the event loop from processing the encryption passphrase interaction prompt. The interaction can only be claimed and answered once the main loop is free to process it, creating a deadlock.

The fix extracts the blocking RPC call into a worker thread (`_run_local_export`), mirroring the existing pattern used by `_export_to_ssh_server`/`_run_daemon_import`. This allows the GTK main loop to remain responsive and process the interaction while the export runs in the background.

Additionally, the interaction broker now distinguishes between explicit user cancellation (`CANCELLED`) and timeout (`EXPIRED`) states, allowing the daemon to report "Encryption password request timed out" instead of the misleading "Encryption cancelled" when the prompt expires unattended. A shorter 30-second timeout is used for backup encryption prompts (vs. the default 120s for SSH auth), so unattended exports fail fast rather than appearing hung.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or core/frontend ownership boundary
- [ ] Public DTOs or client methods were updated
- [x] State, ordering, threading, cancellation, and security semantics were reviewed

The changes are internal to the daemon and GTK frontend:
- `InteractionBroker.request_client_secret_with_status()` is a new internal method that returns both the secret and its final `InteractionState`, allowing callers to distinguish timeout from cancellation
- `SecretBackendService.export_backup()` now uses the shorter `DEFAULT_BACKUP_ENCRYPTION_INTERACTION_TIMEOUT` (30s) for encryption prompts
- `WindowConfigDialogsMixin._run_local_export()` is a new internal method that runs the export on a worker thread

No public API changes or client-facing contract modifications.

## Testing

- Added comprehensive regression test suite in `tests/test_local_export_threading.py`:
  - `test_local_export_does_not_deadlock_encryption_interaction`: Verifies the export runs on a worker thread and the GTK main loop remains free to process interactions
  - `test_local_export_surfaces_worker_exception`: Ensures exceptions in the worker thread are reported to the user
  - `test_local_export_unencrypted_success`: Confirms unencrypted exports are unaffected
  - `test_local_export_reports_encryption_timeout_message`: Validates timeout vs. cancellation messaging

- Added daemon-side tests in `tests/daemon/test_secret_backend_service.py`:
  - `test_export_backup_encrypted_roundtrip_decrypts_with_correct_password`: Full roundtrip encryption/decryption validation
  - `test_export_backup_uses_shorter_backup_encryption_timeout`: Verifies the 30s timeout is applied
  - `test_export_backup_reports_timeout_distinctly_from_cancellation`: Tests timeout messaging
  - `test_export_backup_reports_explicit_cancellation`: Tests cancellation messaging
  - `test_export_backup_unencrypted_never_prompts`: Confirms unencrypted exports don't touch the interaction broker

- Added interaction broker tests in `tests/daemon/test_interaction_broker.py`:
  - `test_request_client_secret_with_status_reports_expired_not_cancelled`: Verifies timeout state reporting
  - `test_request_client_secret_with_status_reports_explicit_cancel`: Verifies cancellation state reporting
  - `test_backup_encryption_timeout_constant_is_shorter_than_default_secret_timeout`: Pins the 30s design target

All existing tests pass; no breaking changes to public APIs.

https://claude.ai/code/session_01JNzdtLLqKKz9kv9vZrjSW5