### PR TITLE
Localize non-SSH plugin UI strings

### DIFF
--- a/data/io.github.mfat.sshpilot.metainfo.xml.in
+++ b/data/io.github.mfat.sshpilot.metainfo.xml.in
@@ -63,7 +63,7 @@
 
     <release version="6.0.0" date="2026-08-30">
       <description>
-        <p>Uprovements to non-SSH protocol plugins</p>
+        <p>Improvements to non-SSH protocol plugins</p>
         <p>Fixes text selection when using remote apps such as tmux and htop</p>
         <p>Fixes SFTP File Manager retry/reconnect flow</p>
       </description>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 sshpilot (6.0.0-1) unstable; urgency=medium
 
   * Release v6.0.0.
-  * Uprovements to non-SSH protocol plugins
+  * Improvements to non-SSH protocol plugins
   * Fixes text selection when using remote apps such as tmux and htop
   * Fixes SFTP File Manager retry/reconnect flow
 

--- a/packaging/fedora/rpm.spec
+++ b/packaging/fedora/rpm.spec
@@ -145,7 +145,7 @@ an alternative to Putty, Termius and Mobaxterm.
 
 %changelog
 * Sun Aug 30 2026 mFat <newmfat@gmail.com> - 6.0.0-1
-- Uprovements to non-SSH protocol plugins
+- Improvements to non-SSH protocol plugins
 - Fixes text selection when using remote apps such as tmux and htop
 - Fixes SFTP File Manager retry/reconnect flow
 

