### PR TITLE
Fix htop mouse clicks and F10 on older remotes

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -2,7 +2,12 @@
 
 SSH Pilot is designed for efficient keyboard navigation. Every shortcut — including split view — can be customized in **Preferences → Shortcuts** or by pressing **Ctrl+?** (**Cmd+?** on macOS).
 
-To avoid clashing with command-line tools (readline, vim, …) and keyboard layouts, several shortcuts are **disabled by default** on Linux/Windows. They are still listed in **Preferences → Shortcuts**, where you can assign your own keys.
+To avoid clashing with command-line tools (readline, vim, htop, …) and keyboard layouts, several shortcuts are **disabled by default** on Linux/Windows. They are still listed in **Preferences → Shortcuts**, where you can assign your own keys.
+
+Function keys used by terminal programs are passed through:
+
+- **F10** is not bound by SSH Pilot. GTK's default "open the application menu" accelerator is cleared so F10 can quit htop or close mc.
+- **F9** toggles the sidebar and **F11** toggles fullscreen; unassign them in **Preferences → Shortcuts** (or enable **Terminal Shortcut Pass-through**) if a remote app needs those keys.
 
 ## Platform Notes
 

--- a/src/sshpilot/daemon_terminal_widget.py
+++ b/src/sshpilot/daemon_terminal_widget.py
@@ -13,6 +13,7 @@ from gi.repository import Gtk
 
 from .daemon_interaction_dialogs import DaemonInteractionDialogs
 from .terminal_backends import GridTrackingVteTerminal
