### PR TITLE
Localize direct SFTP errors in frontend

### DIFF
--- a/docs/api/CHANGELOG.md
+++ b/docs/api/CHANGELOG.md
@@ -5,6 +5,11 @@ notes remain separate.
 
 ## Unreleased
 
+- Direct SFTP RPC failures now use their existing `ErrorCode` values as the
+  presentation contract instead of transporting rendered English messages.
+  GTK maps those codes to gettext messages and keeps an optional raw SFTP
+  server diagnostic separate. The `ErrorData` shape and error-code inventory
+  are unchanged, so `API_IMPLEMENTATION_VERSION` remains `0.47`.
 - Daemon-only retirement repairs now preserve protected broadcast input
   registration, truthful operation-mode recovery, atomic reconnect publication,
   and cross-process shared-settings transactions. These are implementation

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -337,6 +337,13 @@ The requested daemon operation ID is unknown or no longer retained.
 
 Schema-only code. No current client method defines an API timeout.
 
+Direct SFTP RPC responses use the stable SFTP/remote error codes below for
+frontend message selection; their `message` field is not a presentation
+contract. `details.server_message`, when present, is an opaque server
+diagnostic. The optional boolean `details.server_message_is_specific` marks a
+diagnostic that the frontend may append unchanged after its localized generic
+message. Neither diagnostic field is a gettext message identifier.
+
 <!-- api-error: sftp_service_not_found -->
 ## `sftp_service_not_found`
 
@@ -351,7 +358,7 @@ operation.
 <!-- api-error: sftp_command_failed -->
 ## `sftp_command_failed`
 
-A remote SFTP command failed with a safe translated reason.
+A remote SFTP command failed.
 
 <!-- api-error: sftp_protocol_lost -->
 ## `sftp_protocol_lost`

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -26,6 +26,7 @@ src/sshpilot/file_manager/progress_dialog.py
 src/sshpilot/file_manager/properties_dialog.py
 src/sshpilot/file_manager_window.py
 src/sshpilot/gtk/secrets_interaction_presenter.py
+src/sshpilot/gtk/sftp_error_messages.py
 src/sshpilot/gtk/secret_status_messages.py
 src/sshpilot/gtk/secret_transfer_messages.py
 src/sshpilot/host_picker.py

--- a/src/sshpilot/daemon/sftp_runtime.py
+++ b/src/sshpilot/daemon/sftp_runtime.py
@@ -433,34 +433,12 @@ _ERRNO_TO_ERROR_CODE = {
     errno.EPIPE: ErrorCode.SFTP_PROTOCOL_LOST,
 }
 
