### PR TITLE
Discard superseded pending identity intents when SSH config and sidecar both advanced

### DIFF
--- a/src/sshpilot/core/connections/state_file.py
+++ b/src/sshpilot/core/connections/state_file.py
@@ -834,9 +834,11 @@ def recover_pending_identity_transaction(
 ) -> "IdentityRecoveryDecision":
     """Apply only unambiguous pending-intent recovery decisions.
 
-    TARGET and BASE revisions are finalized/aborted respectively. Unrelated,
-    incomplete, stale, or corrupt state is left for a higher-level adapter and
-    is never resolved by guessing.
+    TARGET and BASE revisions are finalized/aborted respectively. An intent
+    superseded by both an unrelated SSH revision and a newer sidecar is
+    discarded without changing the sidecar. Other stale, incomplete, or
+    corrupt state is left for a higher-level adapter and is never resolved by
+    guessing.
     """
     from .identity_state_v2 import (
         IdentityRecoveryAction,
@@ -869,5 +871,15 @@ def recover_pending_identity_transaction(
             write_identity_state_v2(sidecar_path, intent.target_state)
         clear_pending_identity_transaction(intent_path)
     elif decision.action is IdentityRecoveryAction.ABORT_BASE:
+        clear_pending_identity_transaction(intent_path)
+    elif (
+        decision.action is IdentityRecoveryAction.STALE_INTENT
+        and actual_ssh_revision
+        not in (intent.base_ssh_revision, intent.target_ssh_revision)
+    ):
+        # The SSH configuration moved independently and the sidecar also
+        # advanced beyond this intent. Retaining this obsolete journal would
+        # permanently block mutations after a restart. Do not apply either
+        # snapshot; the current sidecar remains authoritative.
         clear_pending_identity_transaction(intent_path)
     return decision

--- a/tests/core/test_connection_identity_state_storage.py
+++ b/tests/core/test_connection_identity_state_storage.py
@@ -611,10 +611,15 @@ def test_recovery_crash_window_matrix(tmp_path: Path):
     assert intent_path.exists()
 
     write_identity_state_v2(sidecar, replace(base, sidecar_generation=2))
-    decision = classify_identity_transaction_recovery(
-        read_identity_state_v2(sidecar), intent, "rev-old"
+    newer_sidecar = read_identity_state_v2(sidecar)
+    decision = recover_pending_identity_transaction(
+        sidecar, actual_ssh_revision="rev-external"
     )
     assert decision.action is IdentityRecoveryAction.STALE_INTENT
+    # A stale journal cannot be applied safely, but its newer sidecar is
+    # already authoritative and must not lock every later mutation forever.
+    assert read_identity_state_v2(sidecar) == newer_sidecar
+    assert not intent_path.exists()
 
     assert classify_identity_transaction_recovery(
         base, intent, None


### PR DESCRIPTION
### Motivation

- Prevent the daemon from entering a permanent "identity degraded" / persistence-failed state when a pending identity transaction is made obsolete by both an unrelated SSH config revision and a newer sidecar file.
- Ensure recovery does not leave a stale intent journal that would block future mutations after restart.

### Description

- Update `recover_pending_identity_transaction` in `src/sshpilot/core/connections/state_file.py` to clear a pending intent when `classify_identity_transaction_recovery` returns `STALE_INTENT` and the observed SSH revision is neither the intent base nor target, preserving the current sidecar as authoritative.
- Add and adjust assertions in `tests/core/test_connection_identity_state_storage.py` to verify that a stale pending intent is removed while the newer sidecar remains unchanged.
- Small clarifying docstring updates describing when an intent is discarded vs left for higher-level adapters.

### Testing

- Ran `python -m pytest -o addopts='' tests/core/test_connection_identity_state_storage.py tests/core/test_connection_repository_uuid_integration.py`, and the test suite completed successfully with all tests passing (61 passed).
- Ran `python -m ruff check src/sshpilot/core/connections/state_file.py tests/core/test_connection_identity_state_storage.py` with no lint failures.
- Ran repository checks (`git diff --check`) and verified there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98fec582348328946d5e2224d2ace3)