--- a/src/sshpilot/connection_dialog.py
+++ b/src/sshpilot/connection_dialog.py
@@ -4124,8 +4124,12 @@ Host {getattr(self, 'nickname_row', None).get_text().strip() if hasattr(self, 'n
         for spec in specs:
             group_key = getattr(spec, 'group', 'general') or 'general'
             if group_key not in groups:
-                title = (backend.display_name or backend.protocol_id) \
-                    if group_key == 'general' else group_key.replace('_', ' ').title()
+                if group_key == 'general':
+                    title = backend.display_name or backend.protocol_id
+                elif group_key == 'advanced':
+                    title = _("Advanced")
+                else:
+                    title = group_key.replace('_', ' ').title()
                 group = Adw.PreferencesGroup(title=title)
                 groups[group_key] = group
                 ordered_groups.append(group)

--- a/src/sshpilot/plugins/builtin/_shell.py
+++ b/src/sshpilot/plugins/builtin/_shell.py
@@ -20,21 +20,26 @@ from typing import List, Optional
 
 from ..api import ProtocolError
 
-__all__ = ["command_split_error", "split_command"]
+__all__ = ["command_split_diagnostic", "split_command"]
 
 
 def _split(value: str) -> List[str]:
     return shlex.split(str(value or ""))
 
 
-def command_split_error(value: object, field: str) -> Optional[str]:
-    """Return a ``validate()`` message if ``value`` is not valid shell words."""
+def command_split_diagnostic(value: object) -> Optional[str]:
+    """Return an opaque parser diagnostic for frontend validation.
+
+    The frontend caller owns the localizable template. Keeping only the raw
+    diagnostic here prevents the daemon-facing ``split_command`` path from
+    acquiring gettext behaviour.
+    """
     if not value:
         return None
     try:
         _split(value)
     except ValueError as exc:
-        return f"{field} could not be parsed: {exc}."
+        return str(exc)
     return None
 
 

--- a/src/sshpilot/plugins/builtin/docker_protocol/__init__.py
+++ b/src/sshpilot/plugins/builtin/docker_protocol/__init__.py
@@ -13,7 +13,7 @@ import shutil  # noqa: F401  # kept: tests patch this module's `shutil.which`
 from gettext import gettext as _
 from typing import Any, Dict, List
 
-from .._shell import command_split_error, split_command
+from .._shell import command_split_diagnostic, split_command
 from ...api import (
     FieldSpec,
     PluginContext,
@@ -35,7 +35,7 @@ class DockerProtocolBackend(ProtocolBackend):
     def connection_fields(self) -> List[FieldSpec]:
         return [
             FieldSpec(key="container", label=_("Container"), kind="text", required=True,
-                      placeholder="name or id"),
+                      placeholder=_("name or id")),
             FieldSpec(key="command", label=_("Command"), kind="text", default="sh",
                       placeholder="sh"),
             FieldSpec(key="runtime", label=_("Runtime"), kind="choice", default="docker",
@@ -43,7 +43,7 @@ class DockerProtocolBackend(ProtocolBackend):
             FieldSpec(key="docker_host", label=_("Daemon host"), kind="text",
                       placeholder="ssh://user@host or tcp://host:2375", group="advanced"),
             FieldSpec(key="user", label=_("User"), kind="text",
-                      placeholder="user or UID", group="advanced"),
+                      placeholder=_("user or UID"), group="advanced"),
             FieldSpec(key="workdir", label=_("Working directory"), kind="text",
                       placeholder="/path/in/container", group="advanced"),
         ]
@@ -51,13 +51,17 @@ class DockerProtocolBackend(ProtocolBackend):
     def validate(self, data: Dict[str, Any]) -> List[str]:
         errors: List[str] = []
         if not (data.get("container") or "").strip():
-            errors.append("A container name or id is required.")
+            errors.append(_("A container name or id is required."))
         runtime = (data.get("runtime") or "docker")
         if runtime not in ("docker", "podman"):
-            errors.append("Runtime must be docker or podman.")
-        problem = command_split_error(data.get("command"), "Command")
-        if problem:
-            errors.append(problem)
+            errors.append(_("Runtime must be docker or podman."))
+        diagnostic = command_split_diagnostic(data.get("command"))
+        if diagnostic:
+            errors.append(
+                _("{field} could not be parsed: {diagnostic}.").format(
+                    field=_("Command"), diagnostic=diagnostic
+                )
+            )
         return errors
 
     def build_spawn(self, connection: Any, ctx: PluginContext) -> SpawnSpec:

--- a/src/sshpilot/plugins/builtin/kubernetes_protocol/__init__.py
+++ b/src/sshpilot/plugins/builtin/kubernetes_protocol/__init__.py
@@ -12,7 +12,7 @@ import shutil  # noqa: F401  # kept: tests patch this module's `shutil.which`
 from gettext import gettext as _
 from typing import Any, Dict, List
 
-from .._shell import command_split_error, split_command
+from .._shell import command_split_diagnostic, split_command
 from ...api import (
     FieldSpec,
     PluginContext,
@@ -34,13 +34,13 @@ class KubernetesProtocolBackend(ProtocolBackend):
     def connection_fields(self) -> List[FieldSpec]:
         return [
             FieldSpec(key="pod", label=_("Pod"), kind="text", required=True,
-                      placeholder="pod name"),
+                      placeholder=_("pod name")),
             FieldSpec(key="container", label=_("Container"), kind="text",
-                      placeholder="(default container)"),
+                      placeholder=_("(default container)")),
             FieldSpec(key="namespace", label=_("Namespace"), kind="text",
                       placeholder="default"),
             FieldSpec(key="kube_context", label=_("Context"), kind="text",
-                      placeholder="(current context)", group="advanced"),
+                      placeholder=_("(current context)"), group="advanced"),
             FieldSpec(key="kubeconfig", label=_("Kubeconfig"), kind="file",
                       group="advanced"),
             FieldSpec(key="command", label=_("Command"), kind="text", default="sh",
@@ -50,10 +50,14 @@ class KubernetesProtocolBackend(ProtocolBackend):
     def validate(self, data: Dict[str, Any]) -> List[str]:
         errors: List[str] = []
         if not (data.get("pod") or "").strip():
-            errors.append("A pod name is required.")
-        problem = command_split_error(data.get("command"), "Command")
-        if problem:
-            errors.append(problem)
+            errors.append(_("A pod name is required."))
+        diagnostic = command_split_diagnostic(data.get("command"))
+        if diagnostic:
+            errors.append(
+                _("{field} could not be parsed: {diagnostic}.").format(
+                    field=_("Command"), diagnostic=diagnostic
+                )
+            )
         return errors
 
     def build_spawn(self, connection: Any, ctx: PluginContext) -> SpawnSpec:

--- a/src/sshpilot/plugins/builtin/mosh_protocol/__init__.py
+++ b/src/sshpilot/plugins/builtin/mosh_protocol/__init__.py
@@ -21,7 +21,7 @@ import shutil
 from gettext import gettext as _
 from typing import Any, Dict, List
 
-from .._shell import command_split_error, split_command
+from .._shell import command_split_diagnostic, split_command
 from ...api import (
     FieldSpec,
     PluginContext,
@@ -43,17 +43,19 @@ class MoshProtocolBackend(ProtocolBackend):
     def connection_fields(self) -> List[FieldSpec]:
         return [
             FieldSpec(key="host", label=_("Host"), kind="text", required=True,
-                      placeholder="hostname or IP address"),
+                      placeholder=_("hostname or IP address")),
             FieldSpec(key="username", label=_("Username"), kind="text",
-                      placeholder="(from ~/.ssh/config)"),
+                      placeholder=_("(from ~/.ssh/config)")),
             FieldSpec(key="port", label=_("SSH port"), kind="int", default=22),
             FieldSpec(key="keyfile", label=_("Key file"), kind="file", group="advanced"),
             FieldSpec(key="extra_ssh_opts", label=_("Extra SSH options"), kind="text",
                       placeholder="-o Compression=yes", group="advanced"),
             FieldSpec(key="predict", label=_("Local echo (predict)"), kind="choice",
                       default="adaptive", group="advanced",
-                      choices=[("adaptive", "Adaptive (default)"), ("always", "Always"),
-                               ("never", "Never"), ("experimental", "Experimental")]),
+                      choices=[("adaptive", _("Adaptive (default)")),
+                               ("always", _("Always")),
+                               ("never", _("Never")),
+                               ("experimental", _("Experimental"))]),
             FieldSpec(key="mosh_port", label=_("UDP port / range"), kind="text",
                       placeholder="60000:60010", group="advanced"),
         ]
