### PR TITLE
Include terminal theme selector in gettext sources

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -61,6 +61,7 @@ src/sshpilot/sshcopyid_window.py
 src/sshpilot/terminal.py
 src/sshpilot/terminal_manager.py
 src/sshpilot/terminal_search.py
+src/sshpilot/terminal_theme_selector.py
 src/sshpilot/text_editor.py
 src/sshpilot/theme_selector.py
 src/sshpilot/web_tab.py


### PR DESCRIPTION
## Summary

Adds `src/sshpilot/terminal_theme_selector.py` to `po/POTFILES`.

The file already uses gettext at runtime, but it was not included in the extraction sources, so three user-facing strings from the new terminal color-scheme selector were missing from the generated POT:

- `Use {theme} terminal colors`
- `The quick brown fox jumps over the lazy dog`
- `Palette`

With this source included, the POT grows from 2,012 to 2,015 messages.

## Validation

- `sshpilot-pot`: passed
- GNU gettext 0.23.1
- POT count: `2012 -> 2015`
- `Use {theme} terminal colors` is extracted as `python-brace-format`
- i18n tests: `21 passed`
- `git diff --check`: passed

## Scope

Only `po/POTFILES` is changed.

No translation catalogs or Python source files are modified.