-_SFTP_STATUS_TO_CODE_AND_MESSAGE = {
-    sftp_proto.FX_NO_SUCH_FILE: (
-        ErrorCode.REMOTE_PATH_NOT_FOUND,
-        "The path was not found",
-    ),
-    sftp_proto.FX_PERMISSION_DENIED: (
-        ErrorCode.REMOTE_PERMISSION_DENIED,
-        "Permission denied",
-    ),
-    sftp_proto.FX_NO_CONNECTION: (
-        ErrorCode.SFTP_PROTOCOL_LOST,
-        "The SFTP connection was lost",
-    ),
-    sftp_proto.FX_CONNECTION_LOST: (
-        ErrorCode.SFTP_PROTOCOL_LOST,
-        "The SFTP connection was lost",
-    ),
-    sftp_proto.FX_OP_UNSUPPORTED: (
-        ErrorCode.REMOTE_UNSUPPORTED_OPERATION,
-        "The server does not support this operation",
-    ),
-}
-
-_ERROR_CODE_MESSAGES = {
-    ErrorCode.SFTP_PROTOCOL_LOST: "The SFTP connection was lost",
-    ErrorCode.REMOTE_PATH_NOT_FOUND: "The path was not found",
-    ErrorCode.REMOTE_PERMISSION_DENIED: "Permission denied",
-    ErrorCode.REMOTE_UNSUPPORTED_OPERATION: "The server does not support this operation",
+_SFTP_STATUS_TO_ERROR_CODE = {
+    sftp_proto.FX_NO_SUCH_FILE: ErrorCode.REMOTE_PATH_NOT_FOUND,
+    sftp_proto.FX_PERMISSION_DENIED: ErrorCode.REMOTE_PERMISSION_DENIED,
+    sftp_proto.FX_NO_CONNECTION: ErrorCode.SFTP_PROTOCOL_LOST,
+    sftp_proto.FX_CONNECTION_LOST: ErrorCode.SFTP_PROTOCOL_LOST,
+    sftp_proto.FX_OP_UNSUPPORTED: ErrorCode.REMOTE_UNSUPPORTED_OPERATION,
 }
 
 _GENERIC_SFTP_STATUS_TEXT = frozenset(
@@ -2042,10 +2020,8 @@ class SftpServiceRuntime:
             server_message = str(exc)
             if server_message:
                 details["server_message"] = server_message
-            mapped = _SFTP_STATUS_TO_CODE_AND_MESSAGE.get(exc.code)
-            if mapped is not None:
-                code, message = mapped
-            else:
+            code = _SFTP_STATUS_TO_ERROR_CODE.get(exc.code)
+            if code is None:
                 code = _ERRNO_TO_ERROR_CODE.get(
                     getattr(exc, "errno", None), ErrorCode.SFTP_COMMAND_FAILED
                 )
@@ -2053,28 +2029,24 @@ class SftpServiceRuntime:
                     server_message
                     and server_message not in _GENERIC_SFTP_STATUS_TEXT
                 ):
-                    message = server_message
-                else:
-                    message = _ERROR_CODE_MESSAGES.get(
-                        code, "The SFTP command failed"
-                    )
+                    details["server_message_is_specific"] = True
             error = SshPilotError(
                 code,
-                message,
+                code.value,
                 details=details,
                 connection_id=record.connection_id,
             )
         elif isinstance(exc, (EOFError, OSError)):
             error = SshPilotError(
                 ErrorCode.SFTP_PROTOCOL_LOST,
-                "The SFTP connection was lost",
+                ErrorCode.SFTP_PROTOCOL_LOST.value,
                 details=details,
                 connection_id=record.connection_id,
             )
         else:
             error = SshPilotError(
                 ErrorCode.SFTP_PROTOCOL_ERROR,
-                "The SFTP command failed",
+                ErrorCode.SFTP_PROTOCOL_ERROR.value,
                 details=details,
                 connection_id=record.connection_id,
             )
@@ -2084,7 +2056,18 @@ class SftpServiceRuntime:
             # covers protocol EOF while the ssh child is still listed as
             # alive. Flip to FAILED so the file-manager Retry UI appears
             # without waiting for another click.
-            self._fail_dead_connection(record, error)
+            # Preserve the separate ServiceFailure presentation contract until
+            # its dedicated migration. Only the direct ErrorData response uses
+            # the stable code as its non-presentational message placeholder.
+            self._fail_dead_connection(
+                record,
+                SshPilotError(
+                    error.code,
+                    "The SFTP connection was lost",
+                    details=error.details,
+                    connection_id=record.connection_id,
+                ),
+            )
         return error
 
     def _fail_dead_connection(self, record: _SftpRecord, error: SshPilotError) -> None:

--- a/src/sshpilot/daemon_sftp_backend.py
+++ b/src/sshpilot/daemon_sftp_backend.py
@@ -42,6 +42,7 @@ from .api.models.transfers import (
 )
 from .file_manager.common import FileEntry
 from .file_manager.exceptions import TransferCancelledException
+from .gtk.sftp_error_messages import format_direct_sftp_error
 from .sftp_service_controller import (
     DaemonSftpServiceController,
     SftpControllerState,
@@ -53,6 +54,25 @@ from .transfer_service_controller import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _localized_direct_error(error: BaseException) -> BaseException:
+    """Clone a direct RPC error with its frontend-rendered display message."""
+
+    if not isinstance(error, SshPilotError):
+        return error
+    message = format_direct_sftp_error(error)
+    if message == str(error):
+        return error
+    return SshPilotError(
+        error.code,
+        message,
+        details=error.details,
+        retryable=error.retryable,
+        request_id=error.request_id,
+        connection_id=error.connection_id,
+        session_id=error.session_id,
+    )
 
 
 def daemon_file_manager_capabilities_missing(client) -> frozenset:
@@ -468,7 +488,7 @@ class DaemonSftpManager(GObject.GObject):
             self._start_count_pass(target, entries)
 
         def _on_error(exc) -> None:
-            self.emit("operation-error", str(exc))
+            self.emit("operation-error", format_direct_sftp_error(exc))
 
         self._sftp_controller.list_directory(target, on_success=_on_success, on_error=_on_error)
 
@@ -559,7 +579,9 @@ class DaemonSftpManager(GObject.GObject):
         self._sftp_controller.mkdir(
             target,
             on_success=lambda r: self._safe_set(future, result=r),
-            on_error=lambda e: self._safe_set(future, exc=e),
+            on_error=lambda e: self._safe_set(
+                future, exc=_localized_direct_error(e)
+            ),
         )
         return future
 
@@ -579,7 +601,7 @@ class DaemonSftpManager(GObject.GObject):
             if isinstance(exc, SshPilotError) and exc.code is ErrorCode.REMOTE_PATH_NOT_FOUND:
                 self._safe_set(future, result=False)
             else:
-                self._safe_set(future, exc=exc)
+                self._safe_set(future, exc=_localized_direct_error(exc))
 
         self._sftp_controller.stat(target, on_success=_on_success, on_error=_on_error)
         return future
@@ -602,7 +624,7 @@ class DaemonSftpManager(GObject.GObject):
             self._safe_set(future, result=entry)
 
         def _on_error(exc) -> None:
-            self._safe_set(future, exc=exc)
+            self._safe_set(future, exc=_localized_direct_error(exc))
 
         self._sftp_controller.stat(
             target,
@@ -625,7 +647,9 @@ class DaemonSftpManager(GObject.GObject):
             source,
             target,
             on_success=lambda r: self._safe_set(future, result=r),
-            on_error=lambda e: self._safe_set(future, exc=e),
+            on_error=lambda e: self._safe_set(
+                future, exc=_localized_direct_error(e)
+            ),
         )
         return future
 
@@ -645,7 +669,7 @@ class DaemonSftpManager(GObject.GObject):
                     exc=FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST), target),
                 )
             elif isinstance(exc, SshPilotError):
