### PR TITLE
Add debug logging for silent terminal clipboard copy failures

### DIFF
--- a/src/sshpilot/terminal.py
+++ b/src/sshpilot/terminal.py
@@ -91,6 +91,35 @@ def _link_click_is_handled(
     return n_press == 1 and active and modifier_held and bool(uri)
 
 
+def clipboard_debug_state(widget) -> str:
+    """Return a privacy-safe snapshot of terminal clipboard/selection state.
+
+    Used to diagnose silent copy failures (issue #1178). Never includes
+    selected or clipboard text — only flags, backend identity, and mouse
+    tracking modes that explain why a selection may not stick.
+    """
+    backend = getattr(widget, "backend", None)
+    backend_name = getattr(widget, "_backend_name", None)
+    if not backend_name:
+        backend_name = type(backend).__name__ if backend is not None else "none"
+    has_selection = False
+    getter = getattr(backend, "get_has_selection", None)
+    if callable(getter):
+        try:
+            has_selection = bool(getter())
+        except Exception:
+            has_selection = False
+    tracker = getattr(widget, "_mouse_tracking", None)
+    mouse_tracking = bool(getattr(tracker, "active", False))
+    modes = getattr(tracker, "modes", ()) or ()
+    pass_through = bool(getattr(widget, "_pass_through_mode", False))
+    return (
+        f"backend={backend_name} has_selection={has_selection} "
+        f"pass_through={pass_through} mouse_tracking={mouse_tracking} "
+        f"mouse_modes={list(modes)}"
+    )
+
+
 def sanitize_local_shell_env(env):
     """Return a copy of *env* stripped of the launching terminal's identity.
 
@@ -1266,6 +1295,11 @@ class TerminalWidget(Gtk.Box):
             self._daemon_size_handler = None
             tracker = getattr(self, "_mouse_tracking", None)
             if tracker is not None:
+                if tracker.active:
+                    logger.debug(
+                        "Terminal mouse tracking reset previously_active=True modes=%s",
+                        list(tracker.modes),
+                    )
                 tracker.reset()
             return
         for attr in ('_daemon_commit_handler', '_daemon_size_handler'):
@@ -1279,6 +1313,11 @@ class TerminalWidget(Gtk.Box):
             setattr(self, attr, None)
         tracker = getattr(self, "_mouse_tracking", None)
         if tracker is not None:
+            if tracker.active:
+                logger.debug(
+                    "Terminal mouse tracking reset previously_active=True modes=%s",
+                    list(tracker.modes),
+                )
             tracker.reset()
 
     def _install_daemon_backend_io(self) -> None:
@@ -1326,7 +1365,15 @@ class TerminalWidget(Gtk.Box):
             raise RuntimeError("No terminal backend to feed display output")
         tracker = getattr(self, "_mouse_tracking", None)
         if tracker is not None:
+            before = tracker.modes
             tracker.feed(data)
+            after = tracker.modes
+            if before != after:
+                logger.debug(
+                    "Terminal mouse tracking changed active=%s modes=%s",
+                    bool(after),
+                    list(after),
+                )
         backend.feed(data)
 
     def _on_daemon_output(self, data):
@@ -3572,8 +3619,16 @@ class TerminalWidget(Gtk.Box):
                     return True
 
                 def _cb_copy(widget, *args):
+                    logger.debug(
+                        "Terminal copy shortcut fired %s",
+                        clipboard_debug_state(self),
+                    )
                     if self.backend:
                         return _schedule_vte_action(self.copy_text)
+                    logger.debug(
+                        "Terminal copy shortcut ignored: no backend %s",
+                        clipboard_debug_state(self),
+                    )
                     return False
 
                 def _cb_paste(widget, *args):
@@ -3793,6 +3848,11 @@ class TerminalWidget(Gtk.Box):
             return False
 
         self._pass_through_mode = enabled
+        logger.debug(
+            "Terminal pass-through mode %s %s",
+            "enabled" if enabled else "disabled",
+            clipboard_debug_state(self),
+        )
         if enabled:
             self._remove_custom_shortcut_controllers()
         else:
@@ -4456,25 +4516,66 @@ class TerminalWidget(Gtk.Box):
         the preference is enabled. Silent (no toast — the signal fires on every
         change during a drag-select), and only when a selection actually exists
         (the signal also fires on deselect)."""
+        has_selection = False
         try:
-            if not self.config.get_setting('terminal.copy_on_select', False):
+            has_selection = bool(self.backend and self.backend.get_has_selection())
+        except Exception:
+            has_selection = False
+        previous = getattr(self, "_logged_has_selection", None)
+        if previous is not has_selection:
+            self._logged_has_selection = has_selection
+            logger.debug(
+                "Terminal selection changed %s",
+                clipboard_debug_state(self),
+            )
+        try:
+            copy_on_select = bool(
+                self.config.get_setting('terminal.copy_on_select', False)
+            )
+            if not copy_on_select:
                 return
-            if self.backend and self.backend.get_has_selection():
+            if has_selection:
+                logger.debug(
+                    "Terminal copy-on-select invoking copy %s",
+                    clipboard_debug_state(self),
+                )
                 self.backend.copy_clipboard()
         except Exception:
             logger.debug("copy-on-select failed", exc_info=True)
 
     def copy_text(self, *, format="text"):
         """Copy selected text to clipboard"""
+        logger.debug(
+            "Terminal copy requested format=%s %s",
+            format,
+            clipboard_debug_state(self),
+        )
         if self.backend:
             def _completed(copied):
+                logger.debug(
+                    "Terminal copy completed copied=%s format=%s %s",
+                    copied,
+                    format,
+                    clipboard_debug_state(self),
+                )
                 if copied:
                     self._show_toast(_("Copied to clipboard"))
 
             self.backend.copy_clipboard(format=format, on_complete=_completed)
+        else:
+            logger.debug(
+                "Terminal copy skipped: no backend format=%s %s",
+                format,
+                clipboard_debug_state(self),
+            )
 
     def handle_backend_copy_result(self, copied):
         """Report a backend-owned shortcut copy through the standard UI path."""
+        logger.debug(
+            "Terminal backend-owned copy result copied=%s %s",
+            copied,
+            clipboard_debug_state(self),
+        )
         if copied:
             self._show_toast(_("Copied to clipboard"))
 

--- a/src/sshpilot/terminal_backends.py
+++ b/src/sshpilot/terminal_backends.py
@@ -22,6 +22,28 @@ from .terminal_color_utils import mix_rgba, relative_luminance, get_contrast_col
 logger = logging.getLogger(__name__)
 
 
+def _log_clipboard_copy(
+    *,
+    backend: str,
+    copied: bool,
+    reason: str,
+    text_len: int = 0,
+    **extra: Any,
+) -> None:
+    """Log a clipboard copy outcome without including selected text."""
+    extras = " ".join(
+        f"{key}={value}" for key, value in extra.items() if value is not None
+    )
+    logger.debug(
+        "Clipboard copy backend=%s copied=%s reason=%s text_len=%s%s",
+        backend,
+        copied,
+        reason,
+        text_len,
+        f" {extras}" if extras else "",
+    )
+
+
 def _pyxterm_input_to_commit(payload: Mapping[str, Any]) -> tuple[Any, int, str]:
     """Return ``(commit_text, byte_size, autocomplete_text)`` for an input message.
 
@@ -1140,17 +1162,34 @@ class VTETerminalBackend:
         on_complete: Optional[Callable[[bool], None]] = None,
     ) -> None:
         copied = False
+        reason = "empty-selection"
+        selected_len = 0
+        has_selection = False
         try:
+            has_selection = bool(self.vte.get_has_selection())
             vte_format = Vte.Format.HTML if format == "html" else Vte.Format.TEXT
             # Validate the payload itself, rather than merely trusting the
             # selection flag.  This also gives the success notification the
             # same semantics as Ptyxis: null/empty selections are not copies.
             selected = self.vte.get_text_selected(vte_format)
+            selected_len = len(selected) if selected else 0
             if selected:
                 self.vte.copy_clipboard_format(vte_format)
                 copied = True
+                reason = "written"
+            elif has_selection:
+                reason = "empty-selection-flag"
         except Exception:
+            reason = "exception"
             logger.debug("Failed to copy VTE selection", exc_info=True)
+        _log_clipboard_copy(
+            backend="vte",
+            copied=copied,
+            reason=reason,
+            text_len=selected_len,
+            format=format,
+            has_selection=has_selection,
+        )
         if on_complete is not None:
             on_complete(copied)
 
@@ -1506,8 +1545,14 @@ class PyXtermTerminalBackend:
         # Embedded backend: nothing server-side to tear down. Subclasses
         # (PyXtermBridgeBackend) close their PTY bridge before calling super().
         callbacks = list(self._clipboard_copy_callbacks.values())
+        pending = len(callbacks)
         self._clipboard_copy_callbacks.clear()
         self._selection_changed_cb = None
+        if pending:
+            logger.debug(
+                "PyXterm destroy failing %s pending clipboard copy callback(s)",
+                pending,
+            )
         for callback in callbacks:
             try:
                 callback(False)
@@ -1809,16 +1854,44 @@ class PyXtermTerminalBackend:
         if display is None:
             display = Gdk.Display.get_default()
         if display is None:
+            logger.debug("PyXterm clipboard unavailable: no Gdk display")
             return None
         return display.get_clipboard()
 
     def _set_system_clipboard_text(self, text: str) -> bool:
         if not text:
+            _log_clipboard_copy(
+                backend="pyxterm",
+                copied=False,
+                reason="empty-selection",
+            )
             return False
         clipboard = self._get_system_clipboard()
         if clipboard is None:
+            _log_clipboard_copy(
+                backend="pyxterm",
+                copied=False,
+                reason="no-clipboard",
+                text_len=len(text),
+            )
             return False
-        clipboard.set(text)
+        try:
+            clipboard.set(text)
+        except Exception:
+            _log_clipboard_copy(
+                backend="pyxterm",
+                copied=False,
+                reason="exception",
+                text_len=len(text),
+            )
+            logger.debug("Failed to set system clipboard from PyXterm", exc_info=True)
+            return False
+        _log_clipboard_copy(
+            backend="pyxterm",
+            copied=True,
+            reason="written",
+            text_len=len(text),
+        )
         return True
 
     def _paste_text(self, text: str) -> None:
@@ -1847,6 +1920,16 @@ class PyXtermTerminalBackend:
         """
         # xterm.js exposes plain selection text only.
         if not self.available or format != "text":
+            reason = "backend-unavailable" if not self.available else "format-unsupported"
+            _log_clipboard_copy(
+                backend="pyxterm",
+                copied=False,
+                reason=reason,
+                format=format,
+                available=self.available,
+                has_selection=self._has_selection,
+                passthrough=self._shortcut_passthrough,
+            )
             if on_complete is not None:
                 on_complete(False)
             return
@@ -1854,17 +1937,36 @@ class PyXtermTerminalBackend:
         request_id = self._clipboard_copy_serial
         if on_complete is not None:
             self._clipboard_copy_callbacks[request_id] = on_complete
+        logger.debug(
+            "PyXterm copy_clipboard dispatch request_id=%s pending=%s "
+            "has_selection=%s passthrough=%s js_ready=%s",
+            request_id,
+            len(self._clipboard_copy_callbacks),
+            self._has_selection,
+            self._shortcut_passthrough,
+            getattr(self, "_js_ready", False),
+        )
         try:
             # IIFE returns a boolean so evaluate_javascript_finish does not see
             # a Promise/"undefined" completion value as an unsupported type.
             script = """
             (function() {
                 var selection = "";
-                if (typeof window.term !== 'undefined' && window.term.hasSelection()) {
-                    selection = window.term.getSelection() || "";
+                var hasSelection = false;
+                if (typeof window.term !== 'undefined') {
+                    hasSelection = !!window.term.hasSelection();
+                    if (hasSelection) {
+                        selection = window.term.getSelection() || "";
+                    }
                 }
                 if (typeof window.ptySend === 'function') {
-                    window.ptySend({type: "copy", requestId: %d, text: selection});
+                    window.ptySend({
+                        type: "copy",
+                        requestId: %d,
+                        text: selection,
+                        hasSelection: hasSelection,
+                        selectionLength: selection.length
+                    });
                 }
                 return true;
             })();
@@ -1873,6 +1975,14 @@ class PyXtermTerminalBackend:
         except Exception as e:
             logger.debug(f"Failed to copy from PyXterm backend: {e}", exc_info=True)
             callback = self._clipboard_copy_callbacks.pop(request_id, None)
+            _log_clipboard_copy(
+                backend="pyxterm",
+                copied=False,
+                reason="javascript-error",
+                request_id=request_id,
+                has_selection=self._has_selection,
+                passthrough=self._shortcut_passthrough,
+            )
             if callback is not None:
                 callback(False)
 
@@ -2424,7 +2534,15 @@ class PyXtermBridgeBackend(PyXtermTerminalBackend):
                 except Exception:  # noqa: BLE001
                     logger.debug("size-changed callback raised", exc_info=True)
         elif kind == "selection-changed":
-            self._has_selection = bool(payload.get("hasSelection"))
+            has_selection = bool(payload.get("hasSelection"))
+            previous = self._has_selection
+            self._has_selection = has_selection
+            if previous != has_selection:
+                logger.debug(
+                    "PyXterm selection-changed has_selection=%s passthrough=%s",
+                    has_selection,
+                    self._shortcut_passthrough,
+                )
             callback = self._selection_changed_cb
             if callback is not None:
                 try:
@@ -2461,15 +2579,51 @@ class PyXtermBridgeBackend(PyXtermTerminalBackend):
             self._set_owner_hovered_link(None)
         elif kind == "paste":
             # Ctrl+Shift+V inside the WebView — use GTK clipboard (other apps).
+            logger.debug(
+                "PyXterm paste shortcut received has_selection=%s passthrough=%s",
+                self._has_selection,
+                self._shortcut_passthrough,
+            )
             self.paste_clipboard()
+        elif kind == "clipboard-passthrough":
+            logger.debug(
+                "PyXterm clipboard shortcut passed through key=%s "
+                "has_selection=%s passthrough=%s",
+                payload.get("key"),
+                payload.get("hasSelection", self._has_selection),
+                self._shortcut_passthrough,
+            )
         elif kind == "copy":
             # Selection posted from JS (shortcut or copy_clipboard).
+            text = payload.get("text") or ""
+            request_id = payload.get("requestId")
+            js_has_selection = payload.get("hasSelection")
+            js_selection_length = payload.get("selectionLength")
+            logger.debug(
+                "PyXterm copy message request_id=%s text_len=%s "
+                "has_selection=%s js_has_selection=%s js_selection_length=%s "
+                "passthrough=%s pending=%s correlated=%s",
+                request_id,
+                len(text),
+                self._has_selection,
+                js_has_selection,
+                js_selection_length,
+                self._shortcut_passthrough,
+                len(self._clipboard_copy_callbacks),
+                request_id in self._clipboard_copy_callbacks,
+            )
             copied = False
             try:
-                copied = self._set_system_clipboard_text(payload.get("text") or "")
+                copied = self._set_system_clipboard_text(text)
             except Exception:  # noqa: BLE001
+                _log_clipboard_copy(
+                    backend="pyxterm",
+                    copied=False,
+                    reason="exception",
+                    text_len=len(text),
+                    request_id=request_id,
+                )
                 logger.debug("Failed to set system clipboard from PyXterm", exc_info=True)
-            request_id = payload.get("requestId")
             callback = self._clipboard_copy_callbacks.pop(request_id, None)
             if callback is not None:
                 callback(copied)

--- a/src/sshpilot/terminal_input.py
+++ b/src/sshpilot/terminal_input.py
@@ -57,6 +57,11 @@ class MouseTrackingState:
     def active(self) -> bool:
         return bool(self._active)
 
+    @property
+    def modes(self) -> tuple[int, ...]:
+        """Enabled DECSET mouse modes, sorted for stable log output."""
+        return tuple(sorted(self._active))
+
     def reset(self) -> None:
         self._active.clear()
         self._tail = b""

--- a/src/sshpilot/xterm_shell.py
+++ b/src/sshpilot/xterm_shell.py
@@ -412,16 +412,29 @@ def _build_shell_html_impl(
       e.preventDefault();
       return false;
     }}
-    if (window.sshpilotShortcutPassthrough) return true;
     if (e.type !== "keydown") return true;
     const isMac = /Mac|iPhone|iPad/.test(navigator.platform || "");
     const clipboardModifier = isMac ? e.metaKey : (e.ctrlKey && e.shiftKey);
-    if (!clipboardModifier) return true;
     const k = e.key.toLowerCase();
+    // Report copy/paste keys even when pass-through is on so Python logs why
+    // the shortcut never became a clipboard write (issue #1178).
+    if (window.sshpilotShortcutPassthrough) {{
+      if (clipboardModifier && (k === "c" || k === "v")) {{
+        send({{ type: "clipboard-passthrough", key: k, hasSelection: term.hasSelection() }});
+      }}
+      return true;
+    }}
+    if (!clipboardModifier) return true;
     if (k === "v") {{ e.preventDefault(); send({{ type: "paste" }}); return false; }}
     if (k === "c") {{
       e.preventDefault();
-      send({{ type: "copy", text: term.getSelection() }});
+      var selection = term.getSelection() || "";
+      send({{
+        type: "copy",
+        text: selection,
+        hasSelection: term.hasSelection(),
+        selectionLength: selection.length
+      }});
       term.focus();
       return false;
     }}

--- a/tests/test_terminal_clipboard_debug.py
+++ b/tests/test_terminal_clipboard_debug.py
@@ -1,0 +1,235 @@
+"""Debug logs for silent terminal copy failures (issue #1178).
+
+These logs must identify *why* a copy no-op'd (empty selection, mouse
+tracking, pass-through, missing clipboard) without recording the selected
+text itself.
+"""
+
+import logging
+from types import SimpleNamespace
+
+from sshpilot.terminal import TerminalWidget, clipboard_debug_state
+from sshpilot.terminal_backends import PyXtermBridgeBackend, PyXtermTerminalBackend
+from sshpilot.terminal_input import MouseTrackingState
+
+
+SECRET = "secret-clipboard-payload"
+
+
+def _bridge_backend():
+    backend = object.__new__(PyXtermBridgeBackend)
+    backend.owner = None
+    backend._bridge = None
+    backend._js_ready = True
+    backend._pending_spawn = None
+    backend._preready_output = []
+    backend._preready_bytes = 0
+    backend._stored_font = None
+    backend._last_size = (24, 80)
+    backend._webview = None
+    backend.widget = object()
+    backend.available = True
+    backend._clipboard_copy_serial = 0
+    backend._clipboard_copy_callbacks = {}
+    backend._has_selection = False
+    backend._selection_changed_cb = None
+    backend._shortcut_passthrough = False
+    return backend
+
+
+def _msg(payload: dict):
+    import json
+
+    return SimpleNamespace(to_json=lambda _indent: json.dumps(payload))
+
+
+def test_clipboard_debug_state_is_privacy_safe():
+    tracker = MouseTrackingState()
+    tracker.feed(b"\x1b[?1000;1006h")
+    widget = SimpleNamespace(
+        backend=SimpleNamespace(get_has_selection=lambda: True),
+        _backend_name="vte",
+        _pass_through_mode=False,
+        _mouse_tracking=tracker,
+    )
+
+    snapshot = clipboard_debug_state(widget)
+
+    assert "backend=vte" in snapshot
+    assert "has_selection=True" in snapshot
+    assert "mouse_tracking=True" in snapshot
+    assert "1000" in snapshot and "1006" in snapshot
+    assert SECRET not in snapshot
+
+
+def test_copy_text_logs_request_and_failure_without_payload(caplog):
+    backend = SimpleNamespace(
+        get_has_selection=lambda: False,
+        copy_clipboard=lambda *, format="text", on_complete=None: on_complete(False),
+    )
+    widget = SimpleNamespace(
+        backend=backend,
+        _backend_name="vte",
+        _pass_through_mode=False,
+        _mouse_tracking=MouseTrackingState(),
+        _show_toast=lambda _message: None,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal"):
+        TerminalWidget.copy_text(widget)
+
+    joined = " ".join(record.getMessage() for record in caplog.records)
+    assert "Terminal copy requested" in joined
+    assert "copied=False" in joined
+    assert "has_selection=False" in joined
+    assert SECRET not in joined
+
+
+def test_backend_owned_copy_result_logs_failure(caplog):
+    widget = SimpleNamespace(
+        backend=SimpleNamespace(get_has_selection=lambda: False),
+        _backend_name="pyxterm",
+        _pass_through_mode=True,
+        _mouse_tracking=MouseTrackingState(),
+        _show_toast=lambda _message: None,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal"):
+        TerminalWidget.handle_backend_copy_result(widget, False)
+
+    assert "backend-owned copy result copied=False" in caplog.text
+    assert "pass_through=True" in caplog.text
+
+
+def test_feed_display_logs_mouse_tracking_transitions(caplog):
+    widget = TerminalWidget.__new__(TerminalWidget)
+    feeds = []
+    widget.backend = SimpleNamespace(feed=feeds.append)
+    widget._mouse_tracking = MouseTrackingState()
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal"):
+        widget._feed_display(b"hello")
+        widget._feed_display(b"\x1b[?1000h")
+        widget._feed_display(b"\x1b[?1000h")
+        widget._feed_display(b"\x1b[?1000l")
+
+    assert feeds == [b"hello", b"\x1b[?1000h", b"\x1b[?1000h", b"\x1b[?1000l"]
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "mouse tracking changed" in record.getMessage()
+    ]
+    assert any("modes=[1000]" in message for message in messages)
+    assert any("active=False" in message for message in messages)
+    assert len(messages) == 2
+
+
+def test_pyxterm_copy_message_logs_lengths_not_text(caplog):
+    backend = _bridge_backend()
+    backend._has_selection = True
+    monkey_writes = []
+    backend._set_system_clipboard_text = (
+        lambda text: monkey_writes.append(text) or True
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend._on_pty_message(
+            None,
+            _msg({
+                "type": "copy",
+                "text": SECRET,
+                "hasSelection": True,
+                "selectionLength": len(SECRET),
+            }),
+        )
+
+    assert monkey_writes == [SECRET]
+    assert "text_len=%s" % len(SECRET) in caplog.text
+    assert "js_has_selection=True" in caplog.text
+    assert SECRET not in caplog.text
+
+
+def test_pyxterm_empty_copy_logs_empty_selection_reason(caplog):
+    backend = _bridge_backend()
+    backend._run_javascript = lambda _script: None
+    completed = []
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend.copy_clipboard(on_complete=completed.append)
+        backend._on_pty_message(
+            None,
+            _msg({
+                "type": "copy",
+                "requestId": 1,
+                "text": "",
+                "hasSelection": False,
+                "selectionLength": 0,
+            }),
+        )
+
+    assert completed == [False]
+    assert "reason=empty-selection" in caplog.text
+    assert "correlated=True" in caplog.text
+
+
+def test_pyxterm_passthrough_copy_is_logged(caplog):
+    backend = _bridge_backend()
+    backend._shortcut_passthrough = True
+    backend._has_selection = True
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend._on_pty_message(
+            None,
+            _msg({"type": "clipboard-passthrough", "key": "c", "hasSelection": True}),
+        )
+
+    assert "clipboard shortcut passed through key=c" in caplog.text
+    assert "has_selection=True" in caplog.text
+
+
+def test_pyxterm_selection_change_logs_transitions_only(caplog):
+    backend = _bridge_backend()
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend._on_pty_message(
+            None, _msg({"type": "selection-changed", "hasSelection": True})
+        )
+        backend._on_pty_message(
+            None, _msg({"type": "selection-changed", "hasSelection": True})
+        )
+        backend._on_pty_message(
+            None, _msg({"type": "selection-changed", "hasSelection": False})
+        )
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "selection-changed" in record.getMessage()
+    ]
+    assert len(messages) == 2
+    assert "has_selection=True" in messages[0]
+    assert "has_selection=False" in messages[1]
+
+
+def test_pyxterm_missing_clipboard_logs_reason(caplog, monkeypatch):
+    backend = object.__new__(PyXtermTerminalBackend)
+    backend._webview = None
+    monkeypatch.setattr(backend, "_get_system_clipboard", lambda: None)
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        result = backend._set_system_clipboard_text(SECRET)
+
+    assert result is False
+    assert "reason=no-clipboard" in caplog.text
+    assert SECRET not in caplog.text
+
+
+def test_pyxterm_destroy_logs_pending_copy_callbacks(caplog):
+    backend = _bridge_backend()
+    backend._run_javascript = lambda _script: None
+    completed = []
+    backend.copy_clipboard(on_complete=completed.append)
+
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        PyXtermTerminalBackend.destroy(backend)
+
+    assert completed == [False]
+    assert "failing 1 pending clipboard copy callback" in caplog.text

--- a/tests/test_terminal_input.py
+++ b/tests/test_terminal_input.py
@@ -58,7 +58,19 @@ def test_mouse_tracking_reset_clears_modes():
     state = MouseTrackingState()
     state.feed(b"\x1b[?1000h")
     assert state.active is True
+    assert state.modes == (1000,)
     state.feed(b"\x1bc")
     assert state.active is False
+    assert state.modes == ()
     assert state.feed(b"\x1b[?1000h\x1bc") is False
     assert state.feed(b"\x1bc\x1b[?1000h") is True
+    assert state.modes == (1000,)
+
+
+def test_mouse_tracking_modes_are_sorted_and_stable():
+    state = MouseTrackingState()
+    state.feed(b"\x1b[?1006h")
+    state.feed(b"\x1b[?1000h")
+    assert state.modes == (1000, 1006)
+    state.feed(b"\x1b[?1000l")
+    assert state.modes == (1006,)

--- a/tests/test_vte_clipboard.py
+++ b/tests/test_vte_clipboard.py
@@ -1,14 +1,18 @@
 """Focused clipboard-result contracts for the VTE backend."""
 
+import logging
 from unittest.mock import MagicMock
 
 from sshpilot.terminal_backends import VTETerminalBackend, Vte
 
 
-def _backend(selected):
+def _backend(selected, has_selection=None):
     backend = object.__new__(VTETerminalBackend)
     backend.vte = MagicMock()
     backend.vte.get_text_selected.return_value = selected
+    backend.vte.get_has_selection.return_value = (
+        bool(selected) if has_selection is None else has_selection
+    )
     return backend
 
 
@@ -52,3 +56,34 @@ def test_vte_copy_failure_never_reports_success():
     backend.copy_clipboard(on_complete=completed.append)
 
     assert completed == [False]
+
+
+def test_vte_copy_logs_empty_selection_without_payload(caplog):
+    backend = _backend("secret-clipboard-payload", has_selection=True)
+    backend.vte.get_text_selected.return_value = ""
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend.copy_clipboard(on_complete=lambda _copied: None)
+
+    assert "reason=empty-selection-flag" in caplog.text
+    assert "has_selection=True" in caplog.text
+    assert "secret-clipboard-payload" not in caplog.text
+
+
+def test_vte_copy_logs_write_length_not_text(caplog):
+    backend = _backend("secret-clipboard-payload")
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend.copy_clipboard(on_complete=lambda _copied: None)
+
+    assert "reason=written" in caplog.text
+    assert "text_len=24" in caplog.text
+    assert "secret-clipboard-payload" not in caplog.text
+
+
+def test_vte_copy_logs_exception_reason(caplog):
+    backend = _backend("selected")
+    backend.vte.copy_clipboard_format.side_effect = RuntimeError("clipboard gone")
+    with caplog.at_level(logging.DEBUG, logger="sshpilot.terminal_backends"):
+        backend.copy_clipboard(on_complete=lambda _copied: None)
+
+    assert "reason=exception" in caplog.text
+    assert "copied=False" in caplog.text

--- a/tests/test_xterm_shell.py
+++ b/tests/test_xterm_shell.py
@@ -63,6 +63,9 @@ def test_clipboard_shortcuts_are_owned_once_and_respect_passthrough():
     assert 'type: "paste"' in html
     assert 'type: "copy"' in html
     assert 'type: "selection-changed"' in html
+    assert 'type: "clipboard-passthrough"' in html
+    assert "hasSelection: term.hasSelection()" in html
+    assert "selectionLength: selection.length" in html
 
 
 def test_link_handler_matches_xterm_docs_pattern():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes diagnostic gap for https://github.com/mfat/sshpilot/issues/1178 — copy failures in tmux/byobu currently leave no trace in logs.

## Summary

Copy from the terminal can fail silently (empty selection, application mouse tracking, pass-through shortcuts, missing Gdk clipboard) with no log line. This adds **Debug** logging across VTE and PyXterm copy paths so a session with logging set to Debug records *why* a copy no-op’d.

Logged (never the selected text itself):

- Copy request/result: backend, `has_selection`, pass-through, mouse-tracking modes
- Copy outcome reason: `written`, `empty-selection`, `empty-selection-flag` (VTE says selected but text is empty), `no-clipboard`, `javascript-error`, `exception`
- Mouse-tracking DECSET transitions (`1000`/`1006`/…) which explain Shift-required selections in tmux
- PyXterm JS copy metadata: `js_has_selection`, `selectionLength`, pending correlated callbacks
- Pass-through copy/paste keys (`clipboard-passthrough`) so Ctrl+Shift+C reaching the shell is visible

Enable **Preferences → logging → Debug** (or `logging.level=debug`) and reproduce a failed copy; `ssh.log` / `sshpilot.log` will contain the new `Clipboard copy` / `Terminal copy` / `mouse tracking` lines.

## API and architecture

- [x] Not applicable: this change does not affect the frontend-neutral API or
      core/frontend ownership boundary

## Testing

```
python3 -m pytest -o addopts= -ra \
  tests/test_vte_clipboard.py \
  tests/test_pyxterm_clipboard.py \
  tests/test_terminal_clipboard_reporting.py \
  tests/test_terminal_clipboard_debug.py \
  tests/test_terminal_input.py \
  tests/test_xterm_shell.py \
  tests/test_terminal_pass_through.py
```

56 passed. New tests assert failure reasons appear at DEBUG and that selected text is never logged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-febad159-d687-410c-938e-b1561dc1c4ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-febad159-d687-410c-938e-b1561dc1c4ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