@@ -61,18 +63,21 @@ class MoshProtocolBackend(ProtocolBackend):
     def validate(self, data: Dict[str, Any]) -> List[str]:
         errors: List[str] = []
         if not (data.get("host") or data.get("hostname")):
-            errors.append("A host is required.")
+            errors.append(_("A host is required."))
         raw_port = data.get("port", self.default_port)
         if raw_port not in (None, ""):
             try:
                 if not 0 < int(raw_port) < 65536:
-                    errors.append("Port must be between 1 and 65535.")
+                    errors.append(_("Port must be between 1 and 65535."))
             except (TypeError, ValueError):
-                errors.append("Port must be a number.")
-        problem = command_split_error(
-            data.get("extra_ssh_opts"), "Extra SSH options")
-        if problem:
-            errors.append(problem)
+                errors.append(_("Port must be a number."))
+        diagnostic = command_split_diagnostic(data.get("extra_ssh_opts"))
+        if diagnostic:
+            errors.append(
+                _("{field} could not be parsed: {diagnostic}.").format(
+                    field=_("Extra SSH options"), diagnostic=diagnostic
+                )
+            )
         return errors
 
     def build_spawn(self, connection: Any, ctx: PluginContext) -> SpawnSpec:

--- a/src/sshpilot/plugins/builtin/serial_protocol/__init__.py
+++ b/src/sshpilot/plugins/builtin/serial_protocol/__init__.py
@@ -23,10 +23,8 @@ from ...api import (
 )
 
 _BAUDS = ("9600", "19200", "38400", "57600", "115200")