-                self._safe_set(future, exc=OSError(exc.message))
+                self._safe_set(future, exc=OSError(format_direct_sftp_error(exc)))
             else:
                 self._safe_set(future, exc=exc)
 
@@ -684,15 +708,19 @@ class DaemonSftpManager(GObject.GObject):
                     "progress", summary.progress or 0.0, summary.message or f"{verb}…"
                 )
 
+        def _on_error(exc) -> None:
+            resolved = self._resolve_operation_exception(exc)
+            if not recursive:
+                resolved = _localized_direct_error(resolved)
+            self._safe_set(future, exc=resolved)
+
         self._sftp_controller.copy(
             source,
             destination,
             recursive=recursive,
             move=move,
             on_success=lambda _result: self._safe_set(future, result=None),
-            on_error=lambda exc: self._safe_set(
-                future, exc=self._resolve_operation_exception(exc)
-            ),
+            on_error=_on_error,
             on_operation_started=on_operation_started,
             on_progress=on_progress,
         )

--- a/src/sshpilot/gtk/sftp_error_messages.py
+++ b/src/sshpilot/gtk/sftp_error_messages.py
@@ -1,0 +1,43 @@
+"""Frontend-owned presentation of direct SFTP RPC errors."""
+
+from __future__ import annotations
+
+from gettext import gettext as _
+
+from ..api.errors import ErrorCode, SshPilotError
+from ..i18n import N_
+
+
+_DIRECT_SFTP_ERROR_TEMPLATES = {
+    ErrorCode.REMOTE_PATH_NOT_FOUND: N_("The path was not found"),
+    ErrorCode.REMOTE_PERMISSION_DENIED: N_("Permission denied"),
+    ErrorCode.SFTP_PROTOCOL_LOST: N_("The SFTP connection was lost"),
+    ErrorCode.REMOTE_UNSUPPORTED_OPERATION: N_(
+        "The server does not support this operation"
+    ),
+    ErrorCode.SFTP_COMMAND_FAILED: N_("The SFTP command failed"),
+    ErrorCode.SFTP_PROTOCOL_ERROR: N_("The SFTP command failed"),
+}
+
+
+def format_direct_sftp_error(error: BaseException) -> str:
+    """Translate a direct SFTP error and append a specific server diagnostic."""
+
+    if not isinstance(error, SshPilotError):
+        return str(error)
+    template = _DIRECT_SFTP_ERROR_TEMPLATES.get(error.code)
+    if template is None:
+        return str(error)
+
+    message = _(template)
+    details = error.details
+    is_specific = details.get("server_message_is_specific", False)
+    if type(is_specific) is not bool:
+        raise ValueError("SFTP server diagnostic classification is invalid")
+    if not is_specific:
+        return message
+
+    diagnostic = details.get("server_message")
+    if type(diagnostic) is not str or not diagnostic:
+        raise ValueError("specific SFTP server diagnostic is missing")
+    return f"{message}\n\n{diagnostic}"

