### PR TITLE
Fix Intel macOS PyInstaller when Homebrew pygobject3 has no bottle

### DIFF
--- a/.github/workflows/macos-pyinstaller-x86.yml
+++ b/.github/workflows/macos-pyinstaller-x86.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    paths:
+      - '.github/workflows/macos-pyinstaller-x86.yml'
   workflow_dispatch:
 
 permissions:
@@ -37,13 +40,21 @@ jobs:
                      /usr/local/bin/python3.13 \
                      /usr/local/bin/python3.13-config
 
-          # Install with overwrite flag to prevent linking errors
+          # Install with overwrite flag to prevent linking errors.
+          # pygobject3 is installed separately: Homebrew 3.58+ currently ships
+          # no Intel macOS bottles (arm64 + Linux only), and macos-15-intel is
+          # Homebrew Tier 3 so brew will not auto-fallback to source.
           brew install --overwrite python@3.13 gtk4 libadwaita vte3 gtksourceview5 \
-            adwaita-icon-theme gobject-introspection pygobject3 py3cairo \
+            adwaita-icon-theme gobject-introspection py3cairo \
             create-dmg sshpass
-            
+
+          brew install --overwrite --build-from-source pygobject3
+          brew unlink python@3.14 2>/dev/null || true
           brew link --overwrite --force python@3.13
           brew link --overwrite libadwaita
+
+          PYTHON_PATH="$(brew --prefix python@3.13)/bin/python3.13"
+          "$PYTHON_PATH" -c "import gi; print('PyGObject', gi.__version__)"
 
       - name: Prepare Homebrew virtual environment
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Intel x86_64 PyInstaller job failed on tags `v5.9.8` and `v5.9.9` while installing Homebrew dependencies:

https://github.com/mfat/sshpilot/actions/runs/33224655815

`brew install pygobject3` now errors with `pygobject3: no bottle available!`. Homebrew pygobject3 3.56.3 still had an Intel bottle (v5.9.7 succeeded); 3.58.0 only publishes arm64 macOS and Linux bottles. `macos-15-intel` is also Homebrew Tier 3, so brew will not auto-build from source.

This change keeps the bottled GTK stack install, then builds `pygobject3` from source, relinks Python 3.13, and checks `import gi` before the PyInstaller venv step.

The Intel packaging workflow also runs on PRs that touch this file so the source build can be verified without cutting a tag.

This does not restore a `v5.9.9` Intel DMG on the original tag. After merge, dispatch the workflow from `dev` or cut a follow-up tag so the release job picks up the fixed workflow.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary

## Testing

- Parsed `.github/workflows/macos-pyinstaller-x86.yml` as YAML locally.
- Confirmed Homebrew pygobject3 3.58.0 bottle tags: `arm64_tahoe`, `arm64_sequoia`, `arm64_sonoma`, `arm64_linux`, `x86_64_linux` (no Intel macOS).
- Compared with successful `v5.9.7` Intel run, which poured `pygobject3 (3.56.3)`.
- GitHub Actions **macOS x86_64 PyInstaller** on this PR passed (8m49s): https://github.com/mfat/sshpilot/actions/runs/33226302645
  - `pygobject3` 3.58.0 built from source in 32s
  - `import gi` reported `PyGObject 3.58.0`
  - `SSHPilot.app` and `sshPilot-macOS-5.9.9-x86_64.dmg` produced
  - sshpass x86_64, GtkSourceView dylib, and daemon smoke-test steps succeeded
- pytest, ruff, and CircleCI failures on this PR are pre-existing on `dev` (missing `anyio`/`hypothesis`, unused test imports, CircleCI has no config). This YAML-only change does not touch those jobs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-716ebc5d-1871-4db7-a761-df39b694d506?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-716ebc5d-1871-4db7-a761-df39b694d506&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