-_FLOW = (("none", "None"), ("hard", "Hardware (RTS/CTS)"), ("soft", "Software (XON/XOFF)"))
 # picocom -f flag values keyed by our choice value
 _PICOCOM_FLOW = {"none": "n", "hard": "h", "soft": "x"}
-_PARITY = (("none", "None"), ("even", "Even"), ("odd", "Odd"))
 _PICOCOM_PARITY = {"none": "n", "even": "e", "odd": "o"}
 
 # ``screen`` takes the line parameters as a comma-separated stty-style list
@@ -65,12 +63,15 @@ class SerialProtocolBackend(ProtocolBackend):
             FieldSpec(key="baud", label=_("Baud rate"), kind="choice", default="115200",
                       choices=[(b, b) for b in _BAUDS]),
             FieldSpec(key="flow", label=_("Flow control"), kind="choice", default="none",
-                      choices=list(_FLOW)),
+                      choices=[("none", _("None")),
+                               ("hard", _("Hardware (RTS/CTS)")),
+                               ("soft", _("Software (XON/XOFF)"))]),
             FieldSpec(key="databits", label=_("Data bits"), kind="choice", default="8",
                       choices=[("8", "8"), ("7", "7"), ("6", "6"), ("5", "5")],
                       group="advanced"),
             FieldSpec(key="parity", label=_("Parity"), kind="choice", default="none",
-                      choices=list(_PARITY), group="advanced"),
+                      choices=[("none", _("None")), ("even", _("Even")),
+                               ("odd", _("Odd"))], group="advanced"),
             FieldSpec(key="stopbits", label=_("Stop bits"), kind="choice", default="1",
                       choices=[("1", "1"), ("2", "2")], group="advanced"),
         ]
@@ -78,13 +79,13 @@ class SerialProtocolBackend(ProtocolBackend):
     def validate(self, data: Dict[str, Any]) -> List[str]:
         errors: List[str] = []
         if not (data.get("device") or "").strip():
-            errors.append("A serial device is required.")
+            errors.append(_("A serial device is required."))
         baud = data.get("baud") or "115200"
         try:
             if int(baud) <= 0:
-                errors.append("Baud rate must be a positive number.")
+                errors.append(_("Baud rate must be a positive number."))
         except (TypeError, ValueError):
-            errors.append("Baud rate must be a number.")
+            errors.append(_("Baud rate must be a number."))
         return errors
 
     def build_spawn(self, connection: Any, ctx: PluginContext) -> SpawnSpec:

--- a/tests/architecture/test_plugin_i18n_boundary.py
+++ b/tests/architecture/test_plugin_i18n_boundary.py
@@ -1,0 +1,99 @@
+"""Architecture checks for frontend-owned built-in plugin localization."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "src" / "sshpilot"
+BUILTINS = SOURCE / "plugins" / "builtin"
+SHELL = BUILTINS / "_shell.py"
+PLUGIN_PATHS = (
+    BUILTINS / "docker_protocol" / "__init__.py",
+    BUILTINS / "kubernetes_protocol" / "__init__.py",
+    BUILTINS / "mosh_protocol" / "__init__.py",
+    BUILTINS / "serial_protocol" / "__init__.py",
+)
+SHELL_FIELD_PATHS = PLUGIN_PATHS[:3]
+RELEASE_NOTE_SOURCES = (
+    ROOT / "data" / "io.github.mfat.sshpilot.metainfo.xml.in",
+    ROOT / "debian" / "changelog",
+    ROOT / "packaging" / "fedora" / "rpm.spec",
+)
+
+
+def _tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _method(tree: ast.Module, name: str) -> ast.FunctionDef:
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _calls(node: ast.AST) -> set[str]:
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def test_shell_parser_helper_never_calls_gettext():
+    tree = _tree(SHELL)
+    imported_modules = {
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    }
+
+    assert "gettext" not in imported_modules
+    assert "_" not in _calls(tree)
+    assert "N_" not in _calls(tree)
+
+
+def test_shell_validation_and_daemon_helpers_stay_on_separate_paths():
+    for path in SHELL_FIELD_PATHS:
+        tree = _tree(path)
+        validation_calls = _calls(_method(tree, "validate"))
+        spawn_calls = _calls(_method(tree, "build_spawn"))
+
+        assert "command_split_diagnostic" in validation_calls
+        assert "split_command" not in validation_calls
+        assert "split_command" in spawn_calls
+        assert "command_split_diagnostic" not in spawn_calls
+        assert "_" not in spawn_calls
+
+    serial_spawn_calls = _calls(_method(_tree(PLUGIN_PATHS[-1]), "build_spawn"))
+    assert "_" not in serial_spawn_calls
+
+
+def test_localized_plugin_methods_are_frontend_only():
+    expected_caller = SOURCE / "connection_dialog.py"
+
+    for call in ("backend.validate(", "backend.connection_fields("):
+        callers = {
+            path
+            for path in SOURCE.rglob("*.py")
+            if call in path.read_text(encoding="utf-8")
+        }
+        assert callers == {expected_caller}
+
+
+def test_frontend_gettext_owners_are_in_potfiles():
+    potfiles = (ROOT / "po" / "POTFILES").read_text(encoding="utf-8").splitlines()
+
+    for path in PLUGIN_PATHS:
+        assert str(path.relative_to(ROOT)) in potfiles
+    assert "src/sshpilot/connection_dialog.py" in potfiles
+    assert "src/sshpilot/plugins/builtin/_shell.py" not in potfiles
+
+
+def test_non_ssh_release_note_typo_is_fixed_in_every_maintained_source():
+    for path in RELEASE_NOTE_SOURCES:
+        source = path.read_text(encoding="utf-8")
+        assert "Uprovements to non-SSH protocol plugins" not in source
+        assert "Improvements to non-SSH protocol plugins" in source

--- a/tests/test_docker_plugin.py
+++ b/tests/test_docker_plugin.py
@@ -36,15 +36,27 @@ def test_loader_discovers_and_activates_docker():
     assert registry_mod.protocol_registry().get_or_none('docker') is not None
 
 
-def test_fields_and_validate():
+def test_fields_and_validate(monkeypatch):
+    import sshpilot.plugins.builtin.docker_protocol as mod
+
+    monkeypatch.setattr(mod, "_", lambda msgid: f"translated:{msgid}")
     backend = DockerProtocolBackend()
     assert backend.capabilities() == frozenset()
     by_key = {f.key: f for f in backend.connection_fields()}
     assert by_key['container'].required
+    assert by_key['container'].placeholder == 'translated:name or id'
+    assert by_key['user'].placeholder == 'translated:user or UID'
     assert by_key['runtime'].default == 'docker'
+    assert [value for value, _label in by_key['runtime'].choices] == [
+        'docker', 'podman'
+    ]
     assert backend.validate({'container': 'web'}) == []
-    assert any('container' in e.lower() for e in backend.validate({}))
-    assert any('docker' in e.lower() for e in backend.validate({'container': 'w', 'runtime': 'nope'}))
+    assert backend.validate({}) == [
+        'translated:A container name or id is required.'
+    ]
+    assert backend.validate({'container': 'w', 'runtime': 'nope'}) == [
+        'translated:Runtime must be docker or podman.'
+    ]
 
 
 def test_build_spawn_basic(monkeypatch):

--- a/tests/test_kubernetes_plugin.py
+++ b/tests/test_kubernetes_plugin.py
@@ -36,13 +36,19 @@ def test_loader_discovers_and_activates_k8s():
     assert registry_mod.protocol_registry().get_or_none('k8s') is not None
 
 
-def test_fields_and_validate():
+def test_fields_and_validate(monkeypatch):
+    import sshpilot.plugins.builtin.kubernetes_protocol as mod
+
+    monkeypatch.setattr(mod, "_", lambda msgid: f"translated:{msgid}")
     backend = KubernetesProtocolBackend()
     assert backend.capabilities() == frozenset()
     by_key = {f.key: f for f in backend.connection_fields()}
     assert by_key['pod'].required
+    assert by_key['pod'].placeholder == 'translated:pod name'
+    assert by_key['container'].placeholder == 'translated:(default container)'
+    assert by_key['kube_context'].placeholder == 'translated:(current context)'
     assert backend.validate({'pod': 'web-0'}) == []
-    assert any('pod' in e.lower() for e in backend.validate({}))
+    assert backend.validate({}) == ['translated:A pod name is required.']
 
 
 def test_build_spawn_basic(monkeypatch):

--- a/tests/test_mosh_plugin.py
+++ b/tests/test_mosh_plugin.py
@@ -52,15 +52,31 @@ def test_loader_discovers_and_activates_mosh():
     assert backend is not None and backend.default_port == 22
 
 
-def test_fields_and_validate():
+def test_fields_and_validate(monkeypatch):
+    import sshpilot.plugins.builtin.mosh_protocol as mod
+
+    monkeypatch.setattr(mod, "_", lambda msgid: f"translated:{msgid}")
     backend = MoshProtocolBackend()
     assert backend.capabilities() == frozenset()
     by_key = {f.key: f for f in backend.connection_fields()}
     assert by_key['host'].required
+    assert by_key['host'].placeholder == 'translated:hostname or IP address'
+    assert by_key['username'].placeholder == 'translated:(from ~/.ssh/config)'
     assert by_key['keyfile'].kind == 'file'
+    assert by_key['predict'].choices == [
+        ('adaptive', 'translated:Adaptive (default)'),
+        ('always', 'translated:Always'),
+        ('never', 'translated:Never'),
+        ('experimental', 'translated:Experimental'),
+    ]
     assert backend.validate({'host': 'h'}) == []
-    assert any('host' in e.lower() for e in backend.validate({}))
-    assert any('port' in e.lower() for e in backend.validate({'host': 'h', 'port': 'x'}))
+    assert backend.validate({}) == ['translated:A host is required.']
+    assert backend.validate({'host': 'h', 'port': 65536}) == [
+        'translated:Port must be between 1 and 65535.'
+    ]
+    assert backend.validate({'host': 'h', 'port': 'x'}) == [
+        'translated:Port must be a number.'
+    ]
 
 
 def test_build_spawn_basic(monkeypatch):

--- a/tests/test_non_ssh_plugin_i18n.py
+++ b/tests/test_non_ssh_plugin_i18n.py
@@ -1,0 +1,54 @@
+"""Frontend rendering checks for built-in non-SSH plugin fields."""
+
+from types import SimpleNamespace
+
+from sshpilot import connection_dialog
+from sshpilot.connection_dialog import ConnectionDialog
+from sshpilot.plugins.api import FieldSpec
+
+
+def test_plugin_advanced_group_title_is_localized_without_changing_key(monkeypatch):
+    class _Group:
+        def __init__(self, *, title):
+            self.title = title
+            self.rows = []
+
+        def add(self, row):
+            self.rows.append(row)
+
+    class _SwitchRow:
+        def set_title(self, title):
+            self.title = title
+
+        def set_active(self, active):
+            self.active = active
+
+    backend = SimpleNamespace(
+        protocol_id="demo",
+        display_name="Demo",
+        connection_fields=lambda: [
+            FieldSpec(
+                key="option",
+                label="Option",
+                kind="switch",
+                default=False,
+                group="advanced",
+            )
+        ],
+    )
+    dialog = SimpleNamespace(_plugin_field_widgets={})
+    monkeypatch.setattr(
+        connection_dialog.Adw, "PreferencesGroup", _Group, raising=False
+    )
+    monkeypatch.setattr(
+        connection_dialog.Adw, "SwitchRow", _SwitchRow, raising=False
+    )
+    monkeypatch.setattr(
+        connection_dialog, "_", lambda msgid: f"translated:{msgid}"
+    )
+
+    groups = ConnectionDialog._build_plugin_field_rows(dialog, backend)
+
+    assert groups[0].title == "translated:Advanced"
+    spec = dialog._plugin_field_widgets["option"][0]
+    assert spec.group == "advanced"

--- a/tests/test_plugin_field_seam.py
+++ b/tests/test_plugin_field_seam.py
@@ -29,6 +29,7 @@ so this runs in CI, unlike the pexpect/docker/socat integration tests.
 
 from __future__ import annotations
 
+import importlib
 import shutil
 
 import pytest
@@ -265,11 +266,30 @@ def test_required_fields_block_saving_and_launching(protocol, registry, tmp_path
 
 
 @pytest.mark.parametrize(
-    "protocol,field",
-    [("docker", "command"), ("k8s", "command"), ("mosh", "extra_ssh_opts")],
+    "protocol,field,field_label,module_name",
+    [
+        ("docker", "command", "Command", "docker_protocol"),
+        ("k8s", "command", "Command", "kubernetes_protocol"),
+        ("mosh", "extra_ssh_opts", "Extra SSH options", "mosh_protocol"),
+    ],
+)
+@pytest.mark.parametrize(
+    "broken_value,diagnostic",
+    [
+        ('sh -c "echo hi', "No closing quotation"),
+        ("echo \\", "No escaped character"),
+    ],
 )
 def test_unparsable_shell_field_is_reported_not_raised(
-    protocol, field, registry, tmp_path
+    protocol,
+    field,
+    field_label,
+    module_name,
+    broken_value,
+    diagnostic,
+    registry,
+    tmp_path,
+    monkeypatch,
 ):
     """A stray quote is a validation error, never an untyped ValueError.
 