--- a/tests/api/test_direct_sftp_error_codec.py
+++ b/tests/api/test_direct_sftp_error_codec.py
@@ -1,0 +1,62 @@
+import pytest
+
+from sshpilot.api.errors import ErrorCode, SshPilotError
+from sshpilot.api.models.common import ConnectionId, RequestId
+from sshpilot.api.transport.codec import (
+    decode_envelope,
+    encode_envelope,
+    error_from_wire,
+    error_to_wire,
+)
+from sshpilot.api.transport.envelopes import ErrorResponseEnvelope
+from sshpilot.api.version import PROTOCOL_VERSION
+
+
+def test_direct_sftp_error_round_trip_preserves_code_and_diagnostic():
+    diagnostic = "server locale diagnostic"
+    error = SshPilotError(
+        ErrorCode.SFTP_COMMAND_FAILED,
+        ErrorCode.SFTP_COMMAND_FAILED.value,
+        details={
+            "service_id": "sftp-7",
+            "sftp_status": 4,
+            "server_message": diagnostic,
+            "server_message_is_specific": True,
+        },
+        connection_id=ConnectionId("demo"),
+    )
+    envelope = ErrorResponseEnvelope(
+        PROTOCOL_VERSION,
+        RequestId("request-1"),
+        error_to_wire(error),
+    )
+
+    encoded = encode_envelope(envelope)
+    decoded = decode_envelope(encoded)
+    restored = error_from_wire(decoded.error)
+
+    assert restored.code is ErrorCode.SFTP_COMMAND_FAILED
+    assert restored.message == ErrorCode.SFTP_COMMAND_FAILED.value
+    assert restored.details == error.details
+    assert restored.details["server_message"] == diagnostic
+    assert "The SFTP command failed" not in str(encoded)
+
+
+def test_direct_sftp_error_codec_rejects_unknown_code():
+    with pytest.raises(ValueError, match="unknown error code"):
+        decode_envelope(
+            {
+                "type": "error",
+                "protocol_version": PROTOCOL_VERSION,
+                "request_id": "request-1",
+                "error": {
+                    "code": "english sentence as protocol code",
+                    "message": "english sentence as protocol code",
+                    "details": {},
+                    "retryable": False,
+                    "request_id": None,
+                    "connection_id": None,
+                    "session_id": None,
+                },
+            }
+        )