+from .terminal_input import commit_payload_to_bytes
 from .terminal_session_controller import (
     DaemonTerminalSessionController,
     daemon_terminal_capabilities_missing,
@@ -91,10 +92,10 @@ class DaemonTerminalWidget(Gtk.Box):
     def last_sequence(self) -> int:
         return self._controller.tab_state.expected_sequence
 
-    def _on_commit(self, _terminal, text, _size) -> None:
+    def _on_commit(self, _terminal, text, size) -> None:
         if self._closed:
             return
-        self._controller.send_input(text.encode("utf-8"))
+        self._controller.send_input(commit_payload_to_bytes(text, size))
 
     def _on_size_changed(self, _terminal, *_details) -> None:
         if self._closed:

--- a/src/sshpilot/main.py
+++ b/src/sshpilot/main.py
@@ -167,6 +167,27 @@ from .platform_utils import is_macos, get_data_dir, get_state_dir
 from .file_manager_integration import should_hide_file_manager_options
 from .startup_info import print_startup_info
 
+
+def apply_terminal_menu_bar_accel_setting(settings=None) -> None:
+    """Clear GTK's F10 menu-bar accelerator so function keys reach the terminal.
+
+    GTK defaults ``gtk-menu-bar-accel`` to F10, which opens the application
+    menu instead of sending F10 to htop/mc/vim. Terminal emulators (GNOME
+    Terminal, Ptyxis) clear this setting. Pass-through mode cannot fix it
+    because F10 is not an sshPilot shortcut.
+    """
+    if settings is None:
+        try:
+            settings = Gtk.Settings.get_default()
+        except Exception:
+            settings = None
+    if settings is None:
+        return
+    try:
+        settings.set_property("gtk-menu-bar-accel", "")
+    except Exception:
+        logger.debug("Could not clear gtk-menu-bar-accel", exc_info=True)
+
 class SshPilotApplication(Adw.Application):
     """Main application class for sshPilot"""
 
@@ -448,6 +469,7 @@ class SshPilotApplication(Adw.Application):
         builds never call ``install_menubar``.
         """
         Adw.Application.do_startup(self)
+        apply_terminal_menu_bar_accel_setting()
 
         if getattr(self, "_macos_menubar_installed", False):
             return

--- a/src/sshpilot/preferences.py
+++ b/src/sshpilot/preferences.py
@@ -677,7 +677,9 @@ class PreferencesWindow(Adw.NavigationPage):
         self.paste_on_right_click_switch = Adw.SwitchRow()
         self.paste_on_right_click_switch.set_title(_("Paste on right-click"))
         self.paste_on_right_click_switch.set_subtitle(
-            _("Right-click pastes; Shift+right-click opens the menu")
+            _("Right-click pastes; Shift+right-click opens the menu. "
+              "Disabled automatically while a remote app (htop, vim, tmux) "
+              "is using the mouse.")
         )
         paste_on_right_click_active = bool(self.config.get_setting('terminal.paste_on_right_click', False))
         self.paste_on_right_click_switch.set_active(paste_on_right_click_active)

--- a/src/sshpilot/terminal.py
+++ b/src/sshpilot/terminal.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 from .ssh_process_manager import SSHProcessManager, process_manager  # noqa: F401
 from .terminal_search import TerminalSearch
 from .core.connection_evidence import classify_connection_evidence
+from .terminal_input import MouseTrackingState, commit_payload_to_bytes
 
 
 # Installed once per process. Inner padding for the terminal text so the
@@ -62,9 +63,14 @@ def _context_click_is_handled(
     paste_on_right_click: bool,
     shift_held: bool,
     native_vte_menu: bool,
+    mouse_tracking: bool = False,
 ) -> bool:
     """Whether SSH Pilot, rather than the backend, owns this pointer sequence."""
     if button not in (Gdk.BUTTON_SECONDARY, 3):
+        return False
+    # htop/vim/tmux enable mouse tracking: the click must reach the emulator
+    # unless Shift is held (the usual "give me the menu anyway" modifier).
+    if mouse_tracking and not shift_held:
         return False
     return (paste_on_right_click and not shift_held) or not native_vte_menu
 
@@ -220,6 +226,7 @@ class TerminalWidget(Gtk.Box):
         self._daemon_interaction_dialogs = None
         self._daemon_commit_handler = None
         self._daemon_size_handler = None
+        self._mouse_tracking = MouseTrackingState()
         self._daemon_exit_handled = False
         self._view_only_overlay = None
         self._reconnect_handler = None
@@ -1257,6 +1264,9 @@ class TerminalWidget(Gtk.Box):
         if backend is None:
             self._daemon_commit_handler = None
             self._daemon_size_handler = None
+            tracker = getattr(self, "_mouse_tracking", None)
+            if tracker is not None:
+                tracker.reset()
             return
         for attr in ('_daemon_commit_handler', '_daemon_size_handler'):
             handler = getattr(self, attr, None)
@@ -1267,6 +1277,9 @@ class TerminalWidget(Gtk.Box):
             except Exception:
                 logger.debug("Failed to disconnect daemon backend handler", exc_info=True)
             setattr(self, attr, None)
+        tracker = getattr(self, "_mouse_tracking", None)
+        if tracker is not None:
+            tracker.reset()
 
     def _install_daemon_backend_io(self) -> None:
         """Wire commit/resize through the terminal backend abstraction.
@@ -1311,6 +1324,9 @@ class TerminalWidget(Gtk.Box):
         backend = getattr(self, 'backend', None)
         if backend is None:
             raise RuntimeError("No terminal backend to feed display output")
+        tracker = getattr(self, "_mouse_tracking", None)
+        if tracker is not None:
+            tracker.feed(data)
         backend.feed(data)
 
     def _on_daemon_output(self, data):
@@ -1439,7 +1455,7 @@ class TerminalWidget(Gtk.Box):
             return
 
         try:
-            data = text.encode('utf-8') if isinstance(text, str) else text
+            data = commit_payload_to_bytes(text, size)
             self._daemon_controller.send_input(data)
         except Exception as e:
             logger.error(f"Failed to send input to daemon: {e}")
@@ -3296,11 +3312,14 @@ class TerminalWidget(Gtk.Box):
                     native_vte_menu = bool(
                         getattr(self, '_native_vte_context_menu', False)
                     )
+                    tracker = getattr(self, "_mouse_tracking", None)
+                    mouse_tracking = bool(tracker is not None and tracker.active)
                     if not _context_click_is_handled(
                         btn,
                         paste_on_right_click=paste_on_rc,
                         shift_held=shift_held,
                         native_vte_menu=native_vte_menu,
+                        mouse_tracking=mouse_tracking,
                     ):
                         return
                     if paste_on_rc and not shift_held:

--- a/src/sshpilot/terminal_backends.py
+++ b/src/sshpilot/terminal_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import codecs
 import logging
 import os
@@ -19,6 +20,23 @@ from .terminal_color_utils import mix_rgba, relative_luminance, get_contrast_col
 
 
 logger = logging.getLogger(__name__)
+
+
+def _pyxterm_input_to_commit(payload: Mapping[str, Any]) -> tuple[Any, int, str]:
+    """Return ``(commit_text, byte_size, autocomplete_text)`` for an input message.
+
+    UTF-8 keystrokes stay strings with a UTF-8 byte length (VTE commit parity).
+    X10 mouse arrives as ``encoding=binary`` base64 and is forwarded as bytes.
+    """
+    data = payload.get("data", "")
+    if payload.get("encoding") == "binary":
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            raw = bytes(data)
+        else:
+            raw = base64.b64decode(data or "", validate=False)
+        return raw, len(raw), ""
+    text = data if isinstance(data, str) else data.decode("utf-8", "replace")
+    return text, len(text.encode("utf-8")), text
 
 
 def _fetch_remote_history_via_daemon(root, connection, timeout: float = 15) -> Optional[str]:
@@ -2378,18 +2396,22 @@ class PyXtermBridgeBackend(PyXtermTerminalBackend):
                 except Exception:  # noqa: BLE001
                     logger.debug("handle_search_results raised", exc_info=True)
         elif kind == "input":
-            data = payload.get("data", "")
+            commit_text, commit_size, autocomplete_text = _pyxterm_input_to_commit(
+                payload
+            )
             if self._bridge is not None:
-                self._bridge.write(data)
+                if isinstance(commit_text, (bytes, bytearray, memoryview)):
+                    self._bridge.write(bytes(commit_text))
+                else:
+                    self._bridge.write(commit_text)
             elif self._commit_cb is not None:
                 # Daemon (or other no-local-PTY) mode: surface keystrokes via the
                 # same commit callback VTE uses, so TerminalWidget stays backend-agnostic.
                 try:
-                    text = data if isinstance(data, str) else data.decode("utf-8", "replace")
-                    self._commit_cb(self.widget, text, len(text))
+                    self._commit_cb(self.widget, commit_text, commit_size)
                 except Exception:  # noqa: BLE001
                     logger.debug("commit callback raised", exc_info=True)
-            self._feed_autocomplete(data if isinstance(data, str) else "")
+            self._feed_autocomplete(autocomplete_text)
         elif kind == "resize":
             self._last_size = (payload.get("rows", 24), payload.get("cols", 80))
             if self._bridge is not None:

--- a/src/sshpilot/terminal_input.py
+++ b/src/sshpilot/terminal_input.py
@@ -1,0 +1,99 @@
+"""PTY-bound terminal input helpers (GTK-free).
+
+Daemon-backed emulators expose user input as Python strings (VTE ``commit``,
+xterm.js ``onData``) even when the payload is an 8-bit protocol such as X10
+mouse. Re-encoding those strings as UTF-8 corrupts high bytes, so ncurses
+apps on older hosts (Ubuntu 18.04/20.04 htop) never see clicks. SGR mouse
+is ASCII-only and is unaffected — which is why Ubuntu 24.04 still worked.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Union
+
+CommitPayload = Union[str, bytes, bytearray, memoryview]
+
+# DECSET/DECRST mouse modes used by ncurses/xterm. 9 is X10, 1000+ are
+# X11/SGR variants; any one of them means the remote app owns pointer events.
+_MOUSE_MODES = frozenset({9, 1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016})
+_MOUSE_CSI_RE = re.compile(rb"\x1b\[\?([\d;]+)([hl])")
+_RESET_RE = re.compile(rb"\x1bc|\x1b\[!p")
+
+
+def commit_payload_to_bytes(text: CommitPayload, size: Optional[int] = None) -> bytes:
+    """Convert an emulator commit payload into bytes for the PTY.
+
+    Keyboard UTF-8 round-trips as UTF-8. X10 mouse reports (and any other
+    8-bit sequence) arrive as latin-1-mapped characters whose original byte
+    length is ``size``. Prefer latin-1 when that matches ``size`` and UTF-8
+    would not.
+    """
+    if isinstance(text, (bytes, bytearray, memoryview)):
+        return bytes(text)
+    if not text:
+        return b""
+    utf8 = text.encode("utf-8")
+    reported = None if size is None else int(size)
+    if reported is None or reported == len(utf8):
+        return utf8
+    try:
+        raw = text.encode("latin-1")
+    except UnicodeEncodeError:
+        return utf8
+    if len(raw) == reported:
+        return raw
+    return utf8
+
+
+class MouseTrackingState:
+    """Track whether the remote application currently wants mouse reports."""
+
+    def __init__(self) -> None:
+        self._active: set[int] = set()
+        self._tail = b""
+
+    @property
+    def active(self) -> bool:
+        return bool(self._active)
+
+    def reset(self) -> None:
+        self._active.clear()
+        self._tail = b""
+
+    def feed(self, data: bytes) -> bool:
+        """Consume display bytes and update tracking state.
+
+        Incomplete CSI sequences at the end of a chunk are held until the
+        next call so ``ESC[?1000h`` split across writes is not missed.
+        """
+        if not data:
+            return self.active
+        buf = self._tail + bytes(data)
+        start = 0
+        for reset in _RESET_RE.finditer(buf):
+            start = reset.end()
+            self._active.clear()
+        scan = buf[start:]
+        consumed = start
+        for match in _MOUSE_CSI_RE.finditer(scan):
+            consumed = start + match.end()
+            enable = match.group(2) == b"h"
+            for part in match.group(1).split(b";"):
+                try:
+                    mode = int(part)
+                except ValueError:
+                    continue
+                if mode not in _MOUSE_MODES:
+                    continue
+                if enable:
+                    self._active.add(mode)
+                else:
+                    self._active.discard(mode)
+        suffix = buf[consumed:]
+        esc = suffix.rfind(b"\x1b")
+        if esc >= 0 and len(suffix) - esc < 64:
+            self._tail = suffix[esc:]
+        else:
+            self._tail = b""
+        return self.active

--- a/src/sshpilot/xterm_shell.py
+++ b/src/sshpilot/xterm_shell.py
@@ -221,6 +221,10 @@ def _build_shell_html_impl(
 
   term.open(document.getElementById("terminal"));
   term.onData(d => send({{ type: "input", data: d }}));
+  // X10 mouse (Ubuntu 18.04/20.04 ncurses) is 8-bit and goes through onBinary,
+  // not onData. SGR mouse is ASCII and stays on onData. Base64 keeps high
+  // bytes intact across the JSON script-message bridge.
+  term.onBinary(d => send({{ type: "input", encoding: "binary", data: btoa(d) }}));
   // OSC 0/2 title changes (remote shell prompt) — used as connect evidence.
   term.onTitleChange(t => send({{ type: "title", title: t }}));
 

--- a/tests/test_macos_menubar.py
+++ b/tests/test_macos_menubar.py
@@ -221,9 +221,14 @@ def _stub_gi_for_app_init(monkeypatch):
     points (SimpleAction construction, Application.__init__ kwargs, connect).
     Provide minimal fakes so the real ``__init__`` — including its menubar
     install timing — executes unchanged.
+
+    Patch the classes ``SshPilotApplication`` actually inherited, not whatever
+    ``gi.repository.Adw`` currently points at. Other tests replace that module
+    (and xdist can schedule this file onto a polluted worker), which made
+    ``super().__init__(...)`` hit ``object.__init__``.
     """
-    import gi.repository as repository
     import sshpilot.macos_menubar as mm
+    import sshpilot.main as main_module
 
     class _FakeAction:
         def __init__(self, name, param_type=None):
@@ -237,18 +242,23 @@ def _stub_gi_for_app_init(monkeypatch):
         def new(cls, name, param_type=None):
             return _FakeAction(name, param_type)
 
-    monkeypatch.setattr(repository.Gio, "SimpleAction", _FakeSimpleAction)
-    monkeypatch.setattr(repository.Adw.Application, "__init__", lambda self, *a, **k: None)
-    monkeypatch.setattr(repository.Gio.Application, "__init__", lambda self, *a, **k: None)
-    monkeypatch.setattr(
-        repository.Adw.Application, "do_startup", lambda self: None, raising=False
-    )
-    monkeypatch.setattr(
-        repository.Gio.Application, "do_startup", lambda self: None, raising=False
-    )
-    monkeypatch.setattr(mm, "build_macos_menubar", lambda **kw: "MENU")
+    class _FakeSettings:
+        def set_property(self, name, value):
+            return None
 
-    import sshpilot.main as main_module
+    def _noop_init(self, *a, **k):
+        return None
+
+    monkeypatch.setattr(main_module.Gio, "SimpleAction", _FakeSimpleAction)
+    monkeypatch.setattr(
+        main_module.Gtk.Settings, "get_default", staticmethod(lambda: _FakeSettings())
+    )
+    for cls in main_module.SshPilotApplication.__mro__[1:]:
+        if cls is object:
+            continue
+        monkeypatch.setattr(cls, "__init__", _noop_init, raising=False)
+        monkeypatch.setattr(cls, "do_startup", _noop_init, raising=False)
+    monkeypatch.setattr(mm, "build_macos_menubar", lambda **kw: "MENU")
     return main_module
 
 

--- a/tests/test_menu_bar_accel.py
+++ b/tests/test_menu_bar_accel.py
@@ -1,0 +1,22 @@
+"""GTK's F10 menu-bar accelerator must not steal htop's Quit key."""
+
+
+def test_terminal_menu_bar_accel_is_cleared():
+    from sshpilot.main import apply_terminal_menu_bar_accel_setting
+
+    class _Settings:
+        def __init__(self):
+            self.props = {}
+
+        def set_property(self, name, value):
+            self.props[name] = value
+
+    settings = _Settings()
+    apply_terminal_menu_bar_accel_setting(settings)
+    assert settings.props["gtk-menu-bar-accel"] == ""
+
+
+def test_missing_settings_are_ignored():
+    from sshpilot.main import apply_terminal_menu_bar_accel_setting
+
+    apply_terminal_menu_bar_accel_setting(None)

--- a/tests/test_pyxterm_daemon_feed.py
+++ b/tests/test_pyxterm_daemon_feed.py
@@ -281,6 +281,48 @@ def test_pyxterm_input_without_bridge_fires_commit_callback():
     assert commits == [("ls\r", 3)]
 
 
+def test_pyxterm_binary_input_preserves_x10_mouse_bytes():
+    import base64
+
+    commits = []
+    written = []
+    b = object.__new__(PyXtermBridgeBackend)
+    b.owner = None
+    b.widget = object()
+    b._bridge = None
+    b._js_ready = True
+    b._autocompleter = None
+    b._commit_cb = None
+    b._size_changed_cb = None
+    b.connect_commit(lambda widget, text, size: commits.append((text, size)))
+
+    raw = b"\x1b[M\x20\xe8("
+    b._on_pty_message(
+        None,
+        _FakeJsValue(
+            {
+                "type": "input",
+                "encoding": "binary",
+                "data": base64.b64encode(raw).decode("ascii"),
+            }
+        ),
+    )
+    assert commits == [(raw, len(raw))]
+
+    b._bridge = type("Bridge", (), {"write": staticmethod(written.append)})()
+    b._on_pty_message(
+        None,
+        _FakeJsValue(
+            {
+                "type": "input",
+                "encoding": "binary",
+                "data": base64.b64encode(raw).decode("ascii"),
+            }
+        ),
+    )
+    assert written == [raw]
+
+
 def test_pyxterm_resize_without_bridge_fires_size_callback():
     sizes = []
     b = object.__new__(PyXtermBridgeBackend)

--- a/tests/test_terminal_dialog_continuity.py
+++ b/tests/test_terminal_dialog_continuity.py
@@ -421,3 +421,16 @@ def test_dialog_input_bytes_still_reach_controller_after_output_continuity_loss(
         b"\x1b",
         b"\x03",
     ]
+
+
+def test_dialog_x10_mouse_commit_keeps_high_bytes():
+    sent = []
+    widget = SimpleNamespace(
+        _daemon_controller=SimpleNamespace(send_input=sent.append),
+        has_input_ownership=True,
+    )
+    # X10 mouse: CSI M + button + x + y. Column 200 is byte 232.
+    text = "\x1b[M" + chr(32) + chr(232) + chr(40)
+    TerminalWidget._on_daemon_commit(widget, None, text, 6)
+    assert sent == [text.encode("latin-1")]
+    assert sent[0][4] == 232

--- a/tests/test_terminal_input.py
+++ b/tests/test_terminal_input.py
@@ -1,0 +1,64 @@
+"""Helpers for daemon-backed terminal input encoding and mouse tracking."""
+
+from sshpilot.terminal_input import MouseTrackingState, commit_payload_to_bytes
+
+
+def test_ascii_commit_round_trips_as_utf8():
+    assert commit_payload_to_bytes("whoami\r", 7) == b"whoami\r"
+    assert commit_payload_to_bytes("\x1bOA", 3) == b"\x1bOA"
+
+
+def test_utf8_character_uses_utf8_when_size_matches_bytes():
+    text = "é"
+    raw = text.encode("utf-8")
+    assert commit_payload_to_bytes(text, len(raw)) == raw
+
+
+def test_x10_mouse_high_bytes_are_preserved_via_latin1():
+    # X10 report: CSI M + (32+button) + (32+x) + (32+y). Column 200 encodes
+    # as byte 232 (0xE8), which is not valid UTF-8 on its own.
+    text = "\x1b[M" + chr(32) + chr(232) + chr(40)
+    assert len(text) == 6
+    utf8 = text.encode("utf-8")
+    assert len(utf8) != 6
+    assert commit_payload_to_bytes(text, 6) == text.encode("latin-1")
+    assert commit_payload_to_bytes(text, 6)[4] == 232
+
+
+def test_bytes_payload_is_returned_unchanged():
+    payload = b"\x1b[M\xe8("
+    assert commit_payload_to_bytes(payload, len(payload)) == payload
+    assert commit_payload_to_bytes(bytearray(payload)) == payload
+
+
+def test_sgr_mouse_stays_ascii():
+    report = "\x1b[<0;12;8M"
+    assert commit_payload_to_bytes(report, len(report)) == report.encode("ascii")
+
+
+def test_mouse_tracking_detects_x10_and_sgr():
+    state = MouseTrackingState()
+    assert state.active is False
+    assert state.feed(b"\x1b[?1000h") is True
+    assert state.feed(b"\x1b[?1006h") is True
+    assert state.feed(b"\x1b[?1006l") is True  # 1000 still on
+    assert state.feed(b"\x1b[?1000l") is False
+
+
+def test_mouse_tracking_combined_csi_and_split_chunks():
+    state = MouseTrackingState()
+    assert state.feed(b"\x1b[?1000;1006h") is True
+    state.reset()
+    assert state.active is False
+    assert state.feed(b"\x1b[?10") is False
+    assert state.feed(b"00h") is True
+
+
+def test_mouse_tracking_reset_clears_modes():
+    state = MouseTrackingState()
+    state.feed(b"\x1b[?1000h")
+    assert state.active is True
+    state.feed(b"\x1bc")
+    assert state.active is False
+    assert state.feed(b"\x1b[?1000h\x1bc") is False
+    assert state.feed(b"\x1bc\x1b[?1000h") is True

--- a/tests/test_terminal_mouse_gesture_ownership.py
+++ b/tests/test_terminal_mouse_gesture_ownership.py
@@ -104,3 +104,28 @@ def test_native_vte_right_click_remains_vte_owned_unless_pasting():
             shift_held=False,
             native_vte_menu=True,
         )
+
+
+def test_mouse_tracking_releases_right_click_even_when_paste_is_on():
+    with patch.object(terminal_mod.Gdk, "BUTTON_SECONDARY", 3), patch.object(
+        terminal_mod.Gtk.EventSequenceState, "DENIED", "denied"
+    ), patch.object(
+        terminal_mod.Gtk.EventSequenceState, "CLAIMED", "claimed"
+    ):
+        handled = terminal_mod._context_click_is_handled(
+            3,
+            paste_on_right_click=True,
+            shift_held=False,
+            native_vte_menu=True,
+            mouse_tracking=True,
+        )
+        assert _resolved_state(handled) == ["denied"]
+        # Shift+right-click still belongs to SSH Pilot (menu / paste override).
+        handled = terminal_mod._context_click_is_handled(
+            3,
+            paste_on_right_click=True,
+            shift_held=True,
+            native_vte_menu=False,
+            mouse_tracking=True,
+        )
+        assert _resolved_state(handled) == ["claimed"]

--- a/tests/test_xterm_shell.py
+++ b/tests/test_xterm_shell.py
@@ -26,6 +26,9 @@ def test_bridge_wiring_present():
     html = build_shell_html()
     assert "window.webkit.messageHandlers.sshpilotPty.postMessage" in html
     assert '"type": "input"' in html or "type: \"input\"" in html or "type:\"input\"" in html
+    assert "term.onBinary" in html
+    assert 'encoding: "binary"' in html
+    assert "btoa(d)" in html
     assert 'send({ type: "ready"' in html or 'type: "ready"' in html
     # Ready is synchronous after fit; one rAF refines size/focus (not double-rAF).
     assert "requestAnimationFrame" in html


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#1212](https://github.com/mfat/sshpilot/issues/1212): mouse clicks and F10 did not reach remote apps such as `htop` on Ubuntu 18.04/20.04, while Ubuntu 24.04 still worked.

Two separate local intercepts were mixed with one encoding bug:

- **X10 mouse (the remote-OS split).** Older ncurses enables X10 mouse (`ESC[M` + three 8-bit bytes). Newer ncurses/htop 3.x uses SGR (`ESC[<...M`), which is ASCII. Daemon-backed VTE re-encoded the `commit` payload as UTF-8, and xterm.js X10 reports went through `onBinary` which we never forwarded. High bytes were dropped or expanded, so clicks never arrived on 18.04/20.04. SGR on 24.04 was unaffected. Switching VTE → PyXterm could not help because both paths lost the 8-bit reports.
- **F10.** GTK’s default `gtk-menu-bar-accel` is F10 (application menu). That is not an sshPilot shortcut, so **Terminal Shortcut Pass-through** could not unbind it. F9 was the sidebar shortcut (user already unbound it); F11 remains fullscreen and can still be unbound in Preferences.

This change:

- Preserves 8-bit commit payloads when VTE’s reported byte length does not match UTF-8.
- Forwards xterm.js `onBinary` as base64/raw bytes into the daemon (and the local PTY bridge).
- Clears `gtk-menu-bar-accel` at startup so F10 reaches the terminal.
- Does not claim right-clicks for paste/menu while the remote app has mouse tracking enabled (Shift+right-click still opens the menu).

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary
- [ ] Public DTOs or client methods were updated
- [ ] Capabilities were updated and only implemented support is advertised
- [ ] Events and structured errors were updated
- [ ] State, ordering, threading, cancellation, and security semantics were reviewed
- [ ] Contract tests were updated
- [ ] API documentation was updated
- [ ] `docs/api/CHANGELOG.md` was updated
- [ ] Compatibility and protocol-version impact were reviewed
- [ ] Generated API artifacts and the public-surface snapshot were deliberately refreshed

## Testing

- `python3 -m pytest -o addopts=""` on `tests/test_macos_menubar.py`, `tests/test_menu_bar_accel.py`, `tests/test_terminal_input.py`, `tests/test_terminal_mouse_gesture_ownership.py`, `tests/test_xterm_shell.py`, `tests/test_pyxterm_daemon_feed.py`, `tests/test_terminal_dialog_continuity.py`, plus the rest of `tests/test_terminal_*.py`, `tests/test_pyxterm_*.py`, `tests/test_xterm_*.py`: **293 passed, 1 skipped**.
- Could not reproduce against live Ubuntu 18.04/20.04 hosts in this environment (no those remotes). Encoding/mouse-tracking/F10 behavior is covered by unit tests.

Please re-test with `sudo htop` on an 18.04/20.04 host: left-click row select, right-click, F9 (after unassigning Toggle Sidebar if still bound), F10 to quit.

GitHub Actions on this branch fails the same pre-existing checks as the last merge to `dev` ([#1217](https://github.com/mfat/sshpilot/pull/1217)): ruff unused imports in sidecar/daemon tests, mcp/sidecar collection errors (`anyio`/`hypothesis` not installed in CI), `test_key_passphrase_roundtrip` (no keyring backend), flaky `test_daemon_client_receives_replay_live_input_and_eof`, and CircleCI “no configuration”. Those are not caused by this change. The extra `test_macos_menubar` failures on the first commit are gone after patching `SshPilotApplication`’s actual MRO bases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e036cc14-6a29-4a5a-b85d-47fb4e600728?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e036cc14-6a29-4a5a-b85d-47fb4e600728&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