@@ -279,13 +299,32 @@ def test_unparsable_shell_field_is_reported_not_raised(
     """
     from sshpilot.plugins.api import ProtocolError
 
+    translated_msgids = []
+
+    def _translate(msgid):
+        translated_msgids.append(msgid)
+        return f"translated:{msgid}"
+
+    module = importlib.import_module(
+        f"sshpilot.plugins.builtin.{module_name}"
+    )
+    monkeypatch.setattr(module, "_", _translate)
+
     backend = registry.get_or_none(protocol)
-    broken = {**CASES[protocol]["fields"], field: 'sh -c "echo hi'}
+    broken = {**CASES[protocol]["fields"], field: broken_value}
 
     problems = backend.validate(
         {"nickname": f"{protocol}-demo", "protocol": protocol, **broken}
     )
-    assert any("could not be parsed" in problem for problem in problems)
+    assert problems == [
+        (
+            "translated:translated:{field} could not be parsed: "
+            "{diagnostic}."
+        ).format(field=field_label, diagnostic=diagnostic)
+    ]
+    assert diagnostic not in translated_msgids
+    assert "{field} could not be parsed: {diagnostic}." in translated_msgids
+    assert field_label in translated_msgids
 
     # And if such a connection is reached some other way (the plugin API, an
     # imported backup), the spawn refuses it as a ProtocolError.

--- a/tests/test_serial_plugin.py
+++ b/tests/test_serial_plugin.py
@@ -38,20 +38,43 @@ def test_loader_discovers_and_activates_serial():
     assert backend.default_port is None
 
 
-def test_capabilities_empty_and_fields_declared():
+def test_capabilities_empty_and_fields_declared(monkeypatch):
+    import sshpilot.plugins.builtin.serial_protocol as mod
+
+    monkeypatch.setattr(mod, "_", lambda msgid: f"translated:{msgid}")
     backend = SerialProtocolBackend()
     assert backend.capabilities() == frozenset()
     by_key = {f.key: f for f in backend.connection_fields()}
     assert by_key['device'].required
     assert by_key['baud'].kind == 'choice'
     assert by_key['baud'].default == '115200'
+    assert by_key['flow'].choices == [
+        ('none', 'translated:None'),
+        ('hard', 'translated:Hardware (RTS/CTS)'),
+        ('soft', 'translated:Software (XON/XOFF)'),
+    ]
+    assert by_key['parity'].choices == [
+        ('none', 'translated:None'),
+        ('even', 'translated:Even'),
+        ('odd', 'translated:Odd'),
+    ]
 
 
-def test_validate_matrix():
+def test_validate_matrix(monkeypatch):
+    import sshpilot.plugins.builtin.serial_protocol as mod
+
+    monkeypatch.setattr(mod, "_", lambda msgid: f"translated:{msgid}")
     backend = SerialProtocolBackend()
     assert backend.validate({'device': '/dev/ttyUSB0', 'baud': '115200'}) == []
-    assert any('device' in e.lower() for e in backend.validate({'baud': '9600'}))
-    assert any('baud' in e.lower() for e in backend.validate({'device': '/dev/x', 'baud': 'abc'}))
+    assert backend.validate({'baud': '9600'}) == [
+        'translated:A serial device is required.'
+    ]
+    assert backend.validate({'device': '/dev/x', 'baud': '0'}) == [
+        'translated:Baud rate must be a positive number.'
+    ]
+    assert backend.validate({'device': '/dev/x', 'baud': 'abc'}) == [
+        'translated:Baud rate must be a number.'
+    ]
 
 
 def test_build_spawn_prefers_picocom(monkeypatch):


### PR DESCRIPTION
## Summary

Localizes remaining frontend-visible strings in the built-in non-SSH plugins without changing the daemon/session API.

This includes:

- plugin validation messages;
- visible choice labels and placeholders;
- command parsing errors while preserving raw parser diagnostics;
- the visible `Advanced` group label;
- the 6.0.0 release-note typo `Uprovements` → `Improvements`.

Internal and persisted plugin values remain unchanged.

Daemon-side plugin launch failures are intentionally out of scope because they require a separate structured session-failure contract.

## Validation

- `pytest -q tests/test_docker_plugin.py tests/test_kubernetes_plugin.py tests/test_mosh_plugin.py tests/test_serial_plugin.py tests/test_plugin_field_seam.py tests/test_non_ssh_plugin_i18n.py tests/architecture/test_plugin_i18n_boundary.py` (63 passed)
- `pytest -q tests/test_i18n_language.py tests/test_properties_dialog_i18n.py tests/architecture/test_backup_i18n_boundary.py tests/architecture/test_sftp_i18n_boundary.py tests/architecture/test_plugin_i18n_boundary.py` (39 passed)
- `pytest -q tests/architecture/test_plugin_i18n_boundary.py tests/test_non_ssh_plugin_i18n.py tests/test_plugin_field_seam.py` (22 passed)
- `pytest -q tests/test_connection_dialog*.py tests/test_non_ssh_plugin_i18n.py` (78 passed, 10 skipped)
- `meson compile -C builddir sshpilot-pot`
- `msgfmt --check-format -o /dev/null po/sshpilot.pot`
- `meson test -C builddir --print-errorlogs` (2 passed)
- `appstreamcli validate --no-net --explain builddir/data/io.github.mfat.sshpilot.metainfo.xml`
- `dpkg-parsechangelog -l debian/changelog`
- Ruff on every modified Python file
- `git diff --check` and `git diff --cached --check`

## Scope

No RPC/API changes and no translation catalogs are modified.