--- a/tests/architecture/test_sftp_i18n_boundary.py
+++ b/tests/architecture/test_sftp_i18n_boundary.py
@@ -1,0 +1,70 @@
+"""Architecture checks for frontend-owned direct SFTP error localization."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "src" / "sshpilot"
+RUNTIME = SOURCE / "daemon" / "sftp_runtime.py"
+PRESENTER = SOURCE / "gtk" / "sftp_error_messages.py"
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def test_sftp_daemon_never_calls_gettext():
+    tree = _tree(RUNTIME)
+    imported_modules = {
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    }
+    calls = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+    assert "gettext" not in imported_modules
+    assert "_" not in calls
+    assert "N_" not in calls
+
+
+def test_direct_sftp_status_map_contains_only_stable_codes():
+    tree = _tree(RUNTIME)
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name)
+            and target.id == "_SFTP_STATUS_TO_ERROR_CODE"
+            for target in node.targets
+        )
+    )
+
+    assert all(isinstance(value, ast.Attribute) for value in assignment.value.values)
+
+
+def test_sftp_presenter_is_the_gettext_extraction_owner():
+    potfiles = (ROOT / "po" / "POTFILES").read_text(encoding="utf-8").splitlines()
+
+    assert "src/sshpilot/gtk/sftp_error_messages.py" in potfiles
+    assert "src/sshpilot/daemon/sftp_runtime.py" not in potfiles
+
+
+def test_sftp_presenter_does_not_depend_on_service_failure_models():
+    imports = {
+        node.module for node in ast.walk(_tree(PRESENTER)) if isinstance(node, ast.ImportFrom)
+    }
+
+    assert "..api.models.operations" not in imports
+    assert "..api.models.transfers" not in imports
+
+
+def test_file_manager_item_count_text_remains_out_of_scope():
+    pane_source = (SOURCE / "file_manager" / "pane.py").read_text(encoding="utf-8")
+
+    assert pane_source.count('f"{entry.item_count} items"') == 3

--- a/tests/daemon/test_daemon_sftp_backend_file_ops.py
+++ b/tests/daemon/test_daemon_sftp_backend_file_ops.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from sshpilot.api.errors import ErrorCode, SshPilotError
-from sshpilot.daemon_sftp_backend import DaemonSftpManager
+from sshpilot.daemon_sftp_backend import DaemonSftpManager, _localized_direct_error
+from sshpilot.gtk import sftp_error_messages
 from sshpilot.sftp_service_controller import SftpControllerState
 
 SERVICE_ID = "sftp-1"
@@ -98,3 +101,61 @@ def test_remove_delegates_recursive_delete_to_daemon():
 
     assert future.result() is None
     assert controller.remove_calls == [("/home/user/tree", True)]
+
+
+def test_direct_future_error_is_localized_without_losing_error_code(monkeypatch):
+    monkeypatch.setattr(sftp_error_messages, "_", lambda _msgid: "Accès refusé")
+    error = SshPilotError(
+        ErrorCode.REMOTE_PERMISSION_DENIED,
+        ErrorCode.REMOTE_PERMISSION_DENIED.value,
+        details={"sftp_status": 3, "server_message": "Permission denied"},
+    )
+
+    localized = _localized_direct_error(error)
+
+    assert isinstance(localized, SshPilotError)
+    assert localized.code is ErrorCode.REMOTE_PERMISSION_DENIED
+    assert localized.message == "Accès refusé"
+    assert localized.details == error.details
+
+
+def test_service_failure_error_is_unchanged_by_direct_adapter(monkeypatch):
+    monkeypatch.setattr(
+        sftp_error_messages,
+        "_",
+        lambda _msgid: pytest.fail("ServiceFailure must not be translated here"),
+    )
+    error = SshPilotError(
+        ErrorCode.SFTP_SERVICE_NOT_READY,
+        "The SFTP session could not be established",
+    )
+
+    assert _localized_direct_error(error) is error
+
+
+def test_list_error_signal_contains_frontend_translation(monkeypatch):
+    controller = _Controller()
+    manager = _manager(controller)
+    emitted = []
+    monkeypatch.setattr(sftp_error_messages, "_", lambda _msgid: "Chemin introuvable")
+    monkeypatch.setattr(
+        DaemonSftpManager,
+        "emit",
+        lambda _self, *args: emitted.append(args),
+    )
+
+    def _list_directory(_path, *, on_success, on_error):
+        del on_success
+        on_error(
+            SshPilotError(
+                ErrorCode.REMOTE_PATH_NOT_FOUND,
+                ErrorCode.REMOTE_PATH_NOT_FOUND.value,
+                details={"sftp_status": 2, "server_message": "No such file"},
+            )
+        )
+
+    controller.list_directory = _list_directory
+
+    manager.listdir("/missing")
+
+    assert emitted == [("operation-error", "Chemin introuvable")]

--- a/tests/daemon/test_sftp_runtime.py
+++ b/tests/daemon/test_sftp_runtime.py
@@ -575,7 +575,12 @@ def test_connection_lost_status_fails_service_with_specific_message():
         _list_tmp(runtime, summary, owner)
 
     assert raised.value.code is ErrorCode.SFTP_PROTOCOL_LOST
-    assert raised.value.message == "The SFTP connection was lost"
+    assert raised.value.message == ErrorCode.SFTP_PROTOCOL_LOST.value
+    assert raised.value.details == {
+        "service_id": summary.id,
+        "sftp_status": sftp_proto.FX_CONNECTION_LOST,
+        "server_message": "Connection lost",
+    }
     failed = runtime.get_service(summary.id)
     assert failed.state is SftpServiceState.FAILED
     assert failed.failure.message == "The SFTP connection was lost"
@@ -593,7 +598,7 @@ def test_permission_denied_status_keeps_service_ready():
         _list_tmp(runtime, summary, owner)
 
     assert raised.value.code is ErrorCode.REMOTE_PERMISSION_DENIED
-    assert raised.value.message == "Permission denied"
+    assert raised.value.message == ErrorCode.REMOTE_PERMISSION_DENIED.value
     assert runtime.get_service(summary.id).state is SftpServiceState.READY
 
 
@@ -609,7 +614,8 @@ def test_fx_failure_keeps_generic_command_message_and_ready_service():
         _list_tmp(runtime, summary, owner)
 
     assert raised.value.code is ErrorCode.SFTP_COMMAND_FAILED
-    assert raised.value.message == "The SFTP command failed"
+    assert raised.value.message == ErrorCode.SFTP_COMMAND_FAILED.value
+    assert "server_message_is_specific" not in raised.value.details
     assert runtime.get_service(summary.id).state is SftpServiceState.READY
 
 
@@ -625,5 +631,66 @@ def test_fx_failure_with_server_text_is_surfaced():
         _list_tmp(runtime, summary, owner)
 
     assert raised.value.code is ErrorCode.SFTP_COMMAND_FAILED
-    assert raised.value.message == "Directory not empty"
+    assert raised.value.message == ErrorCode.SFTP_COMMAND_FAILED.value
+    assert raised.value.details["server_message"] == "Directory not empty"
+    assert raised.value.details["server_message_is_specific"] is True
     assert runtime.get_service(summary.id).state is SftpServiceState.READY
+
+
+@pytest.mark.parametrize(
+    ("status", "server_message", "expected_code"),
+    (
+        (
+            sftp_proto.FX_NO_SUCH_FILE,
+            "No such file",
+            ErrorCode.REMOTE_PATH_NOT_FOUND,
+        ),
+        (
+            sftp_proto.FX_OP_UNSUPPORTED,
+            "Operation unsupported",
+            ErrorCode.REMOTE_UNSUPPORTED_OPERATION,
+        ),
+    ),
+)
+def test_direct_status_errors_use_stable_codes_not_rendered_messages(
+    status, server_message, expected_code
+):
+    runtime, _runner = _make_runtime()
+    owner, summary, client = _ready_service(runtime, _runner)
+
+    def _fail(_path):
+        raise sftp_proto.SFTPError(status, server_message)
+
+    client.listdir_attr = _fail
+    with pytest.raises(SshPilotError) as raised:
+        _list_tmp(runtime, summary, owner)
+
+    assert raised.value.code is expected_code
+    assert raised.value.message == expected_code.value
+    assert raised.value.details["server_message"] == server_message
+    assert "server_message_is_specific" not in raised.value.details
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    (
+        (OSError("system connection detail"), ErrorCode.SFTP_PROTOCOL_LOST),
+        (RuntimeError("library protocol detail"), ErrorCode.SFTP_PROTOCOL_ERROR),
+    ),
+)
+def test_external_exception_text_is_not_transported_as_direct_message(
+    failure, expected_code
+):
+    runtime, _runner = _make_runtime()
+    owner, summary, client = _ready_service(runtime, _runner)
+
+    def _fail(_path):
+        raise failure
+
+    client.listdir_attr = _fail
+    with pytest.raises(SshPilotError) as raised:
+        _list_tmp(runtime, summary, owner)
+
+    assert raised.value.code is expected_code
+    assert raised.value.message == expected_code.value
+    assert str(failure) not in str(raised.value.to_dict())

--- a/tests/daemon/test_sftp_session_death_stuck_tab.py
+++ b/tests/daemon/test_sftp_session_death_stuck_tab.py
@@ -207,7 +207,8 @@ def test_dead_connection_fails_service_and_signals_the_tab():
         "/tmp", on_success=lambda _r: None, on_error=op_errors.append
     )
     assert len(op_errors) == 1
-    assert "The SFTP connection was lost" in str(op_errors[0])
+    assert op_errors[0].code is ErrorCode.SFTP_PROTOCOL_LOST
+    assert op_errors[0].message == ErrorCode.SFTP_PROTOCOL_LOST.value
 
     # Fixed: the failed op flips the service record to FAILED instead of
     # leaving it READY forever.
@@ -219,6 +220,7 @@ def test_dead_connection_fails_service_and_signals_the_tab():
     assert controller.state is SftpControllerState.FAILED
     assert len(errors) == 1
     assert errors[0].code is ErrorCode.SFTP_SERVICE_NOT_READY
+    assert errors[0].message == "The SFTP connection was lost"
 
     # Further ops are now rejected locally -- no more requests hit the dead
     # connection, unlike the old behavior of failing the same way forever.

--- a/tests/test_file_manager_retry.py
+++ b/tests/test_file_manager_retry.py
@@ -152,3 +152,16 @@ def test_connection_error_idle_ignores_replaced_manager(monkeypatch):
     queued[0]()
 
     win._right_pane.show_load_error.assert_not_called()
+
+
+def test_direct_operation_error_reaches_retry_pane_localized():
+    win = _window()
+    manager = MagicMock()
+    win._manager = manager
+    win._pending_paths[win._right_pane] = "/root-only"
+
+    win._on_operation_error(manager, "Accès refusé")
+
+    win._right_pane.show_load_error.assert_called_once_with(
+        "/root-only", "Accès refusé"
+    )

--- a/tests/test_sftp_error_messages.py
+++ b/tests/test_sftp_error_messages.py
@@ -1,0 +1,95 @@
+import pytest
+
+from sshpilot.api.errors import ErrorCode, SshPilotError
+from sshpilot.gtk import sftp_error_messages as messages
+
+
+@pytest.mark.parametrize(
+    ("code", "msgid"),
+    (
+        (ErrorCode.REMOTE_PATH_NOT_FOUND, "The path was not found"),
+        (ErrorCode.REMOTE_PERMISSION_DENIED, "Permission denied"),
+        (ErrorCode.SFTP_PROTOCOL_LOST, "The SFTP connection was lost"),
+        (
+            ErrorCode.REMOTE_UNSUPPORTED_OPERATION,
+            "The server does not support this operation",
+        ),
+        (ErrorCode.SFTP_COMMAND_FAILED, "The SFTP command failed"),
+        (ErrorCode.SFTP_PROTOCOL_ERROR, "The SFTP command failed"),
+    ),
+)
+def test_direct_sftp_error_code_selects_frontend_msgid(monkeypatch, code, msgid):
+    calls = []
+
+    def translate(value):
+        calls.append(value)
+        return f"translated:{value}"
+
+    monkeypatch.setattr(messages, "_", translate)
+    error = SshPilotError(code, code.value)
+
+    assert messages.format_direct_sftp_error(error) == f"translated:{msgid}"
+    assert calls == [msgid]
+
+
+def test_specific_server_diagnostic_is_appended_without_gettext(monkeypatch):
+    calls = []
+
+    def translate(value):
+        calls.append(value)
+        return "La commande SFTP a échoué"
+
+    monkeypatch.setattr(messages, "_", translate)
+    diagnostic = "remote appliance rejected inode 42"
+    error = SshPilotError(
+        ErrorCode.SFTP_COMMAND_FAILED,
+        ErrorCode.SFTP_COMMAND_FAILED.value,
+        details={
+            "sftp_status": 4,
+            "server_message": diagnostic,
+            "server_message_is_specific": True,
+        },
+    )
+
+    assert messages.format_direct_sftp_error(error) == (
+        f"La commande SFTP a échoué\n\n{diagnostic}"
+    )
+    assert calls == ["The SFTP command failed"]
+
+
+def test_generic_server_status_is_not_displayed_as_diagnostic(monkeypatch):
+    monkeypatch.setattr(messages, "_", lambda _value: "Échec SFTP")
+    error = SshPilotError(
+        ErrorCode.SFTP_COMMAND_FAILED,
+        ErrorCode.SFTP_COMMAND_FAILED.value,
+        details={"sftp_status": 4, "server_message": "Failure"},
+    )
+
+    assert messages.format_direct_sftp_error(error) == "Échec SFTP"
+
+
+def test_service_failure_family_is_not_presented_by_direct_formatter(monkeypatch):
+    monkeypatch.setattr(
+        messages,
+        "_",
+        lambda _value: pytest.fail("ServiceFailure text must stay out of this pass"),
+    )
+    error = SshPilotError(
+        ErrorCode.SFTP_SERVICE_NOT_READY,
+        "The SFTP session could not be established",
+    )
+
+    assert messages.format_direct_sftp_error(error) == (
+        "The SFTP session could not be established"
+    )
+
+
+def test_specific_diagnostic_metadata_is_strict():
+    error = SshPilotError(
+        ErrorCode.SFTP_COMMAND_FAILED,
+        ErrorCode.SFTP_COMMAND_FAILED.value,
+        details={"server_message_is_specific": "yes"},
+    )
+
+    with pytest.raises(ValueError, match="classification is invalid"):
+        messages.format_direct_sftp_error(error)


### PR DESCRIPTION
## Summary

Localizes user-visible SFTP errors that are returned directly through `SshPilotError` / `ErrorData`.

This change:

- replaces daemon-side finalized SFTP error text with existing stable `ErrorCode` values;
- keeps raw server/SFTP diagnostics in structured error details;
- translates the user-facing error message only in the frontend;
- appends a specific server diagnostic separately when appropriate;
- keeps the existing RPC/API schema unchanged.

The POT grows from 2,147 to 2,151 entries, adding four new msgids and reusing the existing `Permission denied` translation entry.

## Validation

- API tests: `676 passed`
- targeted SFTP/FileManager/i18n/backup tests: `148 passed`
- sandbox-excluded integration tests run separately: `2 passed`
- SFTP operations/transfers/secret-transfer tests: `91 passed`
- `generate_api_artifacts.py --check`: passed
- Ruff on all modified/new Python files: passed
- `git diff --check`: passed

## Scope

This PR intentionally covers only direct SFTP errors transported through `SshPilotError` / `ErrorData`.

It does not migrate the separate `ServiceFailure` paths used by:

- SFTP service lifecycle;
- recursive operations;
- upload/download transfers.

Those paths remain a separate follow-up.

It also does not modify backup/import messages, general FileManager strings, or translation catalogs.