### PR TITLE
Fix typo in 5.9.6 release notes

### DIFF
--- a/data/io.github.mfat.sshpilot.metainfo.xml.in
+++ b/data/io.github.mfat.sshpilot.metainfo.xml.in
@@ -71,7 +71,7 @@
     <release version="5.9.6" date="2026-08-27">
       <description>
         <p>Fixed subgroups not inheriting parent group color</p>
-        <p>Added option to remeber passwords to password prompts</p>
+        <p>Added option to remember passwords to password prompts</p>
         <p>Minor fixes to DnD in sidebar</p>
       </description>
     </release>

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,7 +11,7 @@ sshpilot (5.9.6-1) unstable; urgency=medium
 
   * Release v5.9.6.
   * Fixed subgroups not inheriting parent group color
-  * Added option to remeber passwords to password prompts
+  * Added option to remember passwords to password prompts
   * Minor fixes to DnD in sidebar
 
  -- Mehdi <mah.fat@gmail.com>  Thu, 27 Aug 2026 20:23:27 +0000

--- a/packaging/fedora/rpm.spec
+++ b/packaging/fedora/rpm.spec
@@ -151,7 +151,7 @@ an alternative to Putty, Termius and Mobaxterm.
 
 * Thu Aug 27 2026 mFat <newmfat@gmail.com> - 5.9.6-1
 - Fixed subgroups not inheriting parent group color
-- Added option to remeber passwords to password prompts
+- Added option to remember passwords to password prompts
 - Minor fixes to DnD in sidebar
 
 * Tue Aug 25 2026 mFat <newmfat@gmail.com> - 5.9.5-1


### PR DESCRIPTION
## Summary

Fixes the same typo in the 5.9.6 release notes across the AppStream, Debian, and Fedora packaging metadata:

`remeber` → `remember`

## Validation

- repository-wide typo search: no remaining `remeber` occurrences
- POT regeneration and comparison: `2034 -> 2034`, with only the corrected msgid changed
- i18n tests: `21 passed`
- Meson validation tests: `2/2 passed`
- direct AppStream validation: passed
- Debian changelog parsing: passed
- `git diff --check`: passed

## Scope

Only the 5.9.6 release-note entries in:

- `data/io.github.mfat.sshpilot.metainfo.xml.in`
- `debian/changelog`
- `packaging/fedora/rpm.spec`
