### PR TITLE
Clarify Preferences SSH Options help and per-connection precedence

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3927,8 +3927,13 @@ msgid "Custom SSH Options"
 msgstr "Benutzerdefinierte SSH-Optionen"
 
 #: src/sshpilot/preferences.py:1784
-msgid "These settings override values from your ~/.ssh/config."
-msgstr "Diese Einstellungen setzen Werte aus Ihrer ~/.ssh/config außer Kraft."
+msgid ""
+"These settings apply to all connections and override values from ~/.ssh/"
+"config. Explicit per-connection settings always win."
+msgstr ""
+"Diese Einstellungen gelten für alle Verbindungen und setzen Werte aus ~/.ssh/"
+"config außer Kraft. Explizite Einstellungen an einer Verbindung haben immer "
+"Vorrang."
 
 #: src/sshpilot/preferences.py:1792
 msgid "SSH Settings"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4534,8 +4534,13 @@ msgid "Custom SSH Options"
 msgstr "Options SSH personnalisées"
 
 #: src/sshpilot/preferences.py:2447
-msgid "These settings override values from your ~/.ssh/config."
-msgstr "Ces paramètres remplacent les valeurs de ~/.ssh/config."
+msgid ""
+"These settings apply to all connections and override values from ~/.ssh/"
+"config. Explicit per-connection settings always win."
+msgstr ""
+"Ces paramètres s’appliquent à toutes les connexions et remplacent les "
+"valeurs de ~/.ssh/config. Les réglages explicites d’une connexion ont "
+"toujours priorité."
 
 #: src/sshpilot/preferences.py:2455
 msgid "SSH Settings"

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -2411,17 +2411,14 @@ class PreferencesWindow(Adw.NavigationPage):
         ssh_settings_page.set_title("SSH")
         ssh_settings_page.set_icon_name("network-workgroup-symbolic")
 
+        # Group description wraps fully; ActionRow subtitles ellipsize at one
+        # line by default, which is too tight for this precedence note.
         help_group = Adw.PreferencesGroup()
-        help_row = Adw.ActionRow()
-        help_row.set_title(_("Custom SSH Options"))
-        help_row.set_subtitle(
-            _("These settings override values from your ~/.ssh/config.")
+        help_group.set_title(_("Custom SSH Options"))
+        help_group.set_description(
+            _("These settings apply to all connections and override values from "
+              "~/.ssh/config. Explicit per-connection settings always win.")
         )
-        if hasattr(help_row, "set_activatable"):
-            help_row.set_activatable(False)
-        if hasattr(help_row, "set_selectable"):
-            help_row.set_selectable(False)
-        help_group.add(help_row)
 
         advanced_group = Adw.PreferencesGroup(title=_("SSH Settings"))
 

--- a/tests/test_preferences_ssh_overrides.py
+++ b/tests/test_preferences_ssh_overrides.py
@@ -771,3 +771,17 @@ def test_sftp_connect_timeout_changed_persists_immediately(tmp_path, monkeypatch
     prefs.on_sftp_connect_timeout_changed(prefs.sftp_connect_timeout_row)
 
     assert config.get_setting('file_manager.sftp_connect_timeout', None) == 20
+
+
+def test_ssh_options_help_explains_per_connection_precedence():
+    """Preferences ▸ SSH Options must say these are app-wide defaults that
+    lose to an explicit per-connection setting, not only that they override
+    ~/.ssh/config.
+    """
+    import inspect
+
+    src = inspect.getsource(PreferencesWindow._build_ssh_settings_preferences_page)
+    assert "~/.ssh/config" in src
+    assert "per-connection" in src
+    assert "help_group.set_description(" in src
+    assert "These settings override values from your ~/.ssh/config." not in src


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Preferences ▸ SSH Options currently said only that these settings override `~/.ssh/config`. That is incomplete: they are app-wide defaults for every connection, and **explicit per-connection settings always win**.

The help text is now a Preferences group description (so the two sentences wrap) instead of an ActionRow subtitle (which ellipsizes at one line).

**Wording currently implemented is option A.** Pick A–E below if you want a swap.

[Preferences SSH Options help text](https://cursor.com/agents/bc-33477c3b-5f34-40ef-91ce-8d5ab475bff4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fssh_options_help.png)

[ssh_options_help_text_walkthrough.mp4](https://cursor.com/agents/bc-33477c3b-5f34-40ef-91ce-8d5ab475bff4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fssh_options_help_text_walkthrough.mp4)

## Wording options

Current (before): `These settings override values from your ~/.ssh/config.`

**A — implemented** (matches keepalive’s “always win”)
> These settings apply to all connections and override values from ~/.ssh/config. Explicit per-connection settings always win.

**B — slightly more explicit about “defaults”**
> These are defaults for all connections. They override ~/.ssh/config. Explicit settings on a connection always take precedence.

**C — “unless the connection sets it”**
> These settings override ~/.ssh/config for every connection. They are not used when a connection sets the same option itself.

**D — shorter**
> App-wide defaults: they override ~/.ssh/config, but any option you set on a connection wins.

**E — closest to the old sentence**
> These settings override values from your ~/.ssh/config. Explicit per-connection settings always win.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or core/frontend ownership boundary

## Testing

- `PYTHONPATH=src python3 -m pytest -o addopts= -ra tests/test_preferences_ssh_overrides.py::test_ssh_options_help_explains_per_connection_precedence tests/test_ssh_connection_builder.py::test_preferences_lose_to_a_connections_own_settings`
- Booted isolated app, opened Preferences ▸ SSH Options, confirmed the live widget description, and walked Interface → SSH Options in the UI


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33477c3b-5f34-40ef-91ce-8d5ab475bff4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33477c3b-5f34-40ef-91ce-8d5ab475bff